### PR TITLE
Add support for mapping nested relational models in the response

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -16,6 +16,13 @@ class Builder
     public $model;
 
     /**
+     * Relations of the $model
+     *
+     * @var array
+     */
+    public $relations;
+
+    /**
      * The query expression.
      *
      * @var string
@@ -54,6 +61,20 @@ class Builder
     {
         $this->model = $model;
         $this->query = $query;
+    }
+
+    /**
+     * Add relations for the model to be mapped
+     *
+     * @param $relations
+     *
+     * @return $this
+     */
+    public function with($relations)
+    {
+        $this->relations = $relations;
+
+        return $this;
     }
 
     /**
@@ -131,7 +152,9 @@ class Builder
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
         $results = Collection::make($engine->map(
-            $rawResults = $engine->paginate($this, $perPage, $page), $this->model
+            $rawResults = $engine->paginate($this, $perPage, $page),
+            $this->model,
+            $this->relations
         ));
 
         $paginator = (new LengthAwarePaginator($results, $engine->getTotalCount($rawResults), $perPage, $page, [

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -128,20 +128,22 @@ class AlgoliaEngine extends Engine
      *
      * @param  mixed  $results
      * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  array  $relations
+     *
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    public function map($results, $model)
+    public function map($results, $model, $relations = [])
     {
         if (count($results['hits']) === 0) {
             return Collection::make();
         }
 
         $keys = collect($results['hits'])
-                        ->pluck('objectID')->values()->all();
+            ->pluck('objectID')->values()->all();
 
         $models = $model->whereIn(
             $model->getKeyName(), $keys
-        )->get()->keyBy($model->getKeyName());
+        )->with($relations)->get()->keyBy($model->getKeyName());
 
         return Collection::make($results['hits'])->map(function ($hit) use ($model, $models) {
             $key = $hit[$model->getKeyName()];

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -222,9 +222,10 @@ class ElasticsearchEngine extends Engine
      *
      * @param  mixed  $results
      * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  array  $relations
      * @return Collection
      */
-    public function map($results, $model)
+    public function map($results, $model, $relations = [])
     {
         if (count($results['hits']) === 0) {
             return Collection::make();
@@ -237,7 +238,7 @@ class ElasticsearchEngine extends Engine
 
         $models = $model->whereIn(
             $model->getKeyName(), $keys
-        )->get()->keyBy($model->getKeyName());
+        )->with($relations)->get()->keyBy($model->getKeyName());
 
         return Collection::make($results['hits']['hits'])->map(function ($hit) use ($model, $models) {
             return $models[$hit['_source'][$model->getKeyName()]];

--- a/src/Engines/Engine.php
+++ b/src/Engines/Engine.php
@@ -46,9 +46,10 @@ abstract class Engine
      *
      * @param  mixed  $results
      * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  array  $relations
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    abstract public function map($results, $model);
+    abstract public function map($results, $model, $relations);
 
     /**
      * Get the total count from a raw result returned by the engine.
@@ -62,12 +63,13 @@ abstract class Engine
      * Get the results of the given query mapped onto models.
      *
      * @param  \Laravel\Scout\Builder  $builder
+     * @param  array  $relations
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    public function get(Builder $builder)
+    public function get(Builder $builder, $relations = [])
     {
         return Collection::make($this->map(
-            $this->search($builder), $builder->model
+            $this->search($builder), $builder->model, $relations
         ));
     }
 }

--- a/src/Engines/NullEngine.php
+++ b/src/Engines/NullEngine.php
@@ -58,9 +58,10 @@ class NullEngine extends Engine
      *
      * @param  mixed  $results
      * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  array  $relations
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    public function map($results, $model)
+    public function map($results, $model, $relations = [])
     {
         return Collection::make();
     }

--- a/tests/AlgoliaEngineTest.php
+++ b/tests/AlgoliaEngineTest.php
@@ -53,6 +53,7 @@ class AlgoliaEngineTest extends AbstractTestCase
         $engine = new AlgoliaEngine($client);
 
         $model = Mockery::mock('StdClass');
+        $model->shouldReceive('with')->once()->with([])->andReturn($model);
         $model->shouldReceive('getKeyName')->andReturn('id');
         $model->shouldReceive('whereIn')->once()->with('id', [1])->andReturn($model);
         $model->shouldReceive('get')->once()->andReturn(Collection::make([new AlgoliaEngineTestModel]));

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -102,6 +102,7 @@ class ElasticsearchEngineTest extends AbstractTestCase
         $engine = new ElasticsearchEngine($client, 'index_name');
 
         $model = Mockery::mock('StdClass');
+        $model->shouldReceive('with')->once()->with([])->andReturn($model);
         $model->shouldReceive('getKeyName')->andReturn('id');
         $model->shouldReceive('whereIn')->once()->with('id', [1])->andReturn($model);
         $model->shouldReceive('get')->once()->andReturn(Collection::make([new ElasticsearchEngineTestModel]));


### PR DESCRIPTION
Fix for #83.

Lets one specify relations to be mapped in the response if your index contains nested relations.

Usage:

```php
$relations = ['products', 'media'];
$orders = App\Order::search('Star Trek')->with($relations)->paginate();
```