### PR TITLE
Fix PHP 5.6 compatibility for null driver

### DIFF
--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -52,6 +52,10 @@ class EngineManager extends Manager
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['scout.driver'] ?? 'null';
+        if (is_null($this->app['config']['scout.driver'])) {
+            return 'null';
+        }
+
+        return $this->app['config']['scout.driver'];
     }
 }


### PR DESCRIPTION
Fix for NullDriver introduced in https://github.com/laravel/scout/pull/224 is PHP7 only.

Thanks to @royscheepens for [noticing](https://github.com/laravel/scout/commit/84762c8ed51cb57f09b5f465e09993e48baf9d55#commitcomment-24295476).