### PR TITLE
Map with objectID instead of primary key

### DIFF
--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -155,7 +155,7 @@ class AlgoliaEngine extends Engine
         )->get()->keyBy($model->getKeyName());
 
         return Collection::make($results['hits'])->map(function ($hit) use ($model, $models) {
-            $key = $hit[$model->getKeyName()];
+            $key = $hit['objectID'];
 
             if (isset($models[$key])) {
                 return $models[$key];


### PR DESCRIPTION
Right now the `objectID` is always sent to the Algolia index and it's used to fetch the results from the DB with `whereIn`.

So I think we could use that same key to map the results, that way the programmer won't be forced to return the primary key in the `toSearchableArray` method.

If this is not OK then we could modify the line 47 to always merge the primary key

`return array_merge(['objectID' => $model->getKey()], $array);`

But i think it's not necessary since both the primary key and the object ID should contain the same value, right?