### PR TITLE
SetSettings feature

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -3,6 +3,7 @@
 namespace Laravel\Scout;
 
 use Laravel\Scout\Jobs\MakeSearchable;
+use BadMethodCallException;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Collection as BaseCollection;
 
@@ -86,6 +87,24 @@ trait Searchable
     public static function makeAllSearchable()
     {
         (new static)->newQuery()->searchable();
+    }
+
+    /**
+     * Save settings to search engine
+     *
+     * @return void
+     * @throws \BadMethodCallException
+     */
+    public static function setSettings()
+    {
+        $model = new static();
+        $engine = $model->searchableUsing();
+
+        if (!method_exists($engine, 'setSettings')) {
+            throw new BadMethodCallException('Search engine "'.get_class($engine).'" does not support setSettings() call.');
+        }
+
+        $engine->setSettings($model, property_exists($model, 'searchSettings') ? $model->searchSettings : []);
     }
 
     /**

--- a/tests/AlgoliaEngineTest.php
+++ b/tests/AlgoliaEngineTest.php
@@ -47,6 +47,129 @@ class AlgoliaEngineTest extends AbstractTestCase
         $engine->search($builder);
     }
 
+    public function test_set_settings_sends_correct_parameters_to_algolia()
+    {
+        $searchSettings = [
+            'attributesToIndex' => [
+                'id',
+                'name',
+            ],
+            'customRanking' => [
+                'desc(popularity)',
+                'asc(name)',
+            ],
+            'synonyms' => [
+                [
+                    'objectID' => 'red-color',
+                    'type'     => 'synonym',
+                    'synonyms' => ['red', 'another red', 'yet another red']
+                ]
+            ],
+            'slaves' => [
+                'my_slave1' => [
+                    'ranking' => [
+                        'desc(id)',
+                        'typo',
+                        'geo',
+                        'words',
+                        'proximity',
+                        'attribute',
+                        'exact',
+                        'custom'
+                    ],
+                ],
+                'my_slave2' => [
+                    'ranking' => [
+                        'asc(id)',
+                        'typo',
+                        'geo',
+                        'words',
+                        'proximity',
+                        'attribute',
+                        'exact',
+                        'custom'
+                    ],
+                ],
+            ],
+        ];
+
+        $client = Mockery::mock('AlgoliaSearch\Client');
+
+        // Master index
+        $client->shouldReceive('initIndex')->with('table')->andReturn($index = Mockery::mock('StdClass'));
+
+        $index->shouldReceive('batchSynonyms')->with([
+            [
+                'objectID' => 'red-color',
+                'type'     => 'synonym',
+                'synonyms' => ['red', 'another red', 'yet another red']
+            ]
+        ], true, true);
+
+        $index->shouldReceive('setSettings')->with([
+            'attributesToIndex' => [
+                'id',
+                'name',
+            ],
+            'customRanking' => [
+                'desc(popularity)',
+                'asc(name)',
+            ],
+            'slaves' => ['my_slave1', 'my_slave2'],
+        ], true);
+
+        // Slave 1
+        $client->shouldReceive('initIndex')->with('my_slave1')->andReturn($index = Mockery::mock('StdClass'));
+
+        $index->shouldReceive('setSettings')->with([
+            'attributesToIndex' => [
+                'id',
+                'name',
+            ],
+            'customRanking' => [
+                'desc(popularity)',
+                'asc(name)',
+            ],
+            'ranking' => [
+                'desc(id)',
+                'typo',
+                'geo',
+                'words',
+                'proximity',
+                'attribute',
+                'exact',
+                'custom'
+            ],
+        ]);
+
+        // Slave 2
+        $client->shouldReceive('initIndex')->with('my_slave2')->andReturn($index = Mockery::mock('StdClass'));
+
+        $index->shouldReceive('setSettings')->with([
+            'attributesToIndex' => [
+                'id',
+                'name',
+            ],
+            'customRanking' => [
+                'desc(popularity)',
+                'asc(name)',
+            ],
+            'ranking' => [
+                'asc(id)',
+                'typo',
+                'geo',
+                'words',
+                'proximity',
+                'attribute',
+                'exact',
+                'custom'
+            ],
+        ]);
+
+        $engine = new AlgoliaEngine($client);
+        $engine->setSettings(new AlgoliaEngineTestModel(), $searchSettings);
+    }
+
     public function test_map_correctly_maps_results_to_models()
     {
         $client = Mockery::mock('AlgoliaSearch\Client');


### PR DESCRIPTION
Hello there,
as requested in #14, I separed `setSettings` feature to a separate PR.

This PR implements:
- setting index settings directly via Scout
- slaves (for creating replicas with different sorting strategy)

This PR adds two method `setSettings` to the Searchable trait which takes model's `$searchSettings` and pushes it to the index.

`setSettings` throws a `BadMethodCallException` when Engine does not support `setSettings`. 

Model's settings variable example:
```php
public $searchSettings = [
    'attributesToIndex' => [
        'id',
        'name',
    ],
    'customRanking' => [
        'desc(popularity)',
        'asc(name)',
    ],
    'synonyms' => [
        [
            'objectID' => 'red-color',
            'type'     => 'synonym',
            'synonyms' => ['red', 'another red', 'yet another red']
        ]
    ],
    'slaves' => [
        'my_slave1' => [
            'ranking' => [
                'desc(id)',
                'typo',
                'geo',
                'words',
                'proximity',
                'attribute',
                'exact',
                'custom'
            ],
        ],
        'my_slave2' => [
            'ranking' => [
                'asc(id)',
                'typo',
                'geo',
                'words',
                'proximity',
                'attribute',
                'exact',
                'custom'
            ],
        ],
    ],
];
```

Test is included.