### PR TITLE
Add ability to run MakeSearchable on non-default queue

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -45,6 +45,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Define a Custom Queue
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to define on which queue MakeSearchable
+    | should run. By default, it will run on the "default" queue.
+    | You can change that setting by changing the value below.
+    |
+    */
+
+    'on_queue' => 'default',
+
+    /*
+    |--------------------------------------------------------------------------
     | Algolia Configuration
     |--------------------------------------------------------------------------
     |

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -57,6 +57,7 @@ trait Searchable
         }
 
         dispatch((new MakeSearchable($models))
+                ->onQueue(config('scout.on_queue'))
                 ->onConnection($models->first()->syncWithSearchUsing()));
     }
 


### PR DESCRIPTION
This PR allows the MakeSearchable job to run outside of the default queue. Adds a config setting called "on_queue" which is "default" by default. 