### PR TITLE
Restrict indexing of a model

### DIFF
--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -30,9 +30,25 @@ class AlgoliaEngine extends Engine
     {
         $index = $this->algolia->initIndex($models->first()->searchableAs());
 
-        $index->addObjects($models->map(function ($model) {
-            return array_merge(['objectID' => $model->getKey()], $model->toSearchableArray());
-        })->values()->all());
+        $counter = $models->filter(function ($model) {
+            if (method_exists($model, 'indexOnly')) {
+                return $model->indexOnly($model->searchableAs());
+            }
+
+            return true;
+        })->count();
+
+        if ($counter > 0) {
+            $index->addObjects($models->filter(function ($model) {
+                if (method_exists($model, 'indexOnly')) {
+                    return $model->indexOnly($model->searchableAs());
+                }
+
+                return true;
+            })->map(function ($model) {
+                return array_merge(['objectID' => $model->getKey()], $model->toSearchableArray());
+            })->values()->all());
+        }
     }
 
     /**

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -35,7 +35,13 @@ class ElasticsearchEngine extends Engine
      */
     public function update($models)
     {
-        $models->each(function ($model) {
+        $models->filter(function ($model) {
+            if (method_exists($model, 'indexOnly')) {
+                return $model->indexOnly($model->searchableAs());
+            }
+
+            return true;
+        })->each(function ($model) {
             $this->elasticsearch->index([
                 'index' => $this->index,
                 'type' => $model->searchableAs(),

--- a/tests/AlgoliaEngineTest.php
+++ b/tests/AlgoliaEngineTest.php
@@ -7,6 +7,7 @@ use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\AlgoliaEngine;
 use Tests\Fixtures\AlgoliaEngineTestModel;
 use Illuminate\Database\Eloquent\Collection;
+use Tests\Fixtures\NotIndexableAlgoliaEngineTestModel;
 
 class AlgoliaEngineTest extends AbstractTestCase
 {
@@ -62,5 +63,18 @@ class AlgoliaEngineTest extends AbstractTestCase
         ]], $model);
 
         $this->assertEquals(1, count($results));
+    }
+
+    public function test_update_doesnt_adds_objects_to_index_when_index_only_returns_false()
+    {
+        $client = Mockery::mock('AlgoliaSearch\Client');
+        $client->shouldReceive('initIndex')->with('table')->andReturn($index = Mockery::mock('StdClass'));
+        $index->shouldNotReceive('addObjects')->with([[
+            'id' => 1,
+            'objectID' => 1,
+        ]]);
+
+        $engine = new AlgoliaEngine($client);
+        $engine->update(Collection::make([new NotIndexableAlgoliaEngineTestModel]));
     }
 }

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -7,6 +7,7 @@ use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\ElasticsearchEngine;
 use Tests\Fixtures\ElasticsearchEngineTestModel;
 use Illuminate\Database\Eloquent\Collection;
+use Tests\Fixtures\NotIndexableElasticsearchEngineTestModel;
 
 class ElasticsearchEngineTest extends AbstractTestCase
 {
@@ -93,5 +94,19 @@ class ElasticsearchEngineTest extends AbstractTestCase
         ], $model);
 
         $this->assertEquals(1, count($results));
+    }
+
+    public function test_update_doesnt_adds_objects_to_index_when_index_only_returns_false()
+    {
+        $client = Mockery::mock('Elasticsearch\Client');
+        $client->shouldNotReceive('index')->with([
+            'index' => 'index_name',
+            'type' => 'table',
+            'id' => 1,
+            'body' => ['id' => 1],
+        ]);
+
+        $engine = new ElasticsearchEngine($client, 'index_name');
+        $engine->update(Collection::make([new NotIndexableElasticsearchEngineTestModel]));
     }
 }

--- a/tests/Fixtures/NotIndexableAlgoliaEngineTestModel.php
+++ b/tests/Fixtures/NotIndexableAlgoliaEngineTestModel.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Fixtures;
+
+class NotIndexableAlgoliaEngineTestModel extends NotIndexableTestModel
+{
+    //
+}

--- a/tests/Fixtures/NotIndexableElasticsearchEngineTestModel.php
+++ b/tests/Fixtures/NotIndexableElasticsearchEngineTestModel.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Fixtures;
+
+class NotIndexableElasticsearchEngineTestModel extends NotIndexableTestModel
+{
+    //
+}

--- a/tests/Fixtures/NotIndexableTestModel.php
+++ b/tests/Fixtures/NotIndexableTestModel.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class NotIndexableTestModel extends TestModel
+{
+    public function indexOnly($index) {
+        return false;
+    }
+}


### PR DESCRIPTION
This pr is fixing #42.

The engines `update` method will look for an `indexOnly` method on the model. If this method is present the model will only be indexed when `indexOnly` returns `true`