### PR TITLE
If search is empty return a regular query.

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -84,7 +84,11 @@ trait Searchable
      */
     public static function search($query, $callback = null)
     {
-        return new Builder(new static, $query, $callback);
+        if (!empty($query)) {
+            return new Builder(new static, $query, $callback);
+        }
+
+        return (new static)->newQuery();
     }
 
     /**


### PR DESCRIPTION
The reason I bring this up is because this is how I initially wrote the query in my controller.

```
$models = Model::search($request->get('search', null))->paginate($request->get('limit', 25));
```

Basically if the search is empty (at least with the elasticsearch driver) it will return an empty collection. This is not really what you would expect, if the search is empty it should return all records. I have not used algolia so I am not sure if the same behavior exists there.

My solution here is just a simple one. It will return a regular query if the search is empty, I don't think it covers every possibility though.

If this is not done then you have to first check if search exists and make the `$models` variable use search or just a regular collection, this just saves you a few lines of code in your controller, but I do see some issues that might come up because of it (functions available in queries not being available in scout).