### PR TITLE
Restrict indexing of a model with searchablAs()

### DIFF
--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -11,7 +11,7 @@ class AlgoliaEngine extends Engine
     /**
      * Create a new engine instance.
      *
-     * @param  \AlgoliaSearch\Client  $algolia
+     * @param  \AlgoliaSearch\Client $algolia
      * @return void
      */
     public function __construct(Algolia $algolia)
@@ -22,26 +22,26 @@ class AlgoliaEngine extends Engine
     /**
      * Update the given model in the index.
      *
-     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @param  \Illuminate\Database\Eloquent\Collection $models
      * @throws \AlgoliaSearch\AlgoliaException
      * @return void
      */
     public function update($models)
     {
-        $index = $this->algolia->initIndex($models->first()->searchableAs());
-
         $counter = $models->filter(function ($model) {
-            if (method_exists($model, 'indexOnly')) {
-                return $model->indexOnly($model->searchableAs());
+            if (is_array($model->searchableAs()) && empty($model->searchableAs())) {
+                return false;
             }
 
             return true;
         })->count();
 
         if ($counter > 0) {
+            $index = $this->algolia->initIndex($models->first()->searchableAs());
+
             $index->addObjects($models->filter(function ($model) {
-                if (method_exists($model, 'indexOnly')) {
-                    return $model->indexOnly($model->searchableAs());
+                if (is_array($model->searchableAs()) && empty($model->searchableAs())) {
+                    return false;
                 }
 
                 return true;
@@ -54,7 +54,7 @@ class AlgoliaEngine extends Engine
     /**
      * Remove the given model from the index.
      *
-     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @param  \Illuminate\Database\Eloquent\Collection $models
      * @return void
      */
     public function delete($models)
@@ -71,7 +71,7 @@ class AlgoliaEngine extends Engine
     /**
      * Perform the given search on the engine.
      *
-     * @param  \Laravel\Scout\Builder  $builder
+     * @param  \Laravel\Scout\Builder $builder
      * @return mixed
      */
     public function search(Builder $builder)
@@ -85,9 +85,9 @@ class AlgoliaEngine extends Engine
     /**
      * Perform the given search on the engine.
      *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @param  int  $perPage
-     * @param  int  $page
+     * @param  \Laravel\Scout\Builder $builder
+     * @param  int $perPage
+     * @param  int $page
      * @return mixed
      */
     public function paginate(Builder $builder, $perPage, $page)
@@ -102,8 +102,8 @@ class AlgoliaEngine extends Engine
     /**
      * Perform the given search on the engine.
      *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @param  array  $options
+     * @param  \Laravel\Scout\Builder $builder
+     * @param  array $options
      * @return mixed
      */
     protected function performSearch(Builder $builder, array $options = [])
@@ -116,21 +116,21 @@ class AlgoliaEngine extends Engine
     /**
      * Get the filter array for the query.
      *
-     * @param  \Laravel\Scout\Builder  $builder
+     * @param  \Laravel\Scout\Builder $builder
      * @return array
      */
     protected function filters(Builder $builder)
     {
         return collect($builder->wheres)->map(function ($value, $key) {
-            return $key.'='.$value;
+            return $key . '=' . $value;
         })->values()->all();
     }
 
     /**
      * Map the given results to instances of the given model.
      *
-     * @param  mixed  $results
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  mixed $results
+     * @param  \Illuminate\Database\Eloquent\Model $model
      * @return \Illuminate\Database\Eloquent\Collection
      */
     public function map($results, $model)
@@ -140,7 +140,7 @@ class AlgoliaEngine extends Engine
         }
 
         $keys = collect($results['hits'])
-                        ->pluck('objectID')->values()->all();
+            ->pluck('objectID')->values()->all();
 
         $models = $model->whereIn(
             $model->getKeyName(), $keys

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -11,7 +11,7 @@ class AlgoliaEngine extends Engine
     /**
      * Create a new engine instance.
      *
-     * @param  \AlgoliaSearch\Client $algolia
+     * @param  \AlgoliaSearch\Client  $algolia
      * @return void
      */
     public function __construct(Algolia $algolia)
@@ -22,7 +22,7 @@ class AlgoliaEngine extends Engine
     /**
      * Update the given model in the index.
      *
-     * @param  \Illuminate\Database\Eloquent\Collection $models
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
      * @throws \AlgoliaSearch\AlgoliaException
      * @return void
      */
@@ -54,7 +54,7 @@ class AlgoliaEngine extends Engine
     /**
      * Remove the given model from the index.
      *
-     * @param  \Illuminate\Database\Eloquent\Collection $models
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
      * @return void
      */
     public function delete($models)
@@ -71,7 +71,7 @@ class AlgoliaEngine extends Engine
     /**
      * Perform the given search on the engine.
      *
-     * @param  \Laravel\Scout\Builder $builder
+     * @param  \Laravel\Scout\Builder  $builder
      * @return mixed
      */
     public function search(Builder $builder)
@@ -85,9 +85,9 @@ class AlgoliaEngine extends Engine
     /**
      * Perform the given search on the engine.
      *
-     * @param  \Laravel\Scout\Builder $builder
-     * @param  int $perPage
-     * @param  int $page
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  int  $perPage
+     * @param  int  $page
      * @return mixed
      */
     public function paginate(Builder $builder, $perPage, $page)
@@ -102,8 +102,8 @@ class AlgoliaEngine extends Engine
     /**
      * Perform the given search on the engine.
      *
-     * @param  \Laravel\Scout\Builder $builder
-     * @param  array $options
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  array  $options
      * @return mixed
      */
     protected function performSearch(Builder $builder, array $options = [])
@@ -122,7 +122,7 @@ class AlgoliaEngine extends Engine
     protected function filters(Builder $builder)
     {
         return collect($builder->wheres)->map(function ($value, $key) {
-            return $key . '=' . $value;
+            return $key.'='.$value;
         })->values()->all();
     }
 
@@ -140,7 +140,7 @@ class AlgoliaEngine extends Engine
         }
 
         $keys = collect($results['hits'])
-            ->pluck('objectID')->values()->all();
+                ->pluck('objectID')->values()->all();
 
         $models = $model->whereIn(
             $model->getKeyName(), $keys

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -116,7 +116,7 @@ class AlgoliaEngine extends Engine
     /**
      * Get the filter array for the query.
      *
-     * @param  \Laravel\Scout\Builder $builder
+     * @param  \Laravel\Scout\Builder  $builder
      * @return array
      */
     protected function filters(Builder $builder)
@@ -129,8 +129,8 @@ class AlgoliaEngine extends Engine
     /**
      * Map the given results to instances of the given model.
      *
-     * @param  mixed $results
-     * @param  \Illuminate\Database\Eloquent\Model $model
+     * @param  mixed  $results
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return \Illuminate\Database\Eloquent\Collection
      */
     public function map($results, $model)
@@ -140,7 +140,7 @@ class AlgoliaEngine extends Engine
         }
 
         $keys = collect($results['hits'])
-                ->pluck('objectID')->values()->all();
+                    ->pluck('objectID')->values()->all();
 
         $models = $model->whereIn(
             $model->getKeyName(), $keys

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -30,9 +30,25 @@ class AlgoliaEngine extends Engine
     {
         $index = $this->algolia->initIndex($models->first()->searchableAs());
 
-        $index->addObjects($models->map(function ($model) {
-            return array_merge(['objectID' => $model->getKey()], $model->toSearchableArray());
-        })->values()->all());
+        $counter = $models->filter(function ($model) {
+            if (method_exists($model, 'indexOnly')) {
+                return $model->indexOnly($model->searchableAs());
+            }
+
+            return true;
+        })->count();
+
+        if ($counter > 0) {
+            $index->addObjects($models->filter(function ($model) {
+                if (method_exists($model, 'indexOnly')) {
+                    return $model->indexOnly($model->searchableAs());
+                }
+
+                return true;
+            })->map(function ($model) {
+                return array_merge(['objectID' => $model->getKey()], $model->toSearchableArray());
+            })->values()->all());
+        }
     }
 
     /**

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -140,7 +140,7 @@ class AlgoliaEngine extends Engine
         }
 
         $keys = collect($results['hits'])
-                    ->pluck('objectID')->values()->all();
+                        ->pluck('objectID')->values()->all();
 
         $models = $model->whereIn(
             $model->getKeyName(), $keys

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -35,7 +35,13 @@ class ElasticsearchEngine extends Engine
      */
     public function update($models)
     {
-        $models->each(function ($model) {
+        $models->filter(function ($model) {
+            if (method_exists($model, 'indexOnly')) {
+                return $model->indexOnly($model->searchableAs());
+            }
+
+            return true;
+        })->each(function ($model) {
             $this->elasticsearch->index([
                 'index' => $this->index,
                 'type' => $model->searchableAs(),

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -47,8 +47,8 @@ class ElasticsearchEngine extends Engine
         $body = new BaseCollection();
 
         $models->filter(function ($model) {
-            if (method_exists($model, 'indexOnly')) {
-                    return $model->indexOnly($model->searchableAs());
+            if (is_array($model->searchableAs()) && empty($model->searchableAs())) {
+                return false;
             }
 
             return true;

--- a/tests/AlgoliaEngineTest.php
+++ b/tests/AlgoliaEngineTest.php
@@ -65,7 +65,7 @@ class AlgoliaEngineTest extends AbstractTestCase
         $this->assertEquals(1, count($results));
     }
 
-    public function test_update_doesnt_adds_objects_to_index_when_index_only_returns_false()
+    public function test_update_doesnt_adds_objects_to_index_when_searchableAs_returns_empty_array()
     {
         $client = Mockery::mock('AlgoliaSearch\Client');
         $client->shouldReceive('initIndex')->with('table')->andReturn($index = Mockery::mock('StdClass'));

--- a/tests/AlgoliaEngineTest.php
+++ b/tests/AlgoliaEngineTest.php
@@ -7,6 +7,7 @@ use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\AlgoliaEngine;
 use Tests\Fixtures\AlgoliaEngineTestModel;
 use Illuminate\Database\Eloquent\Collection;
+use Tests\Fixtures\NotIndexableAlgoliaEngineTestModel;
 
 class AlgoliaEngineTest extends AbstractTestCase
 {
@@ -62,5 +63,18 @@ class AlgoliaEngineTest extends AbstractTestCase
         ]], $model);
 
         $this->assertEquals(1, count($results));
+    }
+
+    public function test_update_doesnt_adds_objects_to_index_when_index_only_returns_false()
+    {
+        $client = Mockery::mock('AlgoliaSearch\Client');
+        $client->shouldReceive('initIndex')->with('table')->andReturn($index = Mockery::mock('StdClass'));
+        $index->shouldNotReceive('addObjects')->with([[
+            'id' => 1,
+            'objectID' => 1,
+        ]]);
+
+        $engine = new AlgoliaEngine($client);
+        $engine->update(Collection::make([new NotIndexableAlgoliaEngineTestModel]));
     }
 }

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -7,6 +7,7 @@ use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\ElasticsearchEngine;
 use Tests\Fixtures\ElasticsearchEngineTestModel;
 use Illuminate\Database\Eloquent\Collection;
+use Tests\Fixtures\NotIndexableElasticsearchEngineTestModel;
 
 class ElasticsearchEngineTest extends AbstractTestCase
 {
@@ -93,5 +94,19 @@ class ElasticsearchEngineTest extends AbstractTestCase
         ], $model);
 
         $this->assertEquals(1, count($results));
+    }
+
+    public function test_update_doesnt_adds_objects_to_index_when_index_only_returns_false()
+    {
+        $client = Mockery::mock('Elasticsearch\Client');
+        $client->shouldNotReceive('index')->with([
+            'index' => 'index_name',
+            'type' => 'table',
+            'id' => 1,
+            'body' => ['id' => 1],
+        ]);
+
+        $engine = new ElasticsearchEngine($client, 'index_name');
+        $engine->update(Collection::make([new NotIndexableElasticsearchEngineTestModel]));
     }
 }

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -204,7 +204,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
         }
     }
 
-    public function test_update_doesnt_adds_objects_to_index_when_index_only_returns_false()
+    public function test_update_doesnt_adds_objects_to_index_when_searchableAs_returns_empty_array()
     {
         $client = Mockery::mock('Elasticsearch\Client');
         $client->shouldReceive('bulk')->with([

--- a/tests/Fixtures/NotIndexableAlgoliaEngineTestModel.php
+++ b/tests/Fixtures/NotIndexableAlgoliaEngineTestModel.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Fixtures;
+
+class NotIndexableAlgoliaEngineTestModel extends NotIndexableTestModel
+{
+    //
+}

--- a/tests/Fixtures/NotIndexableElasticsearchEngineTestModel.php
+++ b/tests/Fixtures/NotIndexableElasticsearchEngineTestModel.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Fixtures;
+
+class NotIndexableElasticsearchEngineTestModel extends NotIndexableTestModel
+{
+    //
+}

--- a/tests/Fixtures/NotIndexableTestModel.php
+++ b/tests/Fixtures/NotIndexableTestModel.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class NotIndexableTestModel extends TestModel
+{
+    public function indexOnly($index) {
+        return false;
+    }
+}

--- a/tests/Fixtures/NotIndexableTestModel.php
+++ b/tests/Fixtures/NotIndexableTestModel.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class NotIndexableTestModel extends TestModel
 {
-    public function indexOnly($index) {
-        return false;
+    public function searchableAs() {
+        return [];
     }
 }


### PR DESCRIPTION
This pr fixes #42.

Its like #50 but as mentioned by @taylorotwell the engines now will look if `searchableAs()` returns an empty array.