### PR TITLE
Added support for Elasticsearch version 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: php
 
 php:
-  - 5.6.6
+  - 5.6
   - 7.0
   - 7.1
 
 sudo: false
 
 before_install:
-  - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.0.1.deb && sudo dpkg -i --force-confnew elasticsearch-1.2.4.deb && sudo service elasticsearch restart
+  - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.0.1.deb && dpkg -i --force-confnew elasticsearch-1.2.4.deb && sudo service elasticsearch restart
 
 install: travis_retry composer install --no-interaction --prefer-dist
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: php
 
 php:
-  - 5.6
+  - 5.6.6
   - 7.0
   - 7.1
 
 sudo: false
 
-services:
-    - elasticsearch
+before_install:
+  - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.0.1.deb && sudo dpkg -i --force-confnew elasticsearch-1.2.4.deb && sudo service elasticsearch restart
 
 install: travis_retry composer install --no-interaction --prefer-dist
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "algolia/algoliasearch-client-php": "^1.10",
-        "elasticsearch/elasticsearch": "^2.2",
+        "elasticsearch/elasticsearch": "^5.0",
         "mockery/mockery": "~0.9",
         "phpunit/phpunit": "~5.0"
     },

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -7,6 +7,7 @@ use AlgoliaSearch\Client as Algolia;
 use Laravel\Scout\Engines\NullEngine;
 use Laravel\Scout\Engines\AlgoliaEngine;
 use Laravel\Scout\Engines\ElasticsearchEngine;
+use Laravel\Scout\Engines\Elasticsearch5Engine;
 use Elasticsearch\ClientBuilder as Elasticsearch;
 
 class EngineManager extends Manager
