### PR TITLE
Consistent naming across engines

### DIFF
--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -55,29 +55,29 @@ class AlgoliaEngine extends Engine
     /**
      * Perform the given search on the engine.
      *
-     * @param  Builder  $query
+     * @param  Builder  $builder
      * @return mixed
      */
-    public function search(Builder $query)
+    public function search(Builder $builder)
     {
-        return $this->performSearch($query, array_filter([
-            'numericFilters' => $this->filters($query),
-            'hitsPerPage' => $query->limit,
+        return $this->performSearch($builder, array_filter([
+            'numericFilters' => $this->filters($builder),
+            'hitsPerPage' => $builder->limit,
         ]));
     }
 
     /**
      * Perform the given search on the engine.
      *
-     * @param  Builder  $query
+     * @param  Builder  $builder
      * @param  int  $perPage
      * @param  int  $page
      * @return mixed
      */
-    public function paginate(Builder $query, $perPage, $page)
+    public function paginate(Builder $builder, $perPage, $page)
     {
-        return $this->performSearch($query, [
-            'numericFilters' => $this->filters($query),
+        return $this->performSearch($builder, [
+            'numericFilters' => $this->filters($builder),
             'hitsPerPage' => $perPage,
             'page' => $page - 1,
         ]);
@@ -86,26 +86,26 @@ class AlgoliaEngine extends Engine
     /**
      * Perform the given search on the engine.
      *
-     * @param  Builder  $query
+     * @param  Builder  $builder
      * @param  array  $options
      * @return mixed
      */
-    protected function performSearch(Builder $query, array $options = [])
+    protected function performSearch(Builder $builder, array $options = [])
     {
         return $this->algolia->initIndex(
-            $query->index ?: $query->model->searchableAs()
-        )->search($query->query, $options);
+            $builder->index ?: $builder->model->searchableAs()
+        )->search($builder->query, $options);
     }
 
     /**
      * Get the filter array for the query.
      *
-     * @param  Builder  $query
+     * @param  Builder  $builder
      * @return array
      */
-    protected function filters(Builder $query)
+    protected function filters(Builder $builder)
     {
-        return collect($query->wheres)->map(function ($value, $key) {
+        return collect($builder->wheres)->map(function ($value, $key) {
             return $key.'='.$value;
         })->values()->all();
     }

--- a/src/Engines/Engine.php
+++ b/src/Engines/Engine.php
@@ -26,7 +26,7 @@ abstract class Engine
     /**
      * Perform the given search on the engine.
      *
-     * @param  Builder  $query
+     * @param  Builder  $builder
      * @return mixed
      */
     abstract public function search(Builder $builder);
@@ -34,7 +34,7 @@ abstract class Engine
     /**
      * Perform the given search on the engine.
      *
-     * @param  Builder  $query
+     * @param  Builder  $builder
      * @param  int  $perPage
      * @param  int  $page
      * @return mixed
@@ -56,10 +56,10 @@ abstract class Engine
      * @param  Builder  $builder
      * @return Collection
      */
-    public function get(Builder $query)
+    public function get(Builder $builder)
     {
         return Collection::make($this->map(
-            $this->search($query), $query->model
+            $this->search($builder), $builder->model
         ));
     }
 }

--- a/src/Engines/NullEngine.php
+++ b/src/Engines/NullEngine.php
@@ -32,7 +32,7 @@ class NullEngine extends Engine
     /**
      * Perform the given search on the engine.
      *
-     * @param  Builder  $query
+     * @param  Builder  $builder
      * @return mixed
      */
     public function search(Builder $builder)
@@ -43,7 +43,7 @@ class NullEngine extends Engine
     /**
      * Perform the given search on the engine.
      *
-     * @param  Builder  $query
+     * @param  Builder  $builder
      * @param  int  $perPage
      * @param  int  $page
      * @return mixed


### PR DESCRIPTION
Make sure the docblocks and source code are consistent in the variable names. Previously, the docblocks would reflect `$query` and the code would actually be `$builder` or the other way around. Now, we're being consistent across the entire file and name any variable with an instance of the Builder `$builder`.