### PR TITLE
Add option to override 'query' key when paginating

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -133,7 +133,8 @@ class Builder
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
         $results = Collection::make($engine->map(
-            $rawResults = $engine->paginate($this, $perPage, $page), $this->model
+            $rawResults = $engine->paginate($this, $perPage, $page),
+            $this->model
         ));
 
         $paginator = (new LengthAwarePaginator($results, $engine->getTotalCount($rawResults), $perPage, $page, [

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -122,9 +122,11 @@ class Builder
      * @param  int  $perPage
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  string  $queryName
+     *
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
-    public function paginate($perPage = 15, $pageName = 'page', $page = null)
+    public function paginate($perPage = 15, $pageName = 'page', $page = null, $queryName = 'query')
     {
         $engine = $this->engine();
 
@@ -139,7 +141,7 @@ class Builder
             'pageName' => $pageName,
         ]));
 
-        return $paginator->appends('query', $this->query);
+        return $paginator->appends($queryName, $this->query);
     }
 
     /**


### PR DESCRIPTION
Related to issue #58.

Let's you override the `?query=` param in `next_page_url`/`prev_page_url` of the paginator if say your Laravel/Lumen app uses a different query parameter name for searches.