### PR TITLE
Switch to simple_query_string for better exception handling in Elasticsearch

### DIFF
--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -145,7 +145,7 @@ class ElasticsearchEngine extends Engine
         if (array_key_exists('filters', $options) && $options['filters']) {
             foreach ($options['filters'] as $field => $value) {
                 $searchQuery[] = [
-                    "match" => [
+                    'match' => [
                         $field => $value
                     ],
                 ];
@@ -168,10 +168,10 @@ class ElasticsearchEngine extends Engine
                 'query' => [
                     'filtered' => [
                         'filter' => [
-                            "query" => [
-                                "query_string" => [
-                                    "query" => "*{$query->query}*",
-                                ]
+                            'query' => [
+                                'simple_query_string' => [
+                                    'query' => $query->query,
+                                ],
                             ],
                         ],
                         'query' => $searchQuery,

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -76,8 +76,8 @@ class ElasticsearchEngineTest extends AbstractTestCase
                             ],
                             'filter' => [
                                 'query' => [
-                                    'query_string' => [
-                                        'query' => '*zonda*',
+                                    'simple_query_string' => [
+                                        'query' => 'zonda',
                                     ]
                                 ]
                             ]


### PR DESCRIPTION
Right now, if you query for, say, `category:foo`, you're gonna see an instance of `Elasticsearch\Common\Exceptions\BadRequest400Exception` thrown because `*category:foo*` is a syntax error in elasticsearch query strings.

All-in-all, `simple_query_string` (which cannot error and silently ignores bad syntax, returning 0 results on a proper non-transport-related error instead) seems to be a much better fit for "it just works".