### PR TITLE
Chain `values` method in map function

### DIFF
--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -171,7 +171,7 @@ class AlgoliaEngine extends Engine
             if (isset($models[$key])) {
                 return $models[$key];
             }
-        })->filter();
+        })->filter()->values();
     }
 
     /**


### PR DESCRIPTION
refer to my pull request in https://github.com/ErickTamayo/laravel-scout-elastic/pull/66

```php
collect([0 => ['id' => 1], 1 => ['id' => 2], 2 => null, 3 => ['id' => 3]])->filter()
```
would get 
```php
collect([0 => ['id' => 1], 1 => ['id' => 2], 3 => ['id' => 3]])
```

which would make `paginate()` returned an object rather than list.