### PR TITLE
Add paginateRaw method to Builder class

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -178,19 +178,21 @@ class Builder
      * @param  int  $perPage
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  bool  $isRaw
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
-    public function paginate($perPage = null, $pageName = 'page', $page = null)
+    public function paginate($perPage = null, $pageName = 'page', $page = null, $isRaw = false)
     {
         $engine = $this->engine();
 
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
         $perPage = $perPage ?: $this->model->getPerPage();
-
-        $results = Collection::make($engine->map(
-            $rawResults = $engine->paginate($this, $perPage, $page), $this->model
-        ));
+        $rawResults = $engine->paginate($this, $perPage, $page);
+        $results = $isRaw ? $rawResults :
+            Collection::make($engine->map(
+            $rawResults, $this->model
+            ))  ;
 
         $paginator = (new LengthAwarePaginator($results, $engine->getTotalCount($rawResults), $perPage, $page, [
             'path' => Paginator::resolveCurrentPath(),
@@ -198,6 +200,16 @@ class Builder
         ]));
 
         return $paginator->appends('query', $this->query);
+    }
+
+    /**
+     * Paginate the given query into a raw data paginator.
+     *
+     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
+     */
+    public function paginateRaw()
+    {
+        return $this->paginate($perPage = null, $pageName = 'page', $page = null, $isRaw = true);
     }
 
     /**


### PR DESCRIPTION
Hi , 
While working with scout using Elastic-Search engine the only way to get all the data returned from Elastic-Search is to use the raw() method from scout Builder class , but we also need the results to be paginated so I added a simple method to handle that . 

I noticed that other people may find this useful i.e. issue #204 

By implementing this (in my case ) I can now get highlights and aggregations(facets) from Elastic-Search . 
