### PR TITLE
Return Algolia Search Highlights

### DIFF
--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -158,6 +158,10 @@ class AlgoliaEngine extends Engine
             $key = $hit[$model->getKeyName()];
 
             if (isset($models[$key])) {
+                if($model->enableSearchHighlights && !empty($hit['_highlightResult'])) {
+                    $models[$key]['_highlightResult'] = $hit['_highlightResult'];
+                }
+
                 return $models[$key];
             }
         })->filter();

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -158,7 +158,7 @@ class AlgoliaEngine extends Engine
             $key = $hit[$model->getKeyName()];
 
             if (isset($models[$key])) {
-                if($model->enableSearchHighlights && !empty($hit['_highlightResult'])) {
+                if(isset($model->enableSearchHighlights) && $model->enableSearchHighlights && !empty($hit['_highlightResult'])) {
                     $models[$key]['_highlightResult'] = $hit['_highlightResult'];
                 }
 


### PR DESCRIPTION
Was thinking it'd be good to have access to the highlighted text in Algolia Search results. Especially now that the callback has been added allowing us to pass options in the `performSearch` method. This change conditionally adds the `_highlightResult` array to each result only if:

**a)** The array exists
**b)** A boolean var `$enableSearchHighlights` is explicitly set in the searchable model.

Signed-off-by: Steve Oldham stevo@vdotgood.com
