### PR TITLE
Added a callback to the perform search method.

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -23,6 +23,13 @@ class Builder
     public $query;
 
     /**
+     * Optional callback before search execution.
+     *
+     * @var string
+     */
+    public $callback;
+
+    /**
      * The custom index specified for the search.
      *
      * @var string
@@ -48,12 +55,14 @@ class Builder
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  string  $query
+     * @param  Closure  $callback
      * @return void
      */
-    public function __construct($model, $query)
+    public function __construct($model, $query, $callback = null)
     {
         $this->model = $model;
         $this->query = $query;
+        $this->callback = $callback;
     }
 
     /**

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -110,7 +110,12 @@ class AlgoliaEngine extends Engine
         );
 
         if ($builder->callback) {
-            return call_user_func($builder->callback, $agolia, $options);
+            return call_user_func(
+                $builder->callback,
+                $agolia,
+                $builder->query,
+                $options
+            );
         }
 
         return $agolia->search($builder->query, $options);

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -105,9 +105,15 @@ class AlgoliaEngine extends Engine
      */
     protected function performSearch(Builder $builder, array $options = [])
     {
-        return $this->algolia->initIndex(
+        $agolia = $this->algolia->initIndex(
             $builder->index ?: $builder->model->searchableAs()
-        )->search($builder->query, $options);
+        );
+
+        if ($builder->callback) {
+            return call_user_func($builder->callback, $agolia, $options);
+        }
+
+        return $agolia->search($builder->query, $options);
     }
 
     /**

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -79,11 +79,12 @@ trait Searchable
      * Perform a search against the model's indexed data.
      *
      * @param  string  $query
+     * @param  Closure  $callback
      * @return \Laravel\Scout\Builder
      */
-    public static function search($query)
+    public static function search($query, $callback = null)
     {
-        return new Builder(new static, $query);
+        return new Builder(new static, $query, $callback);
     }
 
     /**


### PR DESCRIPTION
I'm a huge fan of Scout! It's really simple to use, love that it supports a paid and open-source driver, and that it's built with the intention of being a simple search implementation.

With that being said, I think that it would be feasible to add a callback to the `performSearch()` method of each engine that allows the developer more flexibility in terms of building a search query that is relevant to their application. While both Agolia and Elasticsearch have a vast amount of parameters, I don' think this package needs to re-invent those through additional methods or through arbitrary option arrays. This can be accomplished with a simple callback that provides a filter where you can bring your own query into the mix.  
    
**Example Implementation**
``` php
App\Users::search($request->search, function($engine, $query, $options) {         
        
        // Do stuff with the engine or with the query/options.

        return $engine->search($query); // Must return a search()

});
```
  

**Agolia Example**
``` php
Route::post('/search/users', function (Request $request) {

    return App\Users::search($request->search, function($engine, $query, $options) {

        $options['attributesToRetrieve'] = ['first_name', 'last_name'];

        $options['attributesToHighlight'] = ['first_name'];
         
        return $engine->search($query, $options); // Perform search and return results.

    })->paginate();
});
```
   
 
**Elasticsearch Example**
``` php
Route::post('/search/users', function (Request $request) {

    return App\Users::search($request->search, function($engine, $query) {

        $query['body']  = // Change the default query as needed...
        
        return $engine->search($query); // Perform search and return results.

    })->paginate();
});
```
