### PR TITLE
Return length aware paginator

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Scout;
 
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Database\Eloquent\Collection;
 
@@ -121,7 +122,7 @@ class Builder
      * @param  int  $perPage
      * @param  string  $pageName
      * @param  int|null  $page
-     * @return \Illuminate\Contracts\Pagination\Paginator
+     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
     public function paginate($perPage = 15, $pageName = 'page', $page = null)
     {
@@ -133,13 +134,12 @@ class Builder
             $rawResults = $engine->paginate($this, $perPage, $page), $this->model
         ));
 
-        $paginator = (new Paginator($results, $perPage, $page, [
+        $paginator = (new LengthAwarePaginator($results, $results->count(), $perPage, $page, [
             'path' => Paginator::resolveCurrentPath(),
             'pageName' => $pageName,
         ]));
 
-        return $paginator->appends('query', $this->query)
-                         ->hasMorePagesWhen(($results->count() / $perPage) > $page);
+        return $paginator->appends('query', $this->query);
     }
 
     /**


### PR DESCRIPTION
Changes the paginator to `Illuminate\Pagination\LengthAwarePaginator` so that it matches Eloquent.

Following on from this issue: https://github.com/laravel/scout/issues/36