### PR TITLE
Check models collection on emptiness in queue

### DIFF
--- a/src/Jobs/MakeSearchable.php
+++ b/src/Jobs/MakeSearchable.php
@@ -35,6 +35,10 @@ class MakeSearchable implements ShouldQueue
      */
     public function handle()
     {
+        if (empty($this->models)) {
+            return;
+        }
+
         $this->models->first()->searchableUsing()->update($this->models);
     }
 }


### PR DESCRIPTION
There are 2 cases that might appear and cause exceptions:
* A single model is saved outside global scope (e. g. `Post::create(['deleted_at' => Carbon::now]);`)
* A single model became not valid after dispatching and before queue execution.