### PR TITLE
hhvm doesn't need to be tested

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
 
 sudo: false
 


### PR DESCRIPTION
as hhvm is no longer supported on 5.3