### PR TITLE
Ability to add make all searchable "with trashed"

### DIFF
--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -13,7 +13,9 @@ class ImportCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'scout:import {model}';
+    protected $signature = 'scout:import
+                            {model}
+                            {--withTrashed : Whether soft deleted models should be included}';
 
     /**
      * The console command description.
@@ -40,7 +42,7 @@ class ImportCommand extends Command
             $this->line('<comment>Imported ['.$class.'] models up to ID:</comment> '.$key);
         });
 
-        $model::makeAllSearchable();
+        $model::makeAllSearchable($this->option('withTrashed'));
 
         $events->forget(ModelsImported::class);
 

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -91,15 +91,35 @@ trait Searchable
     /**
      * Make all instances of the model searchable.
      *
+     * @param bool $withTrashed
+     *
      * @return void
      */
-    public static function makeAllSearchable()
+    public static function makeAllSearchable($withTrashed = false)
     {
         $self = new static();
 
-        $self->newQuery()
-            ->orderBy($self->getKeyName())
-            ->searchable();
+        $builder = $self->newQuery()->orderBy($self->getKeyName());
+
+        if ($withTrashed) {
+            try {
+                $builder->withTrashed();
+            } catch (\BadMethodCallException $err) {
+                // If the model does not use soft deletes we fail silently...
+            }
+        }
+
+        $builder->searchable();
+    }
+
+    /**
+     * Make all instances including trashed models searchable.
+     *
+     * @return void
+     */
+    public static function makeAllSearchableWithTrashed()
+    {
+        self::makeAllSearchable(true);
     }
 
     /**

--- a/tests/SearchableTest.php
+++ b/tests/SearchableTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Laravel\Scout\Stub;
 use Mockery;
 use Tests\Fixtures\SearchableTestModel;
@@ -52,6 +53,16 @@ class SearchableTest extends AbstractTestCase
     {
         ModelStubForMakeAllSearchable::makeAllSearchable();
     }
+
+    public function test_make_all_searchable_with_trashed()
+    {
+        ModelStubForMakeAllSearchableWithTrashed::makeAllSearchableWithTrashed();
+    }
+
+    public function test_make_all_searchable_with_trashed_fails_silently()
+    {
+        ModelStubForMakeAllSearchable::makeAllSearchableWithTrashed();
+    }
 }
 
 class ModelStubForMakeAllSearchable extends SearchableTestModel
@@ -62,6 +73,25 @@ class ModelStubForMakeAllSearchable extends SearchableTestModel
 
         $mock->shouldReceive('orderBy')
             ->with('id')
+            ->andReturnSelf()
+            ->shouldReceive('searchable');
+
+        return $mock;
+    }
+}
+
+class ModelStubForMakeAllSearchableWithTrashed extends SearchableTestModel
+{
+    use SoftDeletes;
+
+    public function newQuery()
+    {
+        $mock = \Mockery::mock('Illuminate\Database\Eloquent\Builder');
+
+        $mock->shouldReceive('orderBy')
+            ->with('id')
+            ->andReturnSelf()
+            ->shouldReceive('withTrashed')
             ->andReturnSelf()
             ->shouldReceive('searchable');
 


### PR DESCRIPTION
This adds the ability to include trashed items when making all searchable.

Also adds the flag `--withTrashed` to the import command.

It will fail silently if the model does not implement a withTrashed method.