### PR TITLE
[4.0] Updated to PHPUnit 6 and Mockery 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4",
+        "php": ">=7.0",
         "illuminate/bus": "~5.4",
         "illuminate/contracts": "~5.4",
         "illuminate/database": "~5.4",
@@ -24,8 +24,8 @@
     },
     "require-dev": {
         "algolia/algoliasearch-client-php": "^1.10",
-        "mockery/mockery": "~0.9",
-        "phpunit/phpunit": "~5.0"
+        "mockery/mockery": "~1.0",
+        "phpunit/phpunit": "~6.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
+         beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="vendor/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -3,9 +3,9 @@
 namespace Tests;
 
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-abstract class AbstractTestCase extends PHPUnit_Framework_TestCase
+abstract class AbstractTestCase extends TestCase
 {
     public function tearDown()
     {


### PR DESCRIPTION
Updated `phpunit/phpunit` to `~6.0` and `mockery/mockery` to `~1.0`.

Dropped support to `PHP 5.6`, as PHPUnit 6.0 [requires PHP 7.0](https://github.com/sebastianbergmann/phpunit/blob/master/composer.json#L25).

PS: I've used [this commit](https://github.com/laravel/framework/pull/17864) from `laravel/framework` to prevent failed tests.