### PR TITLE
Fix class names

### DIFF
--- a/src/SearchableScope.php
+++ b/src/SearchableScope.php
@@ -29,7 +29,7 @@ class SearchableScope implements Scope
      */
     public function extend(EloquentBuilder $builder)
     {
-        $builder->macro('searchable', function (Builder $builder) {
+        $builder->macro('searchable', function (EloquentBuilder $builder) {
             $builder->chunk(100, function ($models) use ($builder) {
                 $models->searchable();
 
@@ -37,7 +37,7 @@ class SearchableScope implements Scope
             });
         });
 
-        $builder->macro('unsearchable', function (Builder $builder) {
+        $builder->macro('unsearchable', function (EloquentBuilder $builder) {
             $builder->chunk(100, function ($models) use ($builder) {
                 $models->unsearchable();
             });


### PR DESCRIPTION
Fixes a bug that causes this error
```
[Symfony\Component\Debug\Exception\FatalThrowableError]                                                   
  Type error: Argument 1 passed to Laravel\Scout\SearchableScope::Laravel\Scout\{closure}() must be an ins  
  tance of Laravel\Scout\Builder, instance of Illuminate\Database\Eloquent\Builder given
```

Since an \Illuminate\Database\Eloquent\Builder doesn't extend Laravel\Scout\Builder to me the previous code will not work, these simple class name updates should fix the problem.