### PR TITLE
Allow syncing on default queue connection with custom queue name

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -57,6 +57,7 @@ trait Searchable
         }
 
         dispatch((new MakeSearchable($models))
+                ->onQueue($models->first()->syncWithSearchOnQueue())
                 ->onConnection($models->first()->syncWithSearchUsing()));
     }
 
@@ -210,5 +211,15 @@ trait Searchable
     public function syncWithSearchUsing()
     {
         return config('queue.default');
+    }
+
+    /**
+     * Get the queue that should be used with syncing
+     * 
+     * @return  string
+     */
+    public function syncWithSearchOnQueue()
+    {
+        return 'default';
     }
 }


### PR DESCRIPTION
There may be occasions when you would like to sync your Searchable models outside of your default queue. Currently, this can be done by defining a new connection in the queue config and then overriding syncWithSearchUsing() on any model that uses the Searchable trait. 

While this works, it's a little overkill unless you are using a different queue driver. In these instances, it would be nice to simply use a different queue name, rather than a separate connection.

Based on feedback from an earlier PR, this PR creates a new method on the Searchable trait that can be overridden on a per model basis. It does not require any new config options and works in a manner that is similar to the syncWithSearchUsing() method.