### PR TITLE
Use bulk API for elasticsearch inserts and actually test elasticsearch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ php:
 
 sudo: false
 
+services:
+    - elasticsearch
+
 install: travis_retry composer install --no-interaction --prefer-dist
+
+before_script:
+    - sleep 10
 
 script: vendor/bin/phpunit --verbose

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -161,7 +161,7 @@ class ElasticsearchEngine extends Engine
                         'filter' => [
                             "query" => [
                                 "query_string" => [
-                                    "query" => $query->query,
+                                    "query" => "*{$query->query}*",
                                 ]
                             ],
                         ],

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -56,7 +56,8 @@ class ElasticsearchEngine extends Engine
         });
 
         $this->elasticsearch->bulk([
-            'body' => $body->all()
+            'refresh' => true,
+            'body' => $body->all(),
         ]);
     }
 
@@ -81,7 +82,8 @@ class ElasticsearchEngine extends Engine
         });
 
         $this->elasticsearch->bulk([
-            'body' => $body->all()
+            'refresh' => true,
+            'body' => $body->all(),
         ]);
     }
 

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -131,14 +131,6 @@ class ElasticsearchEngine extends Engine
      */
     protected function performSearch(Builder $query, array $options = [])
     {
-        $filterQuery = [
-            "multi_match" => [
-                "query" => $query->query,
-                "fields" => "*",
-                "lenient" => true,
-            ],
-        ];
-
         $searchQuery = [];
 
         if (array_key_exists('filters', $options) && $options['filters']) {
@@ -153,6 +145,9 @@ class ElasticsearchEngine extends Engine
             $searchQuery = [
                 'bool' => $searchQuery
             ];
+        } else {
+
+
         }
 
         $searchQuery = [
@@ -161,7 +156,13 @@ class ElasticsearchEngine extends Engine
             'body' => [
                 'query' => [
                     'filtered' => [
-                        'filter' => $filterQuery,
+                        'filter' => [
+                            "query" => [
+                                "query_string" => [
+                                    "query" => $query->query,
+                                ]
+                            ],
+                        ],
                         'query' => $searchQuery,
                     ],
                 ],

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -134,19 +134,21 @@ class ElasticsearchEngine extends Engine
         $searchQuery = [];
 
         if (array_key_exists('filters', $options) && $options['filters']) {
-            $searchQuery = array_merge($searchQuery, [
-                "must" => [
-                    "match" => $options['filters'],
-                ],
-            ]);
+            foreach ($options['filters'] as $field => $value) {
+                $searchQuery[] = [
+                    "match" => [
+                        $field => $value
+                    ],
+                ];
+            }
         }
 
         if ($searchQuery) {
             $searchQuery = [
-                'bool' => $searchQuery
+                'bool' => [
+                    'must' => $searchQuery
+                ]
             ];
-        } else {
-
 
         }
 

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -14,6 +14,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
     {
         $client = Mockery::mock('Elasticsearch\Client');
         $client->shouldReceive('bulk')->with([
+            'refresh' => true,
             'body' => [
                 [
                     'index' => [
@@ -36,6 +37,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
     {
         $client = Mockery::mock('Elasticsearch\Client');
         $client->shouldReceive('bulk')->with([
+            'refresh' => true,
             'body' => [
                 [
                     'delete' => [

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -71,10 +71,10 @@ class ElasticsearchEngineTest extends AbstractTestCase
                                 ]
                             ],
                             'filter' => [
-                                'multi_match' => [
-                                    'query' => 'zonda',
-                                    'fields' => '*',
-                                    'lenient' => true
+                                'query' => [
+                                    'query_string' => [
+                                        'query' => 'zonda',
+                                    ]
                                 ]
                             ]
                         ],
@@ -127,13 +127,13 @@ class ElasticsearchEngineTest extends AbstractTestCase
 
         $expected = [
             'total' => 1,
-            'max_score' => 0,
+            'max_score' => 1.0,
             'hits' => [
                 [
                     '_index' => 'index_name',
                     '_type' => 'table',
                     '_id' => '1',
-                    '_score' => 0,
+                    '_score' => 1.0,
                     '_source' => [
                         'id' => 1,
                     ],

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -60,17 +60,23 @@ class ElasticsearchEngineTest extends AbstractTestCase
                 'type' => 'table',
                 'body' => [
                     'query' => [
-                        'bool' => [
+                        'filtered' => [
+                            'query' => [
+                                'bool' => [
+                                    'must' => [
+                                        'match' => [
+                                            'foo' => 1,
+                                        ],
+                                    ],
+                                ]
+                            ],
                             'filter' => [
-                                'query_string' => [
-                                    'query' => '*zonda*',
-                                ],
-                            ],
-                            'must' => [
-                                'match' => [
-                                    'foo' => 1,
-                                ],
-                            ],
+                                'multi_match' => [
+                                    'query' => 'zonda',
+                                    'fields' => '*',
+                                    'lenient' => true
+                                ]
+                            ]
                         ],
                     ],
                 ],

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -129,23 +129,9 @@ class ElasticsearchEngineTest extends AbstractTestCase
 
         $results = $engine->search($builder);
 
-        $expected = [
-            'total' => 1,
-            'max_score' => 1.0,
-            'hits' => [
-                [
-                    '_index' => 'index_name',
-                    '_type' => 'table',
-                    '_id' => '1',
-                    '_score' => 1.0,
-                    '_source' => [
-                        'id' => 1,
-                    ],
-                ],
-            ],
-        ];
-
-        $this->assertEquals($expected, $results['hits']);
+        $this->assertEquals(1, $results['hits']['total']);
+        $this->assertEquals('1', $results['hits']['hits'][0]['_id']);
+        $this->assertEquals(['id' => 1], $results['hits']['hits'][0]['_source']);
 
         $builder->where('title', 'zonda');
         $results = $engine->search($builder);

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -199,7 +199,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
     }
 
     /**
-     * @param  \Elasticsearch\Client $client [description]
+     * @param  \Elasticsearch\Client $client
      */
     protected function markSkippedIfMissingElasticsearch(\Elasticsearch\Client $client)
     {

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -64,9 +64,11 @@ class ElasticsearchEngineTest extends AbstractTestCase
                             'query' => [
                                 'bool' => [
                                     'must' => [
-                                        'match' => [
-                                            'foo' => 1,
-                                        ],
+                                        [
+                                            'match' => [
+                                                'foo' => 1,
+                                            ],
+                                        ]
                                     ],
                                 ]
                             ],
@@ -113,7 +115,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
         $this->assertEquals(1, count($results));
     }
 
-    public function test_real_elasticsearch_update()
+    public function test_real_elasticsearch_update_and_search()
     {
         $engine = $this->getRealElasticsearchEngine();
 
@@ -123,6 +125,8 @@ class ElasticsearchEngineTest extends AbstractTestCase
         sleep(1);
 
         $builder = new Builder(new ElasticsearchEngineTestModel, '1');
+        $builder->where('id', 1);
+
         $results = $engine->search($builder);
 
         $expected = [
@@ -142,6 +146,11 @@ class ElasticsearchEngineTest extends AbstractTestCase
         ];
 
         $this->assertEquals($expected, $results['hits']);
+
+        $builder->where('title', 'zonda');
+        $results = $engine->search($builder);
+
+        $this->assertEquals(0, $results['hits']['total']);
     }
 
     public function test_real_elasticsearch_delete()

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -75,7 +75,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
                             'filter' => [
                                 'query' => [
                                     'query_string' => [
-                                        'query' => 'zonda',
+                                        'query' => '*zonda*',
                                     ]
                                 ]
                             ]
@@ -121,9 +121,6 @@ class ElasticsearchEngineTest extends AbstractTestCase
 
         $engine->update(Collection::make([new ElasticsearchEngineTestModel]));
 
-        // Sleep so elasticsearch processes bulk request
-        sleep(1);
-
         $builder = new Builder(new ElasticsearchEngineTestModel, '1');
         $builder->where('id', 1);
 
@@ -147,13 +144,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
         $engine->update($collection);
         $builder = new Builder(new ElasticsearchEngineTestModel, '1');
 
-        // Sleep so elastichsearch processes bulk request
-        sleep(1);
-
         $engine->delete($collection);
-
-        // Sleep so elastichsearch processes bulk request
-        sleep(1);
 
         $builder = new Builder(new ElasticsearchEngineTestModel, '1');
         $results = $engine->search($builder);


### PR DESCRIPTION
There were errors in api calls for all elastiscsearch versions. This PR fixes it.  
It also adds actual tests against elasticsearch API and uses bulk api for inserts/deletes.

Perhaps even more tests would be required, as I already stumbled across various bugs

Travis Elasticsearch version is `1.4`. On my computer I was testing it using docker with Elasticsearch version `1.5` and `2.3.4`.