### PR TITLE
Advanced where constraints on the Builder class.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ php:
 
 sudo: false
 
-services:
-    - elasticsearch
-
 install: travis_retry composer install --no-interaction --prefer-dist
 
 before_script:

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -159,10 +159,10 @@ class Builder
      * Add a "where in" constraint for the query.
      *
      * @param  string $field
-     * @param  mixed  $value
+     * @param  array  $value
      * @return $this
      */
-    public function whereIn($field, $value)
+    public function whereIn($field, array $value)
     {
         $this->wheres['in'][] = [$field => $value];
 
@@ -187,10 +187,10 @@ class Builder
      * Add a "where not in" constraint for the query.
      *
      * @param  string $field
-     * @param  mixed  $value
+     * @param  array  $value
      * @return $this
      */
-    public function whereNotIn($field, $value)
+    public function whereNotIn($field, array $value)
     {
         $this->wheres['not_in'][] = [$field => $value];
 

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -239,7 +239,7 @@ class Builder
     }
 
     /**
-     * Add an "order" for the search query.
+     * Add an "order" for the query.
      *
      * @param  string  $column
      * @param  string  $direction
@@ -247,10 +247,7 @@ class Builder
      */
     public function orderBy($column, $direction = 'asc')
     {
-        $this->orders[] = [
-            'column' => $column,
-            'direction' => strtolower($direction) == 'asc' ? 'asc' : 'desc',
-        ];
+        $this->orders[$column] = strtolower($direction) == 'asc' ? 'asc' : 'desc';
 
         return $this;
     }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -37,11 +37,21 @@ class Builder
     public $index;
 
     /**
-     * The "where" constraints added to the query.
+     * The "where" constraints that should be applied to the query.
      *
      * @var array
      */
-    public $wheres = [];
+    public $wheres = [
+        'and' => [],
+        'between' => [],
+        'in' => [],
+        'not' => [],
+        'not_in' => [],
+        'not_null' => [],
+        'null' => [],
+        'or' => [],
+        'or_between' => [],
+    ];
 
     /**
      * The "limit" that should be applied to the search.
@@ -86,15 +96,131 @@ class Builder
     }
 
     /**
-     * Add a constraint to the search query.
+     * Add a "where" constraint for the query.
      *
-     * @param  string  $field
+     * @param  string $field
      * @param  mixed  $value
      * @return $this
      */
     public function where($field, $value)
     {
-        $this->wheres[$field] = $value;
+        if (is_null($value)) {
+            return $this->whereNull($field);
+        }
+
+        $this->wheres['and'][] = [$field => $value];
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where" constraint for the query.
+     *
+     * @param  string $field
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function orWhere($field, $value)
+    {
+        $this->wheres['or'][] = [$field => $value];
+
+        return $this;
+    }
+
+    /**
+     * Add a "where between" constraint for the query.
+     *
+     * @param  string $field
+     * @param  array  $value
+     * @return $this
+     */
+    public function whereBetween($field, array $value)
+    {
+        $this->wheres['between'][] = [$field => $value];
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where between" constraint for the query.
+     *
+     * @param  string $field
+     * @param  array  $value
+     * @return $this
+     */
+    public function orWhereBetween($field, array $value)
+    {
+        $this->wheres['or_between'][] = [$field => $value];
+
+        return $this;
+    }
+
+    /**
+     * Add a "where in" constraint for the query.
+     *
+     * @param  string $field
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function whereIn($field, $value)
+    {
+        $this->wheres['in'][] = [$field => $value];
+
+        return $this;
+    }
+
+    /**
+     * Add a "where not" constraint for the query.
+     *
+     * @param  string $field
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function whereNot($field, $value)
+    {
+        $this->wheres['not'][] = [$field => $value];
+
+        return $this;
+    }
+
+    /**
+     * Add a "where not in" constraint for the query.
+     *
+     * @param  string $field
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function whereNotIn($field, $value)
+    {
+        $this->wheres['not_in'][] = [$field => $value];
+
+        return $this;
+    }
+
+    /**
+     * Add a "where null" constraint for the query.
+     *
+     * @param  string $field
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function whereNull($field)
+    {
+        $this->wheres['null'][] = $field;
+
+        return $this;
+    }
+
+    /**
+     * Add a "where not null" constraint for the query.
+     *
+     * @param  string $field
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function whereNotNull($field)
+    {
+        $this->wheres['not_null'][] = $field;
 
         return $this;
     }
@@ -158,7 +284,6 @@ class Builder
     {
         return $this->engine()->get($this);
     }
-
 
     /**
      * Paginate the given query into a simple paginator.

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -129,8 +129,8 @@ class AlgoliaEngine extends Engine
      */
     protected function filters(Builder $builder)
     {
-        return collect($builder->wheres)->map(function ($value, $key) {
-            return $key.'='.$value;
+        return collect($builder->wheres['and'])->map(function ($value, $key) {
+            return key($value).'='.$value[key($value)];
         })->values()->all();
     }
 

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -152,22 +152,22 @@ class ElasticsearchEngine extends Engine
         ];
 
         if (array_key_exists('filters', $options) && $options['filters']) {
-            foreach ($options['filters'] as $field => $value) {
+            foreach ($options['filters'] as $filter) {
 
-                if(is_numeric($value)) {
+                if(is_numeric($filter[key($filter)])) {
                     $filters[] = [
                         'term' => [
-                            $field => $value,
+                            key($filter) => $filter[key($filter)],
                         ],
                     ];
-                } elseif(is_string($value)) {
+                } elseif(is_string($filter[key($filter)])) {
                     $matches[] = [
                         'match' => [
-                            $field => [
-                                'query' => $value,
+                            key($filter) => [
+                                'query' => $filter[key($filter)],
                                 'operator' => 'and'
-                            ]
-                        ]
+                            ],
+                        ],
                     ];
                 }
             }
@@ -217,7 +217,7 @@ class ElasticsearchEngine extends Engine
      */
     protected function filters(Builder $query)
     {
-        return $query->wheres;
+        return $query->wheres['and'];
     }
 
     /**


### PR DESCRIPTION
This PR adds additional methods to the builder class that will allow advanced constraints to be implemented respectively by the engine driver. 

**Where methods:**
- `where($field, $value)`
- `orWhere($field, $value)`
- `whereBetween($field, array $value)`
- `orWhereBetween($field, array $value)`
- `whereIn($field, array $value)`
- `whereNot($field, $value)`
- `whereNot($field, $value)`
- `whereNotIn($field, array $value)`
- `whereNull($field)`
- `whereNotNull($field)`


Each of these where conditions are captured in arrays like so:

```php
$this->where['and'][] = [$field, $value];
``` 

``` php
[
    'featured' => 1,
    'topic' => 'security'
]
```


This would be most helpful and shouldn't cause any breaking changes.
