### PR TITLE
[3.0] Update dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
     },
     "require-dev": {
         "algolia/algoliasearch-client-php": "^1.10",
-        "mockery/mockery": "~0.9",
-        "phpunit/phpunit": "~5.0"
+        "mockery/mockery": "~1.0",
+        "phpunit/phpunit": "~6.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
+         beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="vendor/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -3,9 +3,9 @@
 namespace Tests;
 
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-abstract class AbstractTestCase extends PHPUnit_Framework_TestCase
+abstract class AbstractTestCase extends TestCase
 {
     public function tearDown()
     {


### PR DESCRIPTION
Updated `mockery/mockery` to `~1.0` and `phpunit/phpunit` to `~6.0`.

PS: I've used [this commit](https://github.com/laravel/framework/pull/17864) from `laravel/framework` to prevent failed tests.