### PR TITLE
Add Laravel Scout user agent to Algolia queries

### DIFF
--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -4,6 +4,7 @@ namespace Laravel\Scout;
 
 use Illuminate\Support\Manager;
 use AlgoliaSearch\Client as Algolia;
+use AlgoliaSearch\Version as AlgoliaUserAgent;
 use Laravel\Scout\Engines\NullEngine;
 use Laravel\Scout\Engines\AlgoliaEngine;
 
@@ -27,6 +28,8 @@ class EngineManager extends Manager
      */
     public function createAlgoliaDriver()
     {
+        AlgoliaUserAgent::$custom_value = '; Laravel Scout integration';
+
         return new AlgoliaEngine(new Algolia(
             config('scout.algolia.id'), config('scout.algolia.secret')
         ));


### PR DESCRIPTION
This PR will make sure that the Algolia dashboard can properly identify Laravel Scout users.

We have seen in the past month an increasing amount of users coming from Laravel Scout,
and we are very excited about it given that we share the principle of making developers life easier.

We are currently working on a new iteration of our Algolia dashboard, and we would love to offer dedicated features to Laravel Scout users.

For example:
- Recommend casting `created_at`, `updated_at` to integers so that they can be leveraged more easily in filtering or custom ranking rules
- Add links back to the Laravel Scout Documentation
- Add links to community content that helps you integrate Scout with Algolia

The simplest way to detect Laravel Scout users is to actually customize the user agent.

I would be more than happy to discuss an alternative solution if this one does not meet the expectations of the Laravel Scout package.

Looking forward to bring more awesomeness to the Laravel community!