### PR TITLE
Bypass mapping of Eloquent objects and return just the keys of results

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -152,7 +152,7 @@ class Builder
     /**
      * Get the keys of search results.
      *
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Support\Collection
      */
     public function getKeys()
     {

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -150,6 +150,17 @@ class Builder
     }
 
     /**
+     * Get the keys of search results.
+     *
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function getKeys()
+    {
+        return $this->engine()->getKeys($this);
+    }
+
+
+    /**
      * Paginate the given query into a simple paginator.
      *
      * @param  int  $perPage

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -168,7 +168,7 @@ class AlgoliaEngine extends Engine
      * Pluck and return the primary keys of the results.
      *
      * @param  mixed  $results
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Support\Collection
      */
     public function getIds($results) {
 

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -164,6 +164,20 @@ class AlgoliaEngine extends Engine
     }
 
     /**
+     *
+     * Pluck and return the primary keys of the results.
+     *
+     * @param  mixed  $results
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function getIds($results) {
+
+        return collect($results['hits'])
+            ->pluck('objectID')->values()->all();
+
+    }
+
+    /**
      * Get the total count from a raw result returned by the engine.
      *
      * @param  mixed  $results

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -253,7 +253,7 @@ class ElasticsearchEngine extends Engine
      * Pluck and return the primary keys of the results.
      *
      * @param  mixed  $results
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Support\Collection
      */
     public function getIds($results) {
 

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -249,6 +249,22 @@ class ElasticsearchEngine extends Engine
     }
 
     /**
+     *
+     * Pluck and return the primary keys of the results.
+     *
+     * @param  mixed  $results
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function getIds($results) {
+
+        return collect($results['hits']['hits'])
+            ->pluck('_id')
+            ->values()
+            ->all();
+
+    }
+
+    /**
      * Get the total count from a raw result returned by the engine.
      *
      * @param  mixed  $results

--- a/src/Engines/Engine.php
+++ b/src/Engines/Engine.php
@@ -70,4 +70,15 @@ abstract class Engine
             $this->search($builder), $builder->model
         ));
     }
+
+    /**
+     * Get the results of the query as a Collection of keys.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return \Illuminate\Support\Collection
+     */
+    public function getKeys(Builder $builder)
+    {
+        return $this->getIds($this->search($builder));
+    }
 }


### PR DESCRIPTION
This is the getKeys feature I suggested here: https://github.com/laravel/scout/issues/138

It would be nice to have the option to return only ids of search results as opposed to the entire Eloquent collection.