### PR TITLE
Added ability to search for/only soft deleted models

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -58,6 +58,20 @@ class Builder
     public $orders = [];
 
     /**
+     * If the search should include soft deleted models.
+     *
+     * @var boolean
+     */
+    public $withTrashed = false;
+
+    /**
+     * If the search should only include soft deleted models.
+     *
+     * @var boolean
+     */
+    public $onlyTrashed = false;
+
+    /**
      * Create a new search builder instance.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
@@ -161,6 +175,30 @@ class Builder
 
 
     /**
+     * Specify the search should include soft deletes.
+     * 
+     * @return $this
+     */
+    public function withTrashed()
+    {
+        $this->withTrashed = true;
+
+        return $this;
+    }
+
+    /**
+     * Specify the search should only include soft deletes.
+     *
+     * @return $this
+     */
+    public function onlyTrashed()
+    {
+        $this->onlyTrashed = true;
+
+        return $this;
+    }
+
+    /**
      * Paginate the given query into a simple paginator.
      *
      * @param  int  $perPage
@@ -177,7 +215,7 @@ class Builder
         $perPage = $perPage ?: $this->model->getPerPage();
 
         $results = Collection::make($engine->map(
-            $rawResults = $engine->paginate($this, $perPage, $page), $this->model
+            $rawResults = $engine->paginate($this, $perPage, $page), $this->model, $this->withTrashed, $this->onlyTrashed
         ));
 
         $paginator = (new LengthAwarePaginator($results, $engine->getTotalCount($rawResults), $perPage, $page, [

--- a/src/Engines/Engine.php
+++ b/src/Engines/Engine.php
@@ -54,9 +54,11 @@ abstract class Engine
      *
      * @param  mixed  $results
      * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  bool  $withTrashed
+     * @param  bool  $onlyTrashed
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    abstract public function map($results, $model);
+    abstract public function map($results, $model, $withTrashed, $onlyTrashed);
 
     /**
      * Get the total count from a raw result returned by the engine.
@@ -86,7 +88,7 @@ abstract class Engine
     public function get(Builder $builder)
     {
         return Collection::make($this->map(
-            $this->search($builder), $builder->model
+            $this->search($builder), $builder->model, $builder->withTrashed, $builder->onlyTrashed
         ));
     }
 }

--- a/src/Engines/NullEngine.php
+++ b/src/Engines/NullEngine.php
@@ -69,9 +69,11 @@ class NullEngine extends Engine
      *
      * @param  mixed  $results
      * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  bool  $withTrashed
+     * @param  bool  $onlyTrashed
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    public function map($results, $model)
+    public function map($results, $model, $withTrashed, $onlyTrashed)
     {
         return Collection::make();
     }

--- a/tests/AlgoliaEngineTest.php
+++ b/tests/AlgoliaEngineTest.php
@@ -56,11 +56,13 @@ class AlgoliaEngineTest extends AbstractTestCase
         $model->shouldReceive('getKeyName')->andReturn('id');
         $model->shouldReceive('getQualifiedKeyName')->andReturn('id');
         $model->shouldReceive('whereIn')->once()->with('id', [1])->andReturn($model);
+        $model->shouldReceive('withTrashed')->andReturn(false);
+        $model->shouldReceive('onlyTrashed')->andReturn(false);
         $model->shouldReceive('get')->once()->andReturn(Collection::make([new AlgoliaEngineTestModel]));
 
         $results = $engine->map(['nbHits' => 1, 'hits' => [
             ['objectID' => 1, 'id' => 1],
-        ]], $model, true, false);
+        ]], $model, false, false);
 
         $this->assertEquals(1, count($results));
     }

--- a/tests/AlgoliaEngineTest.php
+++ b/tests/AlgoliaEngineTest.php
@@ -60,7 +60,7 @@ class AlgoliaEngineTest extends AbstractTestCase
 
         $results = $engine->map(['nbHits' => 1, 'hits' => [
             ['objectID' => 1, 'id' => 1],
-        ]], $model);
+        ]], $model, true, false);
 
         $this->assertEquals(1, count($results));
     }


### PR DESCRIPTION
Two options to interact with soft deleted models:

Include soft deleted models
`App\User::search('search query string')->withTrashed()->get();`

Return only soft deleted models
`App\User::search('search query string')->onlyTrashed()->get();`

Models must be deleted within the `withoutSyncingToSearch` callback to avoid the indices being updated during `delete()`.

**Note:** I am not sure if you would like to automate the `withoutSyncingToSearch` aspect by adding to the `ModelObserver` (checking if the model uses `SoftDeletes`, confirm not `forceDeleting`, etc.). If so, I will add that.