### PR TITLE
Add support to use Bool Query of Elasticsearch 5.0

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -72,7 +72,7 @@ return [
 
     'elasticsearch' => [
         'index' => env('ELASTICSEARCH_INDEX', 'laravel'),
-
+        'version' => '5.0.0',
         'config' => [
             'hosts' => [
                 env('ELASTICSEARCH_HOST', 'localhost'),

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -43,7 +43,8 @@ class EngineManager extends Manager
     {
         return new ElasticsearchEngine(
             Elasticsearch::fromConfig(config('scout.elasticsearch.config')),
-            config('scout.elasticsearch.index')
+            config('scout.elasticsearch.index'),
+            config('scout.elasticsearch.version')
         );
     }
 

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -62,17 +62,13 @@ class ElasticsearchEngineTest extends AbstractTestCase
                 'type' => 'table',
                 'body' => [
                     'query' => [
-                        'filtered' => [
-                            'query' => [
-                                'bool' => [
-                                    'must' => [
-                                        [
-                                            'match' => [
-                                                '_all' => [
-                                                    'query' => 'zonda',
-                                                    'fuzziness' => 1,
-                                                ],
-                                            ],
+                        'bool' => [
+                            'must' => [
+                                [
+                                    'match' => [
+                                        '_all' => [
+                                            'query' => 'zonda',
+                                            'fuzziness' => 1,
                                         ],
                                     ],
                                 ],
@@ -84,13 +80,14 @@ class ElasticsearchEngineTest extends AbstractTestCase
                                     ],
                                 ]
                             ],
+                            
                         ],
                     ],
                 ],
                 'size' => 10000,
             ]);
 
-        $engine = new ElasticsearchEngine($client, 'index_name');
+        $engine = new ElasticsearchEngine($client, 'index_name', '5.0.0');
         $builder = new Builder(new ElasticsearchEngineTestModel, 'zonda');
         $builder->where('foo', 1);
         $engine->search($builder);


### PR DESCRIPTION
Responding to issue #122, Elasticsearch 5.0 will responded "no [query] registered for [filtered]" with status 400 bad request. Added support to send the query body as bool query instead of filtered query depends on the version specified in scout.php. 