### PR TITLE
Use "_id" property as a model key

### DIFF
--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -240,7 +240,7 @@ class ElasticsearchEngine extends Engine
         )->get()->keyBy($model->getKeyName());
 
         return Collection::make($results['hits']['hits'])->map(function ($hit) use ($model, $models) {
-            return $models[$hit['_source'][$model->getKeyName()]];
+            return $models[$hit['_id']];
         });
     }
 


### PR DESCRIPTION
Use "_id" property as a model key instead of pulling it from the index body

This is solving a problem where toSearchableArray doesn't return a primary key.
Implementation is already passing model's key to the _id, so it is easy change.