### PR TITLE
ElasticsearchEngine modifications to follow elasticsearch best practices

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -71,12 +71,8 @@ return [
     */
 
     'elasticsearch' => [
-        'index' => env('ELASTICSEARCH_INDEX', 'laravel'),
-
         'config' => [
-            'hosts' => [
-                env('ELASTICSEARCH_HOST')
-            ],
+            'hosts' => explode(',',env('ELASTICSEARCH_HOST','localhost')),
         ],
     ],
 

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -42,8 +42,7 @@ class EngineManager extends Manager
     public function createElasticsearchDriver()
     {
         return new ElasticsearchEngine(
-            Elasticsearch::fromConfig(config('scout.elasticsearch.config')),
-            config('scout.elasticsearch.index')
+            Elasticsearch::fromConfig(config('scout.elasticsearch.config'))
         );
     }
 

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -17,23 +17,14 @@ class ElasticsearchEngine extends Engine
     protected $elasticsearch;
 
     /**
-     * The index name.
-     *
-     * @var string
-     */
-    protected $index;
-
-    /**
      * Create a new engine instance.
      *
      * @param  \Elasticsearch\Client  $elasticsearch
      * @return void
      */
-    public function __construct(Elasticsearch $elasticsearch, $index)
+    public function __construct(Elasticsearch $elasticsearch)
     {
         $this->elasticsearch = $elasticsearch;
-
-        $this->index = $index;
     }
 
     /**
@@ -55,7 +46,7 @@ class ElasticsearchEngine extends Engine
 
             $body->push([
                 'index' => [
-                    '_index' =>  $this->index.'_'.$model->searchableAs(),
+                    '_index' =>  $model->searchableAs(),
                     '_type'  =>  'docs',
                     '_id' => $model->getKey(),
                 ]
@@ -83,7 +74,7 @@ class ElasticsearchEngine extends Engine
         $models->each(function ($model) use ($body) {
             $body->push([
                 'delete' => [
-                    '_index' =>  $this->index.'_'.$model->searchableAs(),
+                    '_index' =>  $model->searchableAs(),
                     '_type'  =>  'docs',
                     '_id'  => $model->getKey(),
                 ]
@@ -149,7 +140,7 @@ class ElasticsearchEngine extends Engine
                 "match" => [
                     "_all" => [
                         "query" => $query->query,
-                        "fuzziness" => 2
+                        "fuzziness" => 1
                     ]
                 ]
             ];
@@ -176,7 +167,7 @@ class ElasticsearchEngine extends Engine
                         "match" => [
                             $field => [
                                 "query" => $filter,
-                                "operator" => "and"
+                                "operator" => "and" //force all terms to match
                             ]
                         ],
                     ];
@@ -187,7 +178,7 @@ class ElasticsearchEngine extends Engine
 
         //construct the final bool query
         $searchQuery = [
-            'index' =>  $this->index.'_'.$query->model->searchableAs(),
+            'index' =>  $query->model->searchableAs(),
             'type'  =>  'docs',
             'body' => [
                 'query' => [

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -149,7 +149,6 @@ class ElasticsearchEngine extends Engine
                 "match" => [
                     "_all" => [
                         "query" => $query->query,
-                        "operator" => "and",
                         "fuzziness" => 2
                     ]
                 ]

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -46,8 +46,8 @@ class ElasticsearchEngine extends Engine
 
             $body->push([
                 'index' => [
-                    '_index' =>  $model->searchableAs(),
-                    '_type'  =>  'docs',
+                    '_index' => $model->searchableAs(),
+                    '_type' => 'docs',
                     '_id' => $model->getKey(),
                 ]
             ]);
@@ -74,9 +74,9 @@ class ElasticsearchEngine extends Engine
         $models->each(function ($model) use ($body) {
             $body->push([
                 'delete' => [
-                    '_index' =>  $model->searchableAs(),
-                    '_type'  =>  'docs',
-                    '_id'  => $model->getKey(),
+                    '_index' => $model->searchableAs(),
+                    '_type' => 'docs',
+                    '_id' => $model->getKey(),
                 ]
             ]);
         });

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -164,7 +164,7 @@ class ElasticsearchEngine extends Engine
                 //if filter val is numeric, add a term filter to the filter clause
                 if(is_numeric($filter))
                 {
-                    $searchQuery['filter'][] =  [
+                    $searchQuery['must'][] =  [
                         "term" => [$field => $filter],
                     ];
                 }

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -55,8 +55,8 @@ class ElasticsearchEngine extends Engine
 
             $body->push([
                 'index' => [
-                    'index' =>  $this->index.'_'.$model->searchableAs(),
-                    'type'  =>  'docs',
+                    '_index' =>  $this->index.'_'.$model->searchableAs(),
+                    '_type'  =>  'docs',
                     '_id' => $model->getKey(),
                 ]
             ]);
@@ -83,8 +83,8 @@ class ElasticsearchEngine extends Engine
         $models->each(function ($model) use ($body) {
             $body->push([
                 'delete' => [
-                    'index' =>  $this->index.'_'.$model->searchableAs(),
-                    'type'  =>  'docs',
+                    '_index' =>  $this->index.'_'.$model->searchableAs(),
+                    '_type'  =>  'docs',
                     '_id'  => $model->getKey(),
                 ]
             ]);

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -133,11 +133,11 @@ class ElasticsearchEngine extends Engine
      */
     protected function performSearch(Builder $query, array $options = [])
     {
-         $searchQuery = [];
+        $searchQuery = [];
 
         //match against all fields with the initial keyword string
         if(!empty($query->query)) {
-            $searchQuery['query'] = [
+            $searchQuery['query']['bool']['must'][] = [
                 "match" => [
                     "_all" => [
                         "query" => $query->query,
@@ -159,7 +159,7 @@ class ElasticsearchEngine extends Engine
                     ];
                 } else {
                     //else its a string so add a match query to the must clause
-                    $searchQuery['filter']['bool']['must'][] =  [
+                    $searchQuery['query']['bool']['must'][] =  [
                         "match" => [
                             $field => [
                                 "query" => $filter,
@@ -223,9 +223,9 @@ class ElasticsearchEngine extends Engine
         }
 
         $keys = collect($results['hits']['hits'])
-                    ->pluck('_id')
-                    ->values()
-                    ->all();
+            ->pluck('_id')
+            ->values()
+            ->all();
 
         $models = $model->whereIn(
             $model->getKeyName(), $keys

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -68,7 +68,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
                                     'match' => [
                                         '_all' => [
                                             'query' => 'zonda',
-                                            'fuzzyness' => 2
+                                            'fuzziness' => 2
                                         ],
                                     ],
                                 ]

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -18,8 +18,8 @@ class ElasticsearchEngineTest extends AbstractTestCase
             'body' => [
                 [
                     'index' => [
-                        '_index' => 'index_name',
-                        '_type' => 'table',
+                        '_index' => 'index_name_table',
+                        '_type' => 'docs',
                         '_id' => 1,
                     ],
                 ],
@@ -41,8 +41,8 @@ class ElasticsearchEngineTest extends AbstractTestCase
             'body' => [
                 [
                     'delete' => [
-                        '_index' => 'index_name',
-                        '_type' => 'table',
+                        '_index' => 'index_name_table',
+                        '_type' => 'docs',
                         '_id' => 1,
                     ],
                 ],
@@ -58,26 +58,22 @@ class ElasticsearchEngineTest extends AbstractTestCase
         $client = Mockery::mock('Elasticsearch\Client');
         $client->shouldReceive('search')
             ->with([
-                'index' => 'index_name',
-                'type' => 'table',
+                'index' => 'index_name_table',
+                'type' => 'docs',
                 'body' => [
                     'query' => [
-                        'filtered' => [
-                            'query' => [
-                                'bool' => [
-                                    'must' => [
-                                        [
-                                            'match' => [
-                                                'foo' => 1,
-                                            ],
-                                        ]
+                        'bool' => [
+                            'must' => [
+                                [
+                                    'match' => [
+                                        '_all' => 'zonda',
                                     ],
                                 ]
                             ],
                             'filter' => [
-                                'query' => [
-                                    'query_string' => [
-                                        'query' => '*zonda*',
+                                [
+                                    'term' => [
+                                        'foo' => 1
                                     ]
                                 ]
                             ]

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -18,7 +18,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
             'body' => [
                 [
                     'index' => [
-                        '_index' => 'index_name_table',
+                        '_index' => 'table',
                         '_type' => 'docs',
                         '_id' => 1,
                     ],
@@ -29,7 +29,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
             ],
         ]);
 
-        $engine = new ElasticsearchEngine($client, 'index_name');
+        $engine = new ElasticsearchEngine($client);
         $engine->update(Collection::make([new ElasticsearchEngineTestModel]));
     }
 
@@ -41,7 +41,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
             'body' => [
                 [
                     'delete' => [
-                        '_index' => 'index_name_table',
+                        '_index' => 'table',
                         '_type' => 'docs',
                         '_id' => 1,
                     ],
@@ -49,7 +49,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
             ],
         ]);
 
-        $engine = new ElasticsearchEngine($client, 'index_name');
+        $engine = new ElasticsearchEngine($client);
         $engine->delete(Collection::make([new ElasticsearchEngineTestModel]));
     }
 
@@ -58,7 +58,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
         $client = Mockery::mock('Elasticsearch\Client');
         $client->shouldReceive('search')
             ->with([
-                'index' => 'index_name_table',
+                'index' => 'table',
                 'type' => 'docs',
                 'body' => [
                     'query' => [
@@ -68,7 +68,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
                                     'match' => [
                                         '_all' => [
                                             'query' => 'zonda',
-                                            'fuzziness' => 2
+                                            'fuzziness' => 1
                                         ],
                                     ],
                                 ],
@@ -84,7 +84,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
                 'size' => 10000,
             ]);
 
-        $engine = new ElasticsearchEngine($client, 'index_name');
+        $engine = new ElasticsearchEngine($client);
         $builder = new Builder(new ElasticsearchEngineTestModel, 'zonda');
         $builder->where('foo', 1);
         $engine->search($builder);
@@ -93,7 +93,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
     public function test_map_correctly_maps_results_to_models()
     {
         $client = Mockery::mock('Elasticsearch\Client');
-        $engine = new ElasticsearchEngine($client, 'index_name');
+        $engine = new ElasticsearchEngine($client);
 
         $model = Mockery::mock('StdClass');
         $model->shouldReceive('getKeyName')->andReturn('id');
@@ -160,7 +160,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
         $this->markSkippedIfMissingElasticsearch($client);
         $this->resetIndex($client);
 
-        return new ElasticsearchEngine($client, 'index_name');
+        return new ElasticsearchEngine($client);
     }
 
     /**
@@ -179,7 +179,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
      */
     protected function resetIndex(\Elasticsearch\Client $client)
     {
-        $data = ['index' => 'index_name_table'];
+        $data = ['index' => 'table'];
 
         if ($client->indices()->exists($data)) {
             $client->indices()->delete($data);

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -66,7 +66,10 @@ class ElasticsearchEngineTest extends AbstractTestCase
                             'must' => [
                                 [
                                     'match' => [
-                                        '_all' => 'zonda',
+                                        '_all' => [
+                                            'query' => 'zonda',
+                                            'fuzzyness' => 2
+                                        ],
                                     ],
                                 ]
                             ],
@@ -178,7 +181,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
      */
     protected function resetIndex(\Elasticsearch\Client $client)
     {
-        $data = ['index' => 'index_name'];
+        $data = ['index' => 'index_name_table'];
 
         if ($client->indices()->exists($data)) {
             $client->indices()->delete($data);

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -53,7 +53,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
         $engine->delete(Collection::make([new ElasticsearchEngineTestModel]));
     }
 
-    public function test_search_sends_correct_parameters_to_algolia()
+    public function test_search_sends_correct_parameters_to_index()
     {
         $client = Mockery::mock('Elasticsearch\Client');
         $client->shouldReceive('search')
@@ -62,19 +62,23 @@ class ElasticsearchEngineTest extends AbstractTestCase
                 'type' => 'docs',
                 'body' => [
                     'query' => [
-                        'bool' => [
-                            'must' => [
-                                [
-                                    'match' => [
-                                        '_all' => [
-                                            'query' => 'zonda',
-                                            'fuzziness' => 1
-                                        ],
+                        'filtered' => [
+                            'query' => [
+                                'match' => [
+                                    '_all' => [
+                                        'query' => 'zonda',
+                                        'fuzziness' => 1
                                     ],
-                                ],
-                                [
-                                    'term' => [
-                                        'foo' => 1
+                                ]
+                            ],
+                            'filter' => [
+                                'bool' => [
+                                    'must' => [
+                                        [
+                                            'term' => [
+                                                'foo' => 1
+                                            ]
+                                        ]
                                     ]
                                 ]
                             ]

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -71,9 +71,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
                                             'fuzziness' => 2
                                         ],
                                     ],
-                                ]
-                            ],
-                            'filter' => [
+                                ],
                                 [
                                     'term' => [
                                         'foo' => 1

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -64,11 +64,17 @@ class ElasticsearchEngineTest extends AbstractTestCase
                     'query' => [
                         'filtered' => [
                             'query' => [
-                                'match' => [
-                                    '_all' => [
-                                        'query' => 'zonda',
-                                        'fuzziness' => 1
-                                    ],
+                                'bool' => [
+                                    'must' => [
+                                        [
+                                            'match' => [
+                                                '_all' => [
+                                                    'query' => 'zonda',
+                                                    'fuzziness' => 1
+                                                ],
+                                            ]
+                                        ]
+                                    ]
                                 ]
                             ],
                             'filter' => [


### PR DESCRIPTION
Corrected several common misconceptions about using elasticsearch:

- NEVER use query_string query ... it's not intended to be opened up to the end user! This allows the end user direct access to the underlying Lucene instance, with which they can easily  (in theory) do a query that would suck up all free JAVA_HEAP and crash elastic.
- Used match query for fulltext searches, and term filter for (numeric) filters
- Used "fuzzy" parameter on main match query to allow fuzzy matching and misspellings
- Used Bool query instead of Filtered query. the filtered query has been depricated as of Elasticsearch 2.0. Bool query is probably the best combo-query to use for most things
- Changed 'index' to be the $model->searchableAs() value prefixed with 'index' value, then set 'type' to static value 'docs'. Elasticsearch Indices should have a single type, unless you have a REALLY good reason to combine multiple types within the same index. In elasticsearch 2.x types are held within the same Apache Lucene instance, thus, you cannot have two fields with the same name but different data types within the same index. This means that an application could have 2 different models that both define the same field, but with different data types. The 2nd model would never index documents because of the field not matching the type elastic is expecting. It also means that, currently, all documents for all models are going into the same index. Which means you have to search through all docs from all models just to find one from a single model.