### PR TITLE
Ability to keep soft deleted records

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -73,6 +73,10 @@ class Builder
         $this->model = $model;
         $this->query = $query;
         $this->callback = $callback;
+
+        if (config('scout.soft_delete', false)) {
+            $this->wheres['__soft_deleted'] = 0;
+        }
     }
 
     /**
@@ -98,6 +102,20 @@ class Builder
     public function where($field, $value)
     {
         $this->wheres[$field] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Add a constraint to the search query.
+     *
+     * @param  string  $field
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function withTrashed()
+    {
+        unset($this->wheres['__soft_deleted']);
 
         return $this;
     }

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -38,7 +38,7 @@ class AlgoliaEngine extends Engine
         $index = $this->algolia->initIndex($models->first()->searchableAs());
 
         $index->addObjects($models->map(function ($model) {
-            $array = $model->toSearchableArray();
+            $array = array_merge($model->toSearchableArray(), $model->scoutMetadata());
 
             if (empty($array)) {
                 return;
@@ -161,7 +161,10 @@ class AlgoliaEngine extends Engine
         $keys = collect($results['hits'])
                         ->pluck('objectID')->values()->all();
 
-        $models = $model->whereIn(
+        $builder = in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses_recursive($model))
+                    ? $model->withTrashed() : $model->newQuery();
+
+        $models = $builder->whereIn(
             $model->getQualifiedKeyName(), $keys
         )->get()->keyBy($model->getKeyName());
 

--- a/src/ModelObserver.php
+++ b/src/ModelObserver.php
@@ -84,7 +84,13 @@ class ModelObserver
             return;
         }
 
-        $model->unsearchable();
+        if ($this->usesSoftDelete($model) && config('scout.soft_delete', false)) {
+            $model->setScoutMeta('__soft_deleted', 1);
+
+            $this->created($model);
+        } else {
+            $model->unsearchable();
+        }
     }
 
     /**
@@ -95,6 +101,21 @@ class ModelObserver
      */
     public function restored($model)
     {
+        if ($this->usesSoftDelete($model) && config('scout.soft_delete', false)) {
+            $model->setScoutMeta('__soft_deleted', 0);
+        }
+
         $this->created($model);
+    }
+
+    /**
+     * Determine if the given model uses soft deletes.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return bool
+     */
+    private function usesSoftDelete($model)
+    {
+        return in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses_recursive($model));
     }
 }

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -9,6 +9,13 @@ use Illuminate\Support\Collection as BaseCollection;
 trait Searchable
 {
     /**
+     * Extra attributes to be added by scout.
+     *
+     * @var array
+     */
+    private $scoutMetadata = [];
+
+    /**
      * Boot the trait.
      *
      * @return void
@@ -221,5 +228,27 @@ trait Searchable
     public function syncWithSearchUsingQueue()
     {
         return config('scout.queue.queue');
+    }
+
+    /**
+     * Set a scout related metadata.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return void
+     */
+    public function setScoutMeta($key, $value)
+    {
+        $this->scoutMetadata[$key] = $value;
+    }
+
+    /**
+     * Get all scout related metadata.
+     *
+     * @return array
+     */
+    public function scoutMetadata()
+    {
+        return $this->scoutMetadata;
     }
 }

--- a/tests/AlgoliaEngineTest.php
+++ b/tests/AlgoliaEngineTest.php
@@ -53,6 +53,7 @@ class AlgoliaEngineTest extends AbstractTestCase
         $engine = new AlgoliaEngine($client);
 
         $model = Mockery::mock('StdClass');
+        $model->shouldReceive('newQuery')->andReturn($model);
         $model->shouldReceive('getKeyName')->andReturn('id');
         $model->shouldReceive('getQualifiedKeyName')->andReturn('id');
         $model->shouldReceive('whereIn')->once()->with('id', [1])->andReturn($model);

--- a/tests/Fixtures/TestModel.php
+++ b/tests/Fixtures/TestModel.php
@@ -22,4 +22,9 @@ class TestModel extends Model
     {
         return ['id' => 1];
     }
+
+    public function scoutMetadata()
+    {
+        return [];
+    }
 }


### PR DESCRIPTION
This PR attempts to introduce the ability to keep soft deleted records in the index in query it if needed.

If you set the `scount.soft_delete` configuration attribute to true, scout will start appending a `__soft_deleted` attribute with your records, its value will be 0 or 1 depends on the state of the Model.

By default a `where` rule is added that prevents bringing soft deleted records, but you can use `User::search('maroon5')->withTrashed()->get()` to bring soft deleted models as well.

This change will require custom Engines to be modified to properly handle the new feature, the changes needed are:
- Merging the scout metadata array while updating/adding records `array_merge($model->toSearchableArray(), $model->scoutMetadata())`
- Use `Model::withTrashed()` while mapping the records with eloquent models in case the feature is enabled.