### PR TITLE
Allow multi-tenancy with Algolia

### DIFF
--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -131,7 +131,11 @@ class AlgoliaEngine extends Engine
         )->get()->keyBy($model->getKeyName());
 
         return collect($results['hits'])->map(function ($hit) use ($model, $models) {
-            return $models[$hit[$model->getKeyName()]];
-        });
+            $key = $hit[$model->getKeyName()];
+
+            if (isset($models[$key])) {
+                return $models[$key];
+            }
+        })->filter();
     }
 }


### PR DESCRIPTION
Right now, if query scopes mean a model is not visible to whatever maps results to models, then you'll get an undefined index error.