### PR TITLE
Explicitly set the order when importing or flushing all models to or from the index.

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -93,7 +93,11 @@ trait Searchable
      */
     public static function makeAllSearchable()
     {
-        (new static)->newQuery()->searchable();
+        $self = new static();
+
+        $self->newQuery()
+            ->orderBy($self->getKeyName())
+            ->searchable();
     }
 
     /**
@@ -113,7 +117,11 @@ trait Searchable
      */
     public static function removeAllFromSearch()
     {
-        (new static)->newQuery()->unsearchable();
+        $self = new static();
+
+        $self->newQuery()
+            ->orderBy($self->getKeyName())
+            ->unsearchable();
     }
 
     /**

--- a/tests/SearchableTest.php
+++ b/tests/SearchableTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Laravel\Scout\Stub;
 use Mockery;
 use Tests\Fixtures\SearchableTestModel;
 
@@ -47,9 +48,45 @@ class SearchableTest extends AbstractTestCase
         $model->queueRemoveFromSearch($collection);
     }
 
+    public function test_make_all_searchable_uses_order_by()
+    {
+        ModelStubForMakeAllSearchable::makeAllSearchable();
+    }
+}
+
+class ModelStubForMakeAllSearchable extends SearchableTestModel
+{
+    public function newQuery()
+    {
+        $mock = \Mockery::mock('Illuminate\Database\Eloquent\Builder');
+
+        $mock->shouldReceive('orderBy')
+            ->with('id')
+            ->andReturnSelf()
+            ->shouldReceive('searchable');
+
+        return $mock;
+    }
+}
+
+class ModelStubForRemoveAllFromSearch extends SearchableTestModel
+{
+    public function newQuery()
+    {
+        $mock = \Mockery::mock('Illuminate\Database\Eloquent\Builder');
+
+        $mock->shouldReceive('orderBy')
+            ->with('id')
+            ->andReturnSelf()
+            ->shouldReceive('unsearchable');
+
+        return $mock;
+    }
 }
 
 namespace Laravel\Scout;
+
+use Tests\Fixtures\SearchableTestModel;
 
 function config($arg)
 {


### PR DESCRIPTION
Solves #104.

This is important when using PostgreSQL and SQL Server (for tables without a clustered key)
because the order of the result set is undefined.

Without this PR on postgresql you can something like this
```php
➔ artisan scout:import "App\Post"
Imported [App\Post] models up to ID: 310
Imported [App\Post] models up to ID: 1002
Imported [App\Post] models up to ID: 236
Imported [App\Post] models up to ID: 513
Imported [App\Post] models up to ID: 1137
Imported [App\Post] models up to ID: 97
Imported [App\Post] models up to ID: 313
Imported [App\Post] models up to ID: 627
Imported [App\Post] models up to ID: 927
Imported [App\Post] models up to ID: 1213
Imported [App\Post] models up to ID: 1496
Imported [App\Post] models up to ID: 1711
Imported [App\Post] models up to ID: 150
Imported [App\Post] models up to ID: 462
Imported [App\Post] models up to ID: 730
Imported [App\Post] models up to ID: 998
Imported [App\Post] models up to ID: 1245
Imported [App\Post] models up to ID: 1487
Imported [App\Post] models up to ID: 1732
Imported [App\Post] models up to ID: 1996
All [App\Post] records have been imported.
```

With this PR applied
```php
➔ artisan scout:import "App\Post"
Imported [App\Post] models up to ID: 101
Imported [App\Post] models up to ID: 201
Imported [App\Post] models up to ID: 301
Imported [App\Post] models up to ID: 401
Imported [App\Post] models up to ID: 501
Imported [App\Post] models up to ID: 601
Imported [App\Post] models up to ID: 701
Imported [App\Post] models up to ID: 801
Imported [App\Post] models up to ID: 901
Imported [App\Post] models up to ID: 1001
Imported [App\Post] models up to ID: 1101
Imported [App\Post] models up to ID: 1201
Imported [App\Post] models up to ID: 1301
Imported [App\Post] models up to ID: 1401
Imported [App\Post] models up to ID: 1501
Imported [App\Post] models up to ID: 1601
Imported [App\Post] models up to ID: 1701
Imported [App\Post] models up to ID: 1801
Imported [App\Post] models up to ID: 1901
Imported [App\Post] models up to ID: 2001
All [App\Post] records have been imported.
```