### PR TITLE
add the ability to delete all indexed documents for the given model

### DIFF
--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Laravel\Scout\Console;
+
+use Illuminate\Console\Command;
+
+class ClearCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'scout:clear {model}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Clear the given model from the search index';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $class = $this->argument('model');
+
+        (new $class)::removeAllFromSearch();
+
+        $this->info('All ['.$class.'] records have been cleared.');
+    }
+}

--- a/src/ScoutServiceProvider.php
+++ b/src/ScoutServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Laravel\Scout;
 
 use Illuminate\Support\ServiceProvider;
+use Laravel\Scout\Console\ClearCommand;
 use Laravel\Scout\Console\ImportCommand;
 
 class ScoutServiceProvider extends ServiceProvider
@@ -21,6 +22,7 @@ class ScoutServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 ImportCommand::class,
+                ClearCommand::class,
             ]);
 
             $this->publishes([


### PR DESCRIPTION
This PR adds the ability to clear all indexed documents for the given model. This is very useful in conjunction with situations when you want to refresh your migrations with --seed option during development.