### PR TITLE
Add where operators and restricted attribute searches

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -58,6 +58,13 @@ class Builder
     public $orders = [];
 
     /**
+     * The "restricted searchable attributes" that should be applied to the search.
+     *
+     * @var array
+     */
+    public $searchableAttributes = [];
+
+    /**
      * Create a new search builder instance.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
@@ -86,15 +93,41 @@ class Builder
     }
 
     /**
+     * Specify the attribute to search on.
+     *
+     * @param  string $attribute
+     */
+    public function onAttribute(string $attribute)
+    {
+        $this->searchableAttributes = [$attribute];
+
+        return $this;
+    }
+
+    /**
+     * Specify the attributes to search on.
+     *
+     * @param  mixed $attribute
+     */
+    public function onAttributes($attributes)
+    {
+        $this->searchableAttributes = is_array($attributes) ? $attributes : func_get_args();
+
+        return $this;
+    }
+
+
+    /**
      * Add a constraint to the search query.
      *
      * @param  string  $field
+     * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
      */
-    public function where($field, $value)
+    public function where($field, $operator, $value = null)
     {
-        $this->wheres[$field] = $value;
+        $this->wheres[$field] = $value === null ? ['=', $operator] : [$operator, $value];
 
         return $this;
     }

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -76,6 +76,7 @@ class AlgoliaEngine extends Engine
         return $this->performSearch($builder, array_filter([
             'numericFilters' => $this->filters($builder),
             'hitsPerPage' => $builder->limit,
+            'restrictSearchableAttributes' => $this->searchableAttributes($builder),
         ]));
     }
 
@@ -91,6 +92,7 @@ class AlgoliaEngine extends Engine
     {
         return $this->performSearch($builder, [
             'numericFilters' => $this->filters($builder),
+            'restrictSearchableAttributes' => $this->searchableAttributes($builder),
             'hitsPerPage' => $perPage,
             'page' => $page - 1,
         ]);
@@ -130,8 +132,25 @@ class AlgoliaEngine extends Engine
     protected function filters(Builder $builder)
     {
         return collect($builder->wheres)->map(function ($value, $key) {
-            return $key.'='.$value;
+            $operator = '=';
+
+            if (is_array($value)) {
+                list($operator, $value) = $value;
+            }
+
+            return $key.$operator.$value;
         })->values()->all();
+    }
+
+    /**
+     * Get the searchable attributes array for the query.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return array
+     */
+    protected function searchableAttributes(Builder $builder)
+    {
+        return $builder->searchableAttributes;
     }
 
     /**


### PR DESCRIPTION
Allows other operators than equals, for example

```php
// where importance > 7
$articles = Article::search('term')->where('importance', '>', 7)->get();

// where importance = 7
$articles = Article::search('term')->where('importance', 7)->get();
```

Also allows you to restrict your search to certain attributes
```php
// only search on the title and content attributes
$articles = Article::search('term')->onAttributes('title', 'content')->where('importance', '>', 7)->get();
```