### PR TITLE
Remove elasticsearch_index, use $model->searchableAs() instead

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -71,8 +71,6 @@ return [
     */
 
     'elasticsearch' => [
-        'index' => env('ELASTICSEARCH_INDEX', 'laravel'),
-
         'config' => [
             'hosts' => [
                 env('ELASTICSEARCH_HOST'),

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -17,11 +17,9 @@ class ElasticsearchEngine extends Engine
     protected $elasticsearch;
 
     /**
-     * The index name.
-     *
      * @var string
      */
-    protected $index;
+    protected $type = 'doc';
 
     /**
      * Create a new engine instance.
@@ -29,11 +27,9 @@ class ElasticsearchEngine extends Engine
      * @param  \Elasticsearch\Client  $elasticsearch
      * @return void
      */
-    public function __construct(Elasticsearch $elasticsearch, $index)
+    public function __construct(Elasticsearch $elasticsearch)
     {
         $this->elasticsearch = $elasticsearch;
-
-        $this->index = $index;
     }
 
     /**
@@ -55,8 +51,8 @@ class ElasticsearchEngine extends Engine
 
             $body->push([
                 'index' => [
-                    '_index' => $this->index,
-                    '_type' => $model->searchableAs(),
+                    '_index' => $model->searchableAs(),
+                    '_type' => $this->type,
                     '_id' => $model->getKey(),
                 ],
             ]);
@@ -83,8 +79,8 @@ class ElasticsearchEngine extends Engine
         $models->each(function ($model) use ($body) {
             $body->push([
                 'delete' => [
-                    '_index' => $this->index,
-                    '_type' => $model->searchableAs(),
+                    '_index' => $model->searchableAs(),
+                    '_type' => $this->type,
                     '_id'  => $model->getKey(),
                 ],
             ]);
@@ -161,8 +157,8 @@ class ElasticsearchEngine extends Engine
         }
 
         $searchQuery = [
-            'index' =>  $this->index,
-            'type'  =>  $query->model->searchableAs(),
+            'index' =>  $query->model->searchableAs(),
+            'type'  =>  $this->type,
             'body' => [
                 'query' => [
                     'filtered' => [

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -18,8 +18,8 @@ class ElasticsearchEngineTest extends AbstractTestCase
             'body' => [
                 [
                     'index' => [
-                        '_index' => 'index_name',
-                        '_type' => 'table',
+                        '_index' => 'table',
+                        '_type' => 'doc',
                         '_id' => 1,
                     ],
                 ],
@@ -29,7 +29,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
             ],
         ]);
 
-        $engine = new ElasticsearchEngine($client, 'index_name');
+        $engine = new ElasticsearchEngine($client);
         $engine->update(Collection::make([new ElasticsearchEngineTestModel]));
     }
 
@@ -41,15 +41,15 @@ class ElasticsearchEngineTest extends AbstractTestCase
             'body' => [
                 [
                     'delete' => [
-                        '_index' => 'index_name',
-                        '_type' => 'table',
+                        '_index' => 'table',
+                        '_type' => 'doc',
                         '_id' => 1,
                     ],
                 ],
             ],
         ]);
 
-        $engine = new ElasticsearchEngine($client, 'index_name');
+        $engine = new ElasticsearchEngine($client);
         $engine->delete(Collection::make([new ElasticsearchEngineTestModel]));
     }
 
@@ -58,8 +58,8 @@ class ElasticsearchEngineTest extends AbstractTestCase
         $client = Mockery::mock('Elasticsearch\Client');
         $client->shouldReceive('search')
             ->with([
-                'index' => 'index_name',
-                'type' => 'table',
+                'index' => 'table',
+                'type' => 'doc',
                 'body' => [
                     'query' => [
                         'filtered' => [
@@ -87,7 +87,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
                 'size' => 10000,
             ]);
 
-        $engine = new ElasticsearchEngine($client, 'index_name');
+        $engine = new ElasticsearchEngine($client);
         $builder = new Builder(new ElasticsearchEngineTestModel, 'zonda');
         $builder->where('foo', 1);
         $engine->search($builder);
@@ -96,7 +96,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
     public function test_map_correctly_maps_results_to_models()
     {
         $client = Mockery::mock('Elasticsearch\Client');
-        $engine = new ElasticsearchEngine($client, 'index_name');
+        $engine = new ElasticsearchEngine($client);
 
         $model = Mockery::mock('StdClass');
         $model->shouldReceive('getKeyName')->andReturn('id');
@@ -163,7 +163,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
         $this->markSkippedIfMissingElasticsearch($client);
         $this->resetIndex($client);
 
-        return new ElasticsearchEngine($client, 'index_name');
+        return new ElasticsearchEngine($client);
     }
 
     /**
@@ -182,7 +182,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
      */
     protected function resetIndex(\Elasticsearch\Client $client)
     {
-        $data = ['index' => 'index_name'];
+        $data = ['index' => 'table'];
 
         if ($client->indices()->exists($data)) {
             $client->indices()->delete($data);


### PR DESCRIPTION
Removed elasticsearch_index, Elasticsearch [officially suggests] (https://www.elastic.co/blog/index-vs-type) using one single Type per Index unless you have a very good reason not to. This is because fields must be consistent between types. Therefor, you could never have 2 fields with the same name but different field types within two different models that use the Searchable trait. In that case elastic would silently fail to index the document with the NON-matching field type.

So, it makes more sense to use `$model->searchableAs()` as the "index" name, and then basically any string as the "type" name.