### PR TITLE
Pass additional parameters to search engine

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -44,16 +44,25 @@ class Builder
     public $limit;
 
     /**
+     * Options that should be passed to the engine.
+     *
+     * @var array
+     */
+    public $options;
+
+    /**
      * Create a new search builder instance.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  string  $query
+     * @param  array $options
      * @return void
      */
-    public function __construct($model, $query)
+    public function __construct($model, $query, array $options = [])
     {
         $this->model = $model;
         $this->query = $query;
+        $this->options = $options;
     }
 
     /**

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -73,10 +73,10 @@ class AlgoliaEngine extends Engine
      */
     public function search(Builder $builder)
     {
-        return $this->performSearch($builder, array_filter([
+        return $this->performSearch($builder, array_merge(array_filter([
             'numericFilters' => $this->filters($builder),
             'hitsPerPage' => $builder->limit,
-        ]));
+        ]), $builder->options));
     }
 
     /**
@@ -89,11 +89,11 @@ class AlgoliaEngine extends Engine
      */
     public function paginate(Builder $builder, $perPage, $page)
     {
-        return $this->performSearch($builder, [
+        return $this->performSearch($builder, array_merge([
             'numericFilters' => $this->filters($builder),
             'hitsPerPage' => $perPage,
             'page' => $page - 1,
-        ]);
+        ], $builder->options));
     }
 
     /**

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -78,12 +78,13 @@ trait Searchable
     /**
      * Perform a search against the model's indexed data.
      *
-     * @param  string  $query
+     * @param  string $query
+     * @param  array $options
      * @return \Laravel\Scout\Builder
      */
-    public static function search($query)
+    public static function search($query, array $options = [])
     {
-        return new Builder(new static, $query);
+        return new Builder(new static, $query, $options);
     }
 
     /**

--- a/tests/AlgoliaEngineTest.php
+++ b/tests/AlgoliaEngineTest.php
@@ -47,6 +47,28 @@ class AlgoliaEngineTest extends AbstractTestCase
         $engine->search($builder);
     }
 
+    public function test_search_sends_additional_parameters_to_algolia()
+    {
+        $client = Mockery::mock('AlgoliaSearch\Client');
+        $client->shouldReceive('initIndex')->with('table')->andReturn($index = Mockery::mock('StdClass'));
+        $index->shouldReceive('search')->with('zonda', [
+            'numericFilters' => ['foo=1'],
+            'aroundLatLng' => '38.437916,-18.529170',
+            'aroundRadius' => '1000',
+            'someParameter' => 'value'
+        ]);
+
+        $engine = new AlgoliaEngine($client);
+        $builder = new Builder(new AlgoliaEngineTestModel, 'zonda', [
+            'aroundLatLng' => '38.437916,-18.529170',
+            'aroundRadius' => '1000',
+            'someParameter' => 'value'
+        ]);
+
+        $builder->where('foo', 1);
+        $engine->search($builder);
+    }
+
     public function test_map_correctly_maps_results_to_models()
     {
         $client = Mockery::mock('AlgoliaSearch\Client');


### PR DESCRIPTION
This PR allows additional parameters to be passed to the search engine. The reason I wanted this was to allow me to pass geo-search options to Algolia, I have therefore only implemented this for Algolia. I know Taylor has mentioned abstraction leakage in some earlier PRs but I really believe many features that make Algolia and Elasticsearch great were missing - such as Geo-search and tag search, this PR adds in the additional flexibility that is much needed. If this is wanted, I can look into Elasticsearch.

fixes #12 