### PR TITLE
Fix Builder namespace

### DIFF
--- a/src/SearchableScope.php
+++ b/src/SearchableScope.php
@@ -4,7 +4,7 @@ namespace Laravel\Scout;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
-use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Builder as DbBuilder;
 use Laravel\Scout\Events\ModelsImported;
 
 class SearchableScope implements Scope
@@ -16,7 +16,7 @@ class SearchableScope implements Scope
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return void
      */
-    public function apply(Builder $builder, Model $model)
+    public function apply(DbBuilder $builder, Model $model)
     {
         //
     }
@@ -27,7 +27,7 @@ class SearchableScope implements Scope
      * @param  \Illuminate\Database\Eloquent\Builder  $builder
      * @return void
      */
-    public function extend(Builder $builder)
+    public function extend(DbBuilder $builder)
     {
         $builder->macro('searchable', function (Builder $builder) {
             $builder->chunk(100, function ($models) use ($builder) {


### PR DESCRIPTION
Fixes #17 

`Builder` class is ambiguous in SearchableScope.php and it throws `FatalErrorException` when performing search.