### PR TITLE
Add macroable to scout builder

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -3,11 +3,14 @@
 namespace Laravel\Scout;
 
 use Illuminate\Pagination\Paginator;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Pagination\LengthAwarePaginator;
 
 class Builder
 {
+    use Macroable;
+
     /**
      * The model instance.
      *

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -29,4 +29,16 @@ class BuilderTest extends AbstractTestCase
 
         $builder->paginate();
     }
+
+    public function test_macroable()
+    {
+        Builder::macro('foo', function () {
+            return 'bar';
+        });
+
+        $builder = new Builder($model = Mockery::mock(), 'zonda');
+        $this->assertEquals(
+            'bar', $builder->foo()
+        );
+    }
 }


### PR DESCRIPTION
Adds macroable to the builder, just like #192. But to the 2.0 branch.