### PR TITLE
Update scout.php

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -55,8 +55,8 @@ return [
     */
 
     'algolia' => [
-        'id' => env('ALGOLIA_APP_ID'),
-        'secret' => env('ALGOLIA_SECRET'),
+        'id' => env('ALGOLIA_APP_ID',''),
+        'secret' => env('ALGOLIA_SECRET',''),
     ],
 
 ];


### PR DESCRIPTION
The format for the default definition for the env files values for the ALGOLIA_APP_ID and ALGOLIA_SECRET is misleading as the placeholder for the parameter was not there.