### PR TITLE
Add location method to search builder

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -44,6 +44,13 @@ class Builder
     public $limit;
 
     /**
+     * The location constraint added to the query.
+     *
+     * @var array
+     */
+    public $location = [];
+
+    /**
      * Create a new search builder instance.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
@@ -79,6 +86,21 @@ class Builder
     public function where($field, $value)
     {
         $this->wheres[$field] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Add location constraint to the query
+     *
+     * @param float $lat
+     * @param float $lng
+     * @param int $radius Radius in km
+     * @return $this
+     */
+    public function withinLocation($lat, $lng, $radius = 10)
+    {
+        $this->location = compact('lat', 'lng', 'radius');
 
         return $this;
     }

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -105,6 +105,8 @@ class AlgoliaEngine extends Engine
      */
     protected function performSearch(Builder $builder, array $options = [])
     {
+        $options = $this->mergeLocation($builder, $options);
+
         return $this->algolia->initIndex(
             $builder->index ?: $builder->model->searchableAs()
         )->search($builder->query, $options);
@@ -161,5 +163,20 @@ class AlgoliaEngine extends Engine
     public function getTotalCount($results)
     {
         return $results['nbHits'];
+    }
+
+    /**
+     * Merge location data with options array to pass to Algolia.
+     *
+     * @param \Laravel\Scout\Builder $builder
+     * @param array $options
+     * @return array
+     */
+    private function mergeLocation (Builder $builder, array $options)
+    {
+        return empty(array_filter($builder->location)) ? $options : array_merge($options, [
+            'aroundLatLng' => $builder->location['lat'] . ',' . $builder->location['lng'],
+            'aroundRadius' => $builder->location['radius']*1000 // Algolia requires metres to be passed
+        ]);
     }
 }

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -172,7 +172,7 @@ class AlgoliaEngine extends Engine
      * @param array $options
      * @return array
      */
-    private function mergeLocation (Builder $builder, array $options)
+    private function mergeLocation(Builder $builder, array $options)
     {
         return empty(array_filter($builder->location)) ? $options : array_merge($options, [
             'aroundLatLng' => $builder->location['lat'] . ',' . $builder->location['lng'],

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -174,6 +174,18 @@ class ElasticsearchEngine extends Engine
             }
         }
 
+        if(!empty(array_filter($query->location))) {
+            $termFilters[] = [
+                'geo_distance' => [
+                    'distance' => $query->location['radius'] . 'km',
+                    'location' => [
+                        'lat' => $query->location['lat'],
+                        'lon' => $query->location['lng']
+                    ]
+                ]
+            ];
+        }
+
         $searchQuery = [
             'index' =>  $this->index,
             'type'  =>  $query->model->searchableAs(),

--- a/tests/AlgoliaEngineTest.php
+++ b/tests/AlgoliaEngineTest.php
@@ -47,6 +47,22 @@ class AlgoliaEngineTest extends AbstractTestCase
         $engine->search($builder);
     }
 
+    public function test_location_search_sends_correct_parameters_to_algolia()
+    {
+        $client = Mockery::mock('AlgoliaSearch\Client');
+        $client->shouldReceive('initIndex')->with('table')->andReturn($index = Mockery::mock('StdClass'));
+        $index->shouldReceive('search')->with('zonda', [
+            'numericFilters' => ['foo=1'],
+            'aroundLatLng' => '38.437916,-18.529170',
+            'aroundRadius' => 10000
+        ]);
+
+        $engine = new AlgoliaEngine($client);
+        $builder = new Builder(new AlgoliaEngineTestModel, 'zonda');
+        $builder->where('foo', 1)->withinLocation('38.437916', '-18.529170', 10);
+        $engine->search($builder);
+    }
+
     public function test_map_correctly_maps_results_to_models()
     {
         $client = Mockery::mock('AlgoliaSearch\Client');


### PR DESCRIPTION
In response to feedback from #77. I have simply made this PR to see what it would feel like to use and what other people think. 

In the other PR I spoke about additional features that Algolia and Elasticsearch provide. When I had a think and stripped them down to the essentials and what is compatible between Algolia and Elasticsearch I found it was only Geosearch that was key.

I don't expect this to be merged, I just want this to start a discussion about whether scout is already supporting the maximum features it plans to.