### PR TITLE
Add count() support to Builder

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -159,6 +159,16 @@ class Builder
         return $this->engine()->get($this);
     }
 
+    /**
+     * Retrieve the number of matching results.
+     *
+     * @return int Number of results
+     */
+    public function count()
+    {
+        return (int) $this->engine()->count($this);
+    }
+
 
     /**
      * Paginate the given query into a simple paginator.

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -80,6 +80,21 @@ class AlgoliaEngine extends Engine
     }
 
     /**
+     * Retrieve number of search results from the the engine
+     *
+     * @param \Laravel\Scout\Builder $builder
+     * @return mixed Number of results
+     */
+    public function count(Builder $builder)
+    {
+        $results =  $this->performSearch($builder, [
+            'responseFields' => ['nbHits'],
+        ]);
+
+        return $results['nbHits'];
+    }
+
+    /**
      * Perform the given search on the engine.
      *
      * @param  \Laravel\Scout\Builder  $builder

--- a/src/Engines/Engine.php
+++ b/src/Engines/Engine.php
@@ -32,6 +32,14 @@ abstract class Engine
     abstract public function search(Builder $builder);
 
     /**
+     * Retrieve number of search results from the the engine
+     *
+     * @param \Laravel\Scout\Builder $builder
+     * @return mixed Number of results
+     */
+    abstract public function count(Builder $builder);
+
+    /**
      * Perform the given search on the engine.
      *
      * @param  \Laravel\Scout\Builder  $builder

--- a/src/Engines/NullEngine.php
+++ b/src/Engines/NullEngine.php
@@ -41,6 +41,17 @@ class NullEngine extends Engine
     }
 
     /**
+     * Retrieve number of search results from the the engine
+     *
+     * @param \Laravel\Scout\Builder $builder
+     * @return mixed Number of results
+     */
+    public function count(Builder $builder)
+    {
+        return 0;
+    }
+
+    /**
      * Perform the given search on the engine.
      *
      * @param  \Laravel\Scout\Builder  $builder


### PR DESCRIPTION
Fixes #164 

There is already `getTotalCount` but it simply extracts the data after performing full search. With `count()` we only retrieve the `nbHits` from Algolia.

To avoid BC break, we can have a default implementation based on `search` and `getTotalCount` in the abstract Engine class (instead of an abstract declaration). 

Please let me know if want me to make any modifications.