@@ -42,6 +43,19 @@ class EngineManager extends Manager
     public function createElasticsearchDriver()
     {
         return new ElasticsearchEngine(
+            Elasticsearch::fromConfig(config('scout.elasticsearch.config')),
+            config('scout.elasticsearch.index')
+        );
+    }
+
+    /**
+     * Create an Elasticsearch engine instance.
+     *
+     * @return \Laravel\Scout\Engines\Elasticsearch5Engine
+     */
+    public function createElasticsearch5Driver()
+    {
+        return new Elasticsearch5Engine(
             Elasticsearch::fromConfig(config('scout.elasticsearch.config')),
             config('scout.elasticsearch.index')
         );

--- a/src/Engines/Elasticsearch5Engine.php
+++ b/src/Engines/Elasticsearch5Engine.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace Laravel\Scout\Engines;
+
+use Laravel\Scout\Builder;
+use Elasticsearch\Client as Elasticsearch;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection as BaseCollection;
+
+class Elasticsearch5Engine extends Engine
+{
+    /**
+     * The Elasticsearch client instance.
+     *
+     * @var \Elasticsearch\Client
+     */
+    protected $elasticsearch;
+
+    /**
+     * The index name.
+     *
+     * @var string
+     */
+    protected $index;
+
+    /**
+     * Create a new engine instance.
+     *
+     * @param  \Elasticsearch\Client  $elasticsearch
+     * @return void
+     */
+    public function __construct(Elasticsearch $elasticsearch, $index)
+    {
+        $this->elasticsearch = $elasticsearch;
+
+        $this->index = $index;
+    }
+
+    /**
+     * Update the given model in the index.
+     *
+     * @param  Collection  $models
+     * @return void
+     */
+    public function update($models)
+    {
+        $body = new BaseCollection();
+
+        $models->each(function ($model) use ($body) {
+            $array = $model->toSearchableArray();
+
+            if (empty($array)) {
+                return;
+            }
+
+            $body->push([
+                'index' => [
+                    '_index' => $this->index,
+                    '_type' => $model->searchableAs(),
+                    '_id' => $model->getKey(),
+                ],
+            ]);
+
+            $body->push($array);
+        });
+
+        $this->elasticsearch->bulk([
+            'refresh' => true,
+            'body' => $body->all(),
+        ]);
+    }
+
+    /**
+     * Remove the given model from the index.
+     *
+     * @param  Collection  $models
+     * @return void
+     */
+    public function delete($models)
+    {
+        $body = new BaseCollection();
+
+        $models->each(function ($model) use ($body) {
+            $body->push([
+                'delete' => [
+                    '_index' => $this->index,
+                    '_type' => $model->searchableAs(),
+                    '_id'  => $model->getKey(),
+                ],
+            ]);
+        });
+
+        $this->elasticsearch->bulk([
+            'refresh' => true,
+            'body' => $body->all(),
+        ]);
+    }
+
+    /**
+     * Perform the given search on the engine.
+     *
+     * @param  Builder  $query
+     * @return mixed
+     */
+    public function search(Builder $query)
+    {
+        return $this->performSearch($query, [
+            'filters' => $this->filters($query),
+            'size' => $query->limit ?: 10000,
+        ]);
+    }
+
+    /**
+     * Perform the given search on the engine.
+     *
+     * @param  Builder  $query
+     * @param  int  $perPage
+     * @param  int  $page
+     * @return mixed
+     */
+    public function paginate(Builder $query, $perPage, $page)
+    {
+        $result = $this->performSearch($query, [
+            'filters' => $this->filters($query),
+            'size' => $perPage,
+            'from' => (($page * $perPage) - $perPage),
+        ]);
+
+        $result['nbPages'] = (int) ceil($result['hits']['total'] / $perPage);
+
+        return $result;
+    }
+
+    /**
+     * Perform the given search on the engine.
+     *
+     * @param  Builder  $builder
+     * @param  array  $options
+     * @return mixed
+     */
+    protected function performSearch(Builder $builder, array $options = [])
+    {
+        $filters = [];
+
+        $matches[] = [
+            'match' => [
+                '_all' => [
+                    'query' => $builder->query,
+                    'fuzziness' => 1
+                ]
+            ]
+        ];
+
+        if (array_key_exists('filters', $options) && $options['filters']) {
+            foreach ($options['filters'] as $field => $value) {
+
+                if(is_numeric($value)) {
+                    $filters[] = [
+                        'term' => [
+                            $field => $value,
+                        ],
+                    ];
+                } elseif(is_string($value)) {
+                    $matches[] = [
+                        'match' => [
+                            $field => [
+                                'query' => $value,
+                                'operator' => 'and'
+                            ]
+                        ]
+                    ];
+                }
+            }
+        }
+
+        $query = [
+            'index' =>  $this->index,
+            'type'  =>  $builder->model->searchableAs(),
+            'body' => [
+                'query' => [
+                    'bool' => [
+                        'filter' => $filters,
+                        'must' => $matches,
+                    ],
+                ],
+            ],
+        ];
+
+        if (array_key_exists('size', $options)) {
+            $query['size'] = $options['size'];
+        }
+
+        if (array_key_exists('from', $options)) {
+            $query['from'] = $options['from'];
+        }
+
+        if ($builder->callback) {
+            return call_user_func(
+                $builder->callback,
+                $this->elasticsearch,
+                $query
+            );
+        }
+
+        //return $query;
+
+        return $this->elasticsearch->search($query);
+    }
+
+    /**
+     * Get the filter array for the query.
+     *
+     * @param  Builder  $query
+     * @return array
+     */
+    protected function filters(Builder $query)
+    {
+        return $query->wheres;
+    }
+
+    /**
+     * Map the given results to instances of the given model.
+     *
+     * @param  mixed  $results
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return Collection
+     */
+    public function map($results, $model)
+    {
+        if (count($results['hits']) === 0) {
+            return Collection::make();
+        }
+
+        $keys = collect($results['hits']['hits'])
+                    ->pluck('_id')
+                    ->values()
+                    ->all();
+
+        $models = $model->whereIn(
+            $model->getQualifiedKeyName(), $keys
+        )->get()->keyBy($model->getKeyName());
+
+        return Collection::make($results['hits']['hits'])->map(function ($hit) use ($model, $models) {
+                return isset($models[$hit['_source'][$model->getKeyName()]])
+                                        ? $models[$hit['_source'][$model->getKeyName()]] : null;
+        })->filter()->values();
+    }
+
+    /**
+     * Get the total count from a raw result returned by the engine.
+     *
+     * @param  mixed  $results
+     * @return int
+     */
+    public function getTotalCount($results)
+    {
+        return $results['hits']['total'];
+    }
+}

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -178,9 +178,13 @@ class ElasticsearchEngine extends Engine
             'type'  =>  $builder->model->searchableAs(),
             'body' => [
                 'query' => [
-                    'bool' => [
+                    'filtered' => [
                         'filter' => $filters,
-                        'must' => $matches,
+                        'query' => [
+                            'bool' => [
+                                'must' => $matches
+                            ]
+                        ],
                     ],
                 ],
             ],

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -178,13 +178,9 @@ class ElasticsearchEngine extends Engine
             'type'  =>  $builder->model->searchableAs(),
             'body' => [
                 'query' => [
-                    'filtered' => [
+                    'bool' => [
                         'filter' => $filters,
-                        'query' => [
-                            'bool' => [
-                                'must' => $matches
-                            ]
-                        ],
+                        'must' => $matches,
                     ],
                 ],
             ],

--- a/tests/Elasticsearch5EngineTest.php
+++ b/tests/Elasticsearch5EngineTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Tests;
+
+use Mockery;
+use Laravel\Scout\Builder;
+use Laravel\Scout\Engines\Elasticsearch5Engine;
+use Tests\Fixtures\ElasticsearchEngineTestModel;
+use Illuminate\Database\Eloquent\Collection;
+
+class Elasticsearch5EngineTest extends AbstractTestCase
+{
+    public function test_update_adds_objects_to_index()
+    {
+        $client = Mockery::mock('Elasticsearch\Client');
+        $client->shouldReceive('bulk')->with([
+            'refresh' => true,
+            'body' => [
+                [
+                    'index' => [
+                        '_index' => 'index_name',
+                        '_type' => 'table',
+                        '_id' => 1,
+                    ],
+                ],
+                [
+                    'id' => 1,
+                ],
+            ],
+        ]);
+
+        $engine = new Elasticsearch5Engine($client, 'index_name');
+        $engine->update(Collection::make([new ElasticsearchEngineTestModel]));
+    }
+
+    public function test_delete_removes_objects_to_index()
+    {
+        $client = Mockery::mock('Elasticsearch\Client');
+        $client->shouldReceive('bulk')->with([
+            'refresh' => true,
+            'body' => [
+                [
+                    'delete' => [
+                        '_index' => 'index_name',
+                        '_type' => 'table',
+                        '_id' => 1,
+                    ],
+                ],
+            ],
+        ]);
+
+        $engine = new Elasticsearch5Engine($client, 'index_name');
+        $engine->delete(Collection::make([new ElasticsearchEngineTestModel]));
+    }
+
+    public function test_search_sends_correct_parameters_to_index()
+    {
+        $client = Mockery::mock('Elasticsearch\Client');
+        $client->shouldReceive('search')
+            ->with([
+                'index' => 'index_name',
+                'type' => 'table',
+                'body' => [
+                    'query' => [
+                        'bool' => [
+                            'filter' => [
+                                0 => [
+                                    'term' => [
+                                        'foo' => 1
+                                    ]
+                                ]
+                            ],
+                            'must' => [
+                                0 => [
+                                    'match' => [
+                                        '_all' => [
+                                            'query' => 'zonda',
+                                            'fuzziness' => 1
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ],
+                'size' => 10000,
+            ]);
+
+        $engine = new Elasticsearch5Engine($client, 'index_name');
+        $builder = new Builder(new ElasticsearchEngineTestModel, 'zonda');
+        $builder->where('foo', 1);
+
+        $engine->search($builder);
+    }
+
+    public function test_map_correctly_maps_results_to_models()
+    {
+        $client = Mockery::mock('Elasticsearch\Client');
+        $engine = new Elasticsearch5Engine($client, 'index_name');
+
+        $model = Mockery::mock('StdClass');
+        $model->shouldReceive('getKeyName')->andReturn('id');
+        $model->shouldReceive('getQualifiedKeyName')->andReturn('id');
+        $model->shouldReceive('whereIn')->once()->with('id', [1])->andReturn($model);
+        $model->shouldReceive('get')->once()->andReturn(Collection::make([new ElasticsearchEngineTestModel]));
+
+        $results = $engine->map([
+            'hits' => [
+                'hits' => [
+                    [
+                        '_id' => 1,
+                        '_source' => ['id' => 1],
+                    ],
+                ],
+            ],
+        ], $model);
+
+        $this->assertEquals(1, count($results));
+    }
+
+    public function test_real_elasticsearch_update_and_search()
+    {
+        $engine = $this->getRealElasticsearchEngine();
+
+        $engine->update(Collection::make([new ElasticsearchEngineTestModel]));
+
+        $builder = new Builder(new ElasticsearchEngineTestModel, '1');
+        $builder->where('id', 1);
+
+        $results = $engine->search($builder);
+
+        $this->assertEquals(1, $results['hits']['total']);
+        $this->assertEquals('1', $results['hits']['hits'][0]['_id']);
+        $this->assertEquals(['id' => 1], $results['hits']['hits'][0]['_source']);
+
+        $builder->where('title', 'zonda');
+        $results = $engine->search($builder);
+
+        $this->assertEquals(0, $results['hits']['total']);
+    }
+
+    public function test_real_elasticsearch_delete()
+    {
+        $engine = $this->getRealElasticsearchEngine();
+        $collection = Collection::make([new ElasticsearchEngineTestModel]);
+
+        $engine->update($collection);
+        $builder = new Builder(new ElasticsearchEngineTestModel, '1');
+
+        $engine->delete($collection);
+
+        $builder = new Builder(new ElasticsearchEngineTestModel, '1');
+        $results = $engine->search($builder);
+
+        $this->assertEquals($results['hits']['total'], 0);
+    }
+
+    /**
+     * @return \Laravel\Scout\Engines\ElasticsearchEngine
+     */
+    protected function getRealElasticsearchEngine()
+    {
+        $client = $this->getRealElasticsearchClient();
+        $this->markSkippedIfMissingElasticsearch($client);
+        $this->resetIndex($client);
+
+        return new Elasticsearch5Engine($client, 'index_name');
+    }
+
+    /**
+     * @return \Elasticsearch\Client
+     */
+    protected function getRealElasticsearchClient()
+    {
+        return \Elasticsearch\ClientBuilder::create()
+            ->setHosts(['127.0.0.1:9200'])
+            ->setRetries(0)
+            ->build();
+    }
+
+    /**
+     * @param  \Elasticsearch\Client $client
+     */
+    protected function resetIndex(\Elasticsearch\Client $client)
+    {
+        $data = ['index' => 'index_name'];
+
+        if ($client->indices()->exists($data)) {
+            $client->indices()->delete($data);
+        }
+
+        $client->indices()->create($data);
+    }
+
+    /**
+     * @param  \Elasticsearch\Client $client
+     */
+    protected function markSkippedIfMissingElasticsearch(\Elasticsearch\Client $client)
+    {
+        try {
+            $client->cluster()->health();
+        } catch (\Elasticsearch\Common\Exceptions\Curl\CouldNotConnectToHost $e) {
+            $this->markTestSkipped('Could not connect to elasticsearch');
+        }
+    }
+}


### PR DESCRIPTION
Fixes #122 

I've used the code supplied in the issue to create a pull request. 

Anyone installing Elasticsearch from now on will end up hitting this error message due to the installation instructions on the elastic.co website specifying version 5. It is my personal opinion that version 5 be the default version supported.