### PR TITLE
Initial Elasticsearch support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "mockery/mockery": "~0.9",
         "phpunit/phpunit": "~5.0",
         "algolia/algoliasearch-client-php": "^1.10",
+        "elasticsearch/elasticsearch": "^2.2",
         "illuminate/bus": "~5.3",
         "illuminate/pagination": "~5.3",
         "illuminate/queue": "~5.3"
@@ -34,7 +35,8 @@
         }
     },
     "suggest": {
-        "algolia/algoliasearch-client-php": "Required to use the Algolia engine."
+        "algolia/algoliasearch-client-php": "Required to use the Algolia engine.",
+        "elasticsearch/elasticsearch": "Required to use the Elasticsearch engine."
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/config/scout.php
+++ b/config/scout.php
@@ -56,12 +56,17 @@ return [
     | for horizontal scalability, reliability, and easy management. Just plug
     | in your Elasticsearch servers to get started searching.
     |
+    | Notice that the config key is passed to the ClientBuilder as it is, so
+    | only add configs that the Elasticsearch can handle.
+    |
     */
 
     'elasticsearch' => [
         'index' => env('ELASTICSEARCH_INDEX', 'laravel'),
-        'hosts' => [
-            env('ELASTICSEARCH_HOST')
+        'config' => [
+            'hosts' => [
+                env('ELASTICSEARCH_HOST')
+            ],
         ],
     ],
 

--- a/config/scout.php
+++ b/config/scout.php
@@ -46,4 +46,22 @@ return [
         'secret' => env('ALGOLIA_SECRET'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Elasticsearch Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your Elasticsearch settings. Elasticsearch
+    | is a distributed, open source search and analytics engine, designed
+    | for horizontal scalability, reliability, and easy management. Just plug
+    | in your Elasticsearch servers to get started searching.
+    |
+    */
+
+    'elasticsearch' => [
+        'hosts' => [
+            env('ELASTICSEARCH_HOST')
+        ],
+    ],
+
 ];

--- a/config/scout.php
+++ b/config/scout.php
@@ -59,6 +59,7 @@ return [
     */
 
     'elasticsearch' => [
+        'index' => env('ELASTICSEARCH_INDEX', 'laravel'),
         'hosts' => [
             env('ELASTICSEARCH_HOST')
         ],

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -11,7 +11,7 @@ class EngineManager extends Manager
     /**
      * Get a driver instance.
      *
-     * @param  string  $driver
+     * @param  string  $name
      * @return mixed
      */
     public function engine($name = null)
@@ -31,6 +31,11 @@ class EngineManager extends Manager
         ));
     }
 
+    /**
+     * Create an Elasticsearch engine instance.
+     *
+     * @return Engines\ElasticsearchEngine
+     */
     public function createElasticsearchDriver()
     {
         return new Engines\ElasticsearchEngine(

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -35,7 +35,8 @@ class EngineManager extends Manager
     {
         return new Engines\ElasticsearchEngine(Elasticsearch::create()
             ->setHosts(config('scout.elasticsearch.hosts'))
-            ->build()
+            ->build(),
+            config('scout.elasticsearch.index')
         );
     }
 

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -33,9 +33,8 @@ class EngineManager extends Manager
 
     public function createElasticsearchDriver()
     {
-        return new Engines\ElasticsearchEngine(Elasticsearch::create()
-            ->setHosts(config('scout.elasticsearch.hosts'))
-            ->build(),
+        return new Engines\ElasticsearchEngine(
+            Elasticsearch::fromConfig(config('scout.elasticsearch.config')),
             config('scout.elasticsearch.index')
         );
     }

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -4,6 +4,7 @@ namespace Laravel\Scout;
 
 use Illuminate\Support\Manager;
 use AlgoliaSearch\Client as Algolia;
+use Elasticsearch\ClientBuilder as Elasticsearch;
 
 class EngineManager extends Manager
 {
@@ -28,6 +29,14 @@ class EngineManager extends Manager
         return new Engines\AlgoliaEngine(new Algolia(
             config('scout.algolia.id'), config('scout.algolia.secret')
         ));
+    }
+
+    public function createElasticsearchDriver()
+    {
+        return new Engines\ElasticsearchEngine(Elasticsearch::create()
+            ->setHosts(config('scout.elasticsearch.hosts'))
+            ->build()
+        );
     }
 
     /**

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -28,14 +28,14 @@ class ElasticsearchEngine extends Engine
      */
     public function update($models)
     {
-        foreach($models as $model) {
+        $models->each(function ($model) {
             $this->elasticsearch->index([
-                'index' =>  'laravel',
-                'type'  =>  $model->searchableAs(),
-                'id'    =>  $model->getKey(),
-                'body'  =>  $model->toSearchableArray(),
+                'index' => 'laravel',
+                'type' => $model->searchableAs(),
+                'id' => $model->getKey(),
+                'body' => $model->toSearchableArray(),
             ]);
-        }
+        });
     }
 
     /**
@@ -46,13 +46,13 @@ class ElasticsearchEngine extends Engine
      */
     public function delete($models)
     {
-        foreach($models as $model) {
+        $models->each(function ($model) {
             $this->elasticsearch->delete([
                 'index' => 'laravel',
                 'type' => $model->searchableAs(),
                 'id'  => $model->getKey(),
             ]);
-        }
+        });
     }
 
     /**

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -70,10 +70,10 @@ class ElasticsearchEngine extends Engine
      */
     public function search(Builder $query)
     {
-        return $this->performSearch($query, array_filter([
+        return $this->performSearch($query, [
             'filters' => $this->filters($query),
             'size' => $query->limit ?: 10000,
-        ]));
+        ]);
     }
 
     /**
@@ -174,7 +174,9 @@ class ElasticsearchEngine extends Engine
         }
 
         $keys = collect($results['hits']['hits'])
-                        ->pluck('_id')->values()->all();
+                    ->pluck('_id')
+                    ->values()
+                    ->all();
 
         $models = $model->whereIn(
             $model->getKeyName(), $keys
@@ -182,7 +184,6 @@ class ElasticsearchEngine extends Engine
 
 
         return collect($results['hits']['hits'])->map(function ($hit) use ($model, $models) {
-
             return $models[$hit['_source'][$model->getKeyName()]];
         });
     }

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Laravel\Scout\Engines;
+
+use Laravel\Scout\Builder;
+use Elasticsearch\Client as Elasticsearch;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection as BaseCollection;
+
+class ElasticsearchEngine extends Engine
+{
+    /**
+     * Create a new engine instance.
+     *
+     * @param  \Elasticsearch\Client  $elasticsearch
+     * @return void
+     */
+    public function __construct(Elasticsearch $elasticsearch)
+    {
+        $this->elasticsearch = $elasticsearch;
+    }
+
+    /**
+     * Update the given model in the index.
+     *
+     * @param  Collection  $models
+     * @return void
+     */
+    public function update($models)
+    {
+        foreach($models as $model) {
+            $this->elasticsearch->index([
+                'index' =>  'laravel',
+                'type'  =>  $model->searchableAs(),
+                'id'    =>  $model->getKey(),
+                'body'  =>  $model->toSearchableArray(),
+            ]);
+        }
+    }
+
+    /**
+     * Remove the given model from the index.
+     *
+     * @param  Collection  $models
+     * @return void
+     */
+    public function delete($models)
+    {
+        foreach($models as $model) {
+            $this->elasticsearch->delete([
+                'index' => 'laravel',
+                'type' => $model->searchableAs(),
+                'id'  => $model->getKey(),
+            ]);
+        }
+    }
+
+    /**
+     * Perform the given search on the engine.
+     *
+     * @param  Builder  $query
+     * @return mixed
+     */
+    public function search(Builder $query)
+    {
+        return $this->performSearch($query, array_filter([
+            'filters' => $this->filters($query),
+            'size' => $query->limit,
+        ]));
+    }
+
+    /**
+     * Perform the given search on the engine.
+     *
+     * @param  Builder  $query
+     * @param  int  $perPage
+     * @param  int  $page
+     * @return mixed
+     */
+    public function paginate(Builder $query, $perPage, $page)
+    {
+        $from = (($page * $perPage) - $perPage);
+
+        $result = $this->performSearch($query, [
+            'filters' => $this->filters($query),
+            'size' => $perPage,
+            'from' => $from,
+        ]);
+
+        $result['nbPages'] = (int) ceil($result['hits']['total'] / $perPage);
+
+        return $result;
+    }
+
+    /**
+     * Perform the given search on the engine.
+     *
+     * @param  Builder  $query
+     * @param  array  $options
+     * @return mixed
+     */
+    protected function performSearch(Builder $query, array $options = [])
+    {
+        $filterQuery = [
+            "filter" => [
+                "query_string" => [
+                    "query" => "*{$query->query}*",
+                ],
+            ]
+        ];
+
+        if (array_key_exists('filters', $options) && $options['filters']) {
+            $filterQuery = array_merge($filterQuery, [
+                "must" => [
+                    "match" => $options['filters'],
+                ],
+            ]);
+        }
+
+        $searchQuery = [
+            'index' =>  'laravel',
+            'type'  =>  $query->model->searchableAs(),
+            'body' => [
+                'query' => [
+                    "bool" => $filterQuery,
+                ],
+            ],
+        ];
+
+        if (array_key_exists('size', $options)) {
+            $searchQuery = array_merge($searchQuery, [
+                'size' => $options['size'],
+            ]);
+        }
+
+        if (array_key_exists('from', $options)) {
+            $searchQuery = array_merge($searchQuery, [
+                'from' => $options['from'],
+            ]);
+        }
+
+        return $this->elasticsearch->search($searchQuery);
+    }
+
+    /**
+     * Get the filter array for the query.
+     *
+     * @param  Builder  $query
+     * @return array
+     */
+    protected function filters(Builder $query)
+    {
+        return $query->wheres;
+    }
+
+    /**
+     * Map the given results to instances of the given model.
+     *
+     * @param  mixed  $results
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return Collection
+     */
+    public function map($results, $model)
+    {
+        if (count($results['hits']) === 0) {
+            return Collection::make();
+        }
+
+        $keys = collect($results['hits']['hits'])
+                        ->pluck('_id')->values()->all();
+
+        $models = $model->whereIn(
+            $model->getKeyName(), $keys
+        )->get()->keyBy($model->getKeyName());
+
+
+        return collect($results['hits']['hits'])->map(function ($hit) use ($model, $models) {
+
+            return $models[$hit['_source'][$model->getKeyName()]];
+        });
+    }
+}

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -72,7 +72,7 @@ class ElasticsearchEngine extends Engine
     {
         return $this->performSearch($query, array_filter([
             'filters' => $this->filters($query),
-            'size' => $query->limit,
+            'size' => $query->limit ?: 10000,
         ]));
     }
 

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -10,14 +10,21 @@ use Illuminate\Support\Collection as BaseCollection;
 class ElasticsearchEngine extends Engine
 {
     /**
+     * @var string $index
+     */
+    protected $index;
+
+    /**
      * Create a new engine instance.
      *
      * @param  \Elasticsearch\Client  $elasticsearch
      * @return void
      */
-    public function __construct(Elasticsearch $elasticsearch)
+    public function __construct(Elasticsearch $elasticsearch, $index)
     {
         $this->elasticsearch = $elasticsearch;
+
+        $this->index = $index;
     }
 
     /**
@@ -30,7 +37,7 @@ class ElasticsearchEngine extends Engine
     {
         $models->each(function ($model) {
             $this->elasticsearch->index([
-                'index' => 'laravel',
+                'index' => $this->index,
                 'type' => $model->searchableAs(),
                 'id' => $model->getKey(),
                 'body' => $model->toSearchableArray(),
@@ -48,7 +55,7 @@ class ElasticsearchEngine extends Engine
     {
         $models->each(function ($model) {
             $this->elasticsearch->delete([
-                'index' => 'laravel',
+                'index' => $this->index,
                 'type' => $model->searchableAs(),
                 'id'  => $model->getKey(),
             ]);
@@ -118,7 +125,7 @@ class ElasticsearchEngine extends Engine
         }
 
         $searchQuery = [
-            'index' =>  'laravel',
+            'index' =>  $this->index,
             'type'  =>  $query->model->searchableAs(),
             'body' => [
                 'query' => [

--- a/src/SearchableScope.php
+++ b/src/SearchableScope.php
@@ -4,7 +4,7 @@ namespace Laravel\Scout;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
-use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Laravel\Scout\Events\ModelsImported;
 
 class SearchableScope implements Scope
@@ -16,7 +16,7 @@ class SearchableScope implements Scope
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return void
      */
-    public function apply(Builder $builder, Model $model)
+    public function apply(EloquentBuilder $builder, Model $model)
     {
         //
     }
@@ -27,9 +27,9 @@ class SearchableScope implements Scope
      * @param  \Illuminate\Database\Eloquent\Builder  $builder
      * @return void
      */
-    public function extend(Builder $builder)
+    public function extend(EloquentBuilder $builder)
     {
-        $builder->macro('searchable', function (Builder $builder) {
+        $builder->macro('searchable', function (EloquentBuilder $builder) {
             $builder->chunk(100, function ($models) use ($builder) {
                 $models->searchable();
 
@@ -37,7 +37,7 @@ class SearchableScope implements Scope
             });
         });
 
-        $builder->macro('unsearchable', function (Builder $builder) {
+        $builder->macro('unsearchable', function (EloquentBuilder $builder) {
             $builder->chunk(100, function ($models) use ($builder) {
                 $models->unsearchable();
             });

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests;
+
+use Mockery;
+use Laravel\Scout\Builder;
+use Laravel\Scout\Engines\ElasticsearchEngine;
+use Tests\Fixtures\ElasticsearchEngineTestModel;
+use Illuminate\Database\Eloquent\Collection;
+
+class ElasticsearchEngineTest extends AbstractTestCase
+{
+    public function test_update_adds_objects_to_index()
+    {
+        $client = Mockery::mock('Elasticsearch\Client');
+        $client->shouldReceive('index')->with([
+            'index' => 'index_name',
+            'type' => 'table',
+            'id' => 1,
+            'body' => ['id' => 1],
+        ]);
+
+        $engine = new ElasticsearchEngine($client, 'index_name');
+        $engine->update(Collection::make([new ElasticsearchEngineTestModel]));
+    }
+
+
+    public function test_delete_removes_objects_to_index()
+    {
+        $client = Mockery::mock('Elasticsearch\Client');
+        $client->shouldReceive('delete')->with([
+            'index' => 'index_name',
+            'type' => 'table',
+            'id' => 1,
+        ]);
+
+
+        $engine = new ElasticsearchEngine($client, 'index_name');
+        $engine->delete(Collection::make([new ElasticsearchEngineTestModel]));
+    }
+
+    public function test_search_sends_correct_parameters_to_algolia()
+    {
+        $client = Mockery::mock('Elasticsearch\Client');
+        $client->shouldReceive('search')
+            ->with([
+                'index' =>  'index_name',
+                'type'  =>  'table',
+                'body' => [
+                    'query' => [
+                        "bool" => [
+                            "filter" => [
+                                "query_string" => [
+                                    "query" => "*zonda*",
+                                ],
+                            ],
+                            "must" => [
+                                "match" => [
+                                    'foo' => 1,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'size' => 10000,
+            ]);
+
+        $engine = new ElasticsearchEngine($client, 'index_name');
+        $builder = new Builder(new ElasticsearchEngineTestModel, 'zonda');
+        $builder->where('foo', 1);
+        $engine->search($builder);
+    }
+
+    public function test_map_correctly_maps_results_to_models()
+    {
+        $client = Mockery::mock('Elasticsearch\Client');
+        $engine = new ElasticsearchEngine($client, 'index_name');
+
+        $model = Mockery::mock('StdClass');
+        $model->shouldReceive('getKeyName')->andReturn('id');
+        $model->shouldReceive('whereIn')->once()->with('id', [1])->andReturn($model);
+        $model->shouldReceive('get')->once()->andReturn(Collection::make([new ElasticsearchEngineTestModel]));
+
+        $results = $engine->map([
+            'hits' => [
+                'hits' => [
+                    [
+                        '_id' => 1,
+                        '_source' => ['id' => 1]
+                    ],
+                ]
+            ]
+        ], $model);
+
+        $this->assertEquals(1, count($results));
+    }
+}

--- a/tests/Fixtures/AlgoliaEngineTestModel.php
+++ b/tests/Fixtures/AlgoliaEngineTestModel.php
@@ -2,24 +2,7 @@
 
 namespace Tests\Fixtures;
 
-use Illuminate\Database\Eloquent\Model;
-
-class AlgoliaEngineTestModel extends Model
+class AlgoliaEngineTestModel extends TestModel
 {
-    public $id = 1;
-
-    public function searchableAs()
-    {
-        return 'table';
-    }
-
-    public function getKey()
-    {
-        return $this->id;
-    }
-
-    public function toSearchableArray()
-    {
-        return ['id' => 1];
-    }
+    //
 }

--- a/tests/Fixtures/ElasticsearchEngineTestModel.php
+++ b/tests/Fixtures/ElasticsearchEngineTestModel.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Fixtures;
+
+class ElasticsearchEngineTestModel extends TestModel
+{
+    //
+}

--- a/tests/Fixtures/TestModel.php
+++ b/tests/Fixtures/TestModel.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TestModel extends Model
+{
+    public $id = 1;
+
+    public function searchableAs()
+    {
+        return 'table';
+    }
+
+    public function getKey()
+    {
+        return $this->id;
+    }
+
+    public function toSearchableArray()
+    {
+        return ['id' => 1];
+    }
+}


### PR DESCRIPTION
Reopened since squashing would include other poeples commits from the upstream sync.

Initial Elasticsearch support, tests on the way.

Some options may differ and I may make a custom config key for customizing the query parameter, Elastic can be really complex but this setup should cover most scenarios.

Working right now:

- Searching
- Searching with where conditions
- Pagination
- Unit Testing :)

TODO:
- For future implementations, for both algolia and elastic, may the performSearch be a replaceable callback,so people can extend and customize it, gonna send a separate PR on it