### PR TITLE
Allow for customizing searchable chunk size

### DIFF
--- a/src/SearchableScope.php
+++ b/src/SearchableScope.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Scout;
 
+use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
 use Laravel\Scout\Events\ModelsImported;
@@ -29,16 +30,18 @@ class SearchableScope implements Scope
      */
     public function extend(EloquentBuilder $builder)
     {
-        $builder->macro('searchable', function (EloquentBuilder $builder) {
-            $builder->chunk(100, function ($models) use ($builder) {
+        $chunkSize = app(ConfigRepository::class)->get('scout.searchableChunkSize', 100);
+        
+        $builder->macro('searchable', function (EloquentBuilder $builder) use ($chunkSize) {
+            $builder->chunk($chunkSize, function ($models) use ($builder) {
                 $models->searchable();
 
                 event(new ModelsImported($models));
             });
         });
 
-        $builder->macro('unsearchable', function (EloquentBuilder $builder) {
-            $builder->chunk(100, function ($models) use ($builder) {
+        $builder->macro('unsearchable', function (EloquentBuilder $builder) use ($chunkSize) {
+            $builder->chunk($chunkSize, function ($models) use ($builder) {
                 $models->unsearchable();
             });
         });


### PR DESCRIPTION
Currently the chunk size is fixed at 100 which, at least for Elasticsearch, renders the import process quite slow.

For 100 000 records import time can be lowered 3 times by increasing the chunk size to about a thousand:
![import_time](https://cloud.githubusercontent.com/assets/13980973/22884554/d0d5708c-f1f5-11e6-8312-c045e7f42190.PNG)

This change allows for setting a custom chunk size in `config/scout.php` as `searchableChunkSize` option.
It is fully backwards compatible and doesn't affect existing applications in any way as  far as I know.