### PR TITLE
Changed main Elasticsearch query to use a "match"

### DIFF
--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -53,7 +53,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
         $engine->delete(Collection::make([new ElasticsearchEngineTestModel]));
     }
 
-    public function test_search_sends_correct_parameters_to_algolia()
+    public function test_search_sends_correct_parameters_to_index()
     {
         $client = Mockery::mock('Elasticsearch\Client');
         $client->shouldReceive('search')
@@ -68,18 +68,21 @@ class ElasticsearchEngineTest extends AbstractTestCase
                                     'must' => [
                                         [
                                             'match' => [
-                                                'foo' => 1,
+                                                '_all' => [
+                                                    'query' => 'zonda',
+                                                    'fuzziness' => 1,
+                                                ],
                                             ],
                                         ],
                                     ],
                                 ],
                             ],
                             'filter' => [
-                                'query' => [
-                                    'simple_query_string' => [
-                                        'query' => 'zonda',
+                                [
+                                    'term' => [
+                                        'foo' => 1,
                                     ],
-                                ],
+                                ]
                             ],
                         ],
                     ],


### PR DESCRIPTION
In elasticsearch, _simple_query_string_ (as well as _query_string_) are special types of queries that pass directly through to the underlying Apache Lucene instance. Generally speaking, you don't want to give users direct access to the Lucene instance because the query accepts special fulltext operators  (+,|,~,*,-,etc...). Using these operators, a person could craft very powerful fulltext queries. Possibly inadvertently! The worry is, the user could accidentally bring the elasticsearch cluster down by doing TOO large of a search.

Furthermore, using _simple_query_string_, you forgo portions of the analyzation and tokenization processes that elastic is known for.

It makes a lot more sense to craft a match query, that accepts and analyzes/tokenizes the given keywords in a way that is more controlled and ultimately a safer user experience.

In fact this is exactly why elasticsearch exists ... to abstract the lucene query syntax into more usable form.

Lastly, while the _filtered_ query is now deprecated, it MUST be used to maintain backward compatibility with Elasticsearch 1.x. Therefor, we can nest a _bool_ query into the _query_ portion of the _filtered_ query with both a _match_ for our main search, and/or a _match_ for any string based filters the user may have added. 

This leaves only _term_ filters in the _filter_ portion of the _filtered_ query. This means, the matches will be scored, as they are within the _query_ portion of the _filtered_ query and the _term_ filters will NOT be scored ... as they are filters. This is the only way to "filter" by analyzed strings without defining special elasticsearch field mappings.

Before this change, the actual query (keywords) were within the _filters_ portion of the _filtered_ query and thus were NOT SCORED at all! Only the Filters would have been scored, which are optional. In fact the whole thing was reversed from the way it should have been. Which I believe was done to be able to filter on both integers and strings.

Anyway, I believe this will improve functionality, speed, result accuracy, and cluster stability!

Also, I don't believe Algolia allows fulltext search syntax to be used in it's search strings, so it makes sense that elasticsearch shouldn't allow it either (could be wrong tho, I have very little experience with Algolia).
