### PR TITLE
Added getTotalCount() method to engines to solve pagination issues.

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -139,7 +139,7 @@ class Builder
         ]));
 
         return $paginator->appends('query', $this->query)
-                         ->hasMorePagesWhen(($results->count() / $perPage) > $page);
+                         ->hasMorePagesWhen(($engine->getTotalCount($rawResults) / $perPage) > $page);
     }
 
     /**

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -138,4 +138,15 @@ class AlgoliaEngine extends Engine
             }
         })->filter();
     }
+
+    /**
+     * Get the total count from a raw result returned by the engine.
+     *
+     * @param  mixed  $results
+     * @return int
+     */
+    public function getTotalCount($results)
+    {
+        return $results['nbHits'];
+    }
 }

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -227,4 +227,15 @@ class ElasticsearchEngine extends Engine
             return $models[$hit['_source'][$model->getKeyName()]];
         });
     }
+
+    /**
+     * Get the total count from a raw result returned by the engine.
+     *
+     * @param  mixed  $results
+     * @return int
+     */
+    public function getTotalCount($results)
+    {
+        return $results['hits']['total'];
+    }
 }

--- a/src/Engines/Engine.php
+++ b/src/Engines/Engine.php
@@ -51,6 +51,14 @@ abstract class Engine
     abstract public function map($results, $model);
 
     /**
+     * Get the total count from a raw result returned by the engine.
+     *
+     * @param  mixed  $results
+     * @return int
+     */
+    abstract public function getTotalCount($results);
+
+    /**
      * Get the results of the given query mapped onto models.
      *
      * @param  \Laravel\Scout\Builder  $builder

--- a/src/Engines/NullEngine.php
+++ b/src/Engines/NullEngine.php
@@ -64,4 +64,15 @@ class NullEngine extends Engine
     {
         return Collection::make();
     }
+
+    /**
+     * Get the total count from a raw result returned by the engine.
+     *
+     * @param  mixed  $results
+     * @return int
+     */
+    public function getTotalCount($results)
+    {
+        return count($results);
+    }
 }

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -22,6 +22,7 @@ class BuilderTest extends AbstractTestCase
         });
         $engine->shouldReceive('paginate');
         $engine->shouldReceive('map')->andReturn(Collection::make([new StdClass]));
+        $engine->shouldReceive('getTotalCount');
 
         $builder->paginate();
     }


### PR DESCRIPTION
As mentioned in the Issue #46

```
->hasMorePagesWhen(($results->count() / $perPage) > $page)
```

always returns false because it is the result count will always match the `$perPage` parameter. To solve this issue i added a method to the engines called `getTotalCount()` that is used to get the correct count of the search results. The new builder code then looks like this:

```
->hasMorePagesWhen(($engine->getTotalCount($rawResults) / $perPage) > $page);
```