### PR TITLE
Get perPage from Illuminate model

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -124,11 +124,13 @@ class Builder
      * @param  int|null  $page
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
-    public function paginate($perPage = 15, $pageName = 'page', $page = null)
+    public function paginate($perPage = null, $pageName = 'page', $page = null)
     {
         $engine = $this->engine();
 
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
+
+        $perPage = $perPage ?: $this->model->getPerPage();
 
         $results = Collection::make($engine->map(
             $rawResults = $engine->paginate($this, $perPage, $page), $this->model

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -12,14 +12,17 @@ class BuilderTest extends AbstractTestCase
 {
     public function test_pagination_correctly_handles_paginated_results()
     {
-        $builder = new Builder($model = Mockery::mock(), 'zonda');
-        $model->shouldReceive('searchableUsing')->andReturn($engine = Mockery::mock());
         Paginator::currentPageResolver(function () {
             return 1;
         });
         Paginator::currentPathResolver(function () {
             return 'http://localhost/foo';
         });
+
+        $builder = new Builder($model = Mockery::mock(), 'zonda');
+        $model->shouldReceive('getPerPage')->andReturn(15);
+        $model->shouldReceive('searchableUsing')->andReturn($engine = Mockery::mock());
+
         $engine->shouldReceive('paginate');
         $engine->shouldReceive('map')->andReturn(Collection::make([new StdClass]));
         $engine->shouldReceive('getTotalCount');


### PR DESCRIPTION
Gets the "per page" value from the `Illuminate\Database\Eloquent\Model` instead, similar to how `Illuminate/Database/Eloquent/Builder` currently works.

Since `$perPage = 15` on the model base-class, the default param value is not needed anymore.