### PR TITLE
Show flush progress in the console.

### DIFF
--- a/src/Events/ModelsFlushed.php
+++ b/src/Events/ModelsFlushed.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Laravel\Scout\Events;
+
+class ModelsFlushed
+{
+    /**
+     * The model collection.
+     *
+     * @var \Illuminate\Database\Eloquent\Collection
+     */
+    public $models;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @return void
+     */
+    public function __construct($models)
+    {
+        $this->models = $models;
+    }
+}

--- a/src/SearchableScope.php
+++ b/src/SearchableScope.php
@@ -5,6 +5,7 @@ namespace Laravel\Scout;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
 use Laravel\Scout\Events\ModelsImported;
+use Laravel\Scout\Events\ModelsFlushed;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
 class SearchableScope implements Scope
@@ -40,6 +41,8 @@ class SearchableScope implements Scope
         $builder->macro('unsearchable', function (EloquentBuilder $builder, $chunk = null) {
             $builder->chunk($chunk ?: config('scout.chunk.unsearchable', 500), function ($models) use ($builder) {
                 $models->unsearchable();
+
+                event(new ModelsFlushed($models));
             });
         });
     }


### PR DESCRIPTION
When bulk importing models for index via the console we can already see the progress of the import with what ID has been reached on the models at the end of each chunk.

I flushed a huge amount of models from elastic earlier, as there was no visual clue of progress it just felt like the command had halted for some reason, one might think there is a connection issue to the their search server for instance.

This PR adds the same functionality to the flush command, it will now look this:
<img width="385" alt="import" src="https://user-images.githubusercontent.com/8780549/31095778-e86ef26e-a7b1-11e7-8e6d-cb0927429203.png">
