### PR TITLE
Use string "null" if default driver is set to NULL

### DIFF
--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -52,6 +52,6 @@ class EngineManager extends Manager
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['scout.driver'];
+        return $this->app['config']['scout.driver'] ?? 'null';
     }
 }


### PR DESCRIPTION
If your `SCOUT_DRIVER` environmental variable is set to `"null"`, the `env()` helper will convert that to the value `NULL`. The current workaround is to set the value to `'"null"'`, which forces `env()` to load it as a string, or to add a check to your `scout.php` config file.

This updates `getDefaultDriver()` to return the string `"null"` if the value of `config('scout.driver')` returns `NULL`.