### PR TITLE
Return the result from callback in withoutSyncingToSearch

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -160,14 +160,14 @@ trait Searchable
      * Temporarily disable search syncing for the given callback.
      *
      * @param  callable  $callback
-     * @return void
+     * @return mixed
      */
     public static function withoutSyncingToSearch($callback)
     {
         static::disableSearchSyncing();
 
         try {
-            $callback();
+            return $callback();
         } finally {
             static::enableSearchSyncing();
         }


### PR DESCRIPTION
I think that this method would be more useful if it returns the result from the callback