### PR TITLE
Extend search method to receive optional $args

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -22,6 +22,13 @@ class Builder
     public $query;
 
     /**
+     * Additional search arguments
+     *
+     * @var array
+     */
+    public $args;
+
+    /**
      * The custom index specified for the search.
      *
      * @var string
@@ -47,12 +54,14 @@ class Builder
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  string  $query
+     * @param  array   $args
      * @return void
      */
-    public function __construct($model, $query)
+    public function __construct($model, $query, array $args = [])
     {
         $this->model = $model;
         $this->query = $query;
+        $this->args = $args;
     }
 
     /**

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -92,6 +92,8 @@ class AlgoliaEngine extends Engine
      */
     protected function performSearch(Builder $builder, array $options = [])
     {
+        $options = array_merge($options, $builder->args);
+
         return $this->algolia->initIndex(
             $builder->index ?: $builder->model->searchableAs()
         )->search($builder->query, $options);

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -70,11 +70,12 @@ trait Searchable
      * Perform a search against the model's indexed data.
      *
      * @param  string  $query
+     * @param  array   $args
      * @return \Illuminate\Support\Collection
      */
-    public static function search($query)
+    public static function search($query, array $args = [])
     {
-        return new Builder(new static, $query);
+        return new Builder(new static, $query, $args);
     }
 
     /**

--- a/tests/AlgoliaEngineTest.php
+++ b/tests/AlgoliaEngineTest.php
@@ -39,10 +39,11 @@ class AlgoliaEngineTest extends PHPUnit_Framework_TestCase
         $client->shouldReceive('initIndex')->with('table')->andReturn($index = Mockery::mock('StdClass'));
         $index->shouldReceive('search')->with('zonda', [
             'numericFilters' => ['foo=1'],
+            'filters' => 'foo:bar AND baz>10',
         ]);
 
         $engine = new AlgoliaEngine($client);
-        $builder = new Laravel\Scout\Builder(new AlgoliaEngineTestModel, 'zonda');
+        $builder = new Laravel\Scout\Builder(new AlgoliaEngineTestModel, 'zonda', ['filters' => 'foo:bar AND baz>10']);
         $builder->where('foo', 1);
         $engine->search($builder);
     }


### PR DESCRIPTION
Hello again from Algolia,

as implementation of filters in #14 leaked abstration, here we implemented `filters` feature of Algolia in more abstract way which should suit more use-cases and do not leak abstraction only because Algolia.

`search()` method of Searchable trait now accepts second optional parameter `$args` which can be used to pass special arguments (like filters) to search. Those `$args` are stored within `Builder` and can be used in search engines while performing search.

Let us know what you think.

❤️ from Algolia