### PR TITLE
Add getSearchResults on the builder

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -159,6 +159,15 @@ class Builder
         return $this->engine()->get($this);
     }
 
+    /**
+     * Get the raw results of the search, not mapped onto models.
+     *
+     * @return mixed
+     */
+    public function getSearchResults()
+    {
+        return $this->engine()->search($this);
+    }
 
     /**
      * Paginate the given query into a simple paginator.

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -130,6 +130,16 @@ class Builder
     }
 
     /**
+     * Get the raw results of the search.
+     *
+     * @return mixed
+     */
+    public function raw()
+    {
+        return $this->engine()->search($this);
+    }
+
+    /**
      * Get the keys of search results.
      *
      * @return \Illuminate\Support\Collection
@@ -157,16 +167,6 @@ class Builder
     public function get()
     {
         return $this->engine()->get($this);
-    }
-
-    /**
-     * Get the raw results of the search, not mapped onto models.
-     *
-     * @return mixed
-     */
-    public function getSearchResults()
-    {
-        return $this->engine()->search($this);
     }
 
     /**


### PR DESCRIPTION
Adds a method to get the raw search results, unmapped, from the builder.

Relates to #190 & #114 

If accepted, I will also make a pull request for the 3.0 branch.