### PR TITLE
Configure/optimize bulk chunk sizes

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -30,6 +30,22 @@ return [
 
     'prefix' => env('SCOUT_PREFIX', ''),
 
+	/*
+	|--------------------------------------------------------------------------
+	| Data Chuck Size
+	|--------------------------------------------------------------------------
+	|
+	| This option allows you to control if the size of the data that syncs
+	| with your search engine. This chuck (page) size allows you to 
+	| optimize the bulk data for both searchable and unsearchable methods.
+	|
+	*/
+
+    'chunk' => [
+	    'searchable' => env('SCOUT_CHUNK_SEARCHABLE', 500),
+	    'unsearchable' => env('SCOUT_CHUNK_UNSEARCHABLE', 500)
+    ],
+
     /*
     |--------------------------------------------------------------------------
     | Queue Data Syncing

--- a/src/SearchableScope.php
+++ b/src/SearchableScope.php
@@ -30,7 +30,7 @@ class SearchableScope implements Scope
     public function extend(EloquentBuilder $builder)
     {
         $builder->macro('searchable', function (EloquentBuilder $builder) {
-            $builder->chunk(500, function ($models) use ($builder) {
+            $builder->chunk(config('scout.chunk.searchable',500), function ($models) use ($builder) {
                 $models->searchable();
 
                 event(new ModelsImported($models));
@@ -38,7 +38,7 @@ class SearchableScope implements Scope
         });
 
         $builder->macro('unsearchable', function (EloquentBuilder $builder) {
-            $builder->chunk(500, function ($models) use ($builder) {
+            $builder->chunk(config('scout.chunk.unsearchable',500), function ($models) use ($builder) {
                 $models->unsearchable();
             });
         });


### PR DESCRIPTION
This option allows you to control if the size of the data that syncs
with your search engine. This chuck (page) size allows you to 
optimize the bulk data for both searchable and unsearchable methods.

This is very useful for optimizing data imports depending on machine size and data set sizes.