### PR TITLE
Conditionally make a model instance searchable

### DIFF
--- a/src/ModelObserver.php
+++ b/src/ModelObserver.php
@@ -59,6 +59,10 @@ class ModelObserver
         if (static::syncingDisabledFor($model)) {
             return;
         }
+        
+        if (! $model->shouldBeSearchable()) {
+            return;
+        }
 
         $model->searchable();
     }

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -197,6 +197,16 @@ trait Searchable
     }
 
     /**
+     * Determine if the model should be searchable.
+     * 
+     * @return boolean
+     */
+    public function shouldBeSearchable()
+    {
+        return true;
+    }
+
+    /**
      * Get the indexable data array for the model.
      *
      * @return array

--- a/tests/ModelObserverTest.php
+++ b/tests/ModelObserverTest.php
@@ -11,6 +11,7 @@ class ModelObserverTest extends AbstractTestCase
     {
         $observer = new ModelObserver;
         $model = Mockery::mock();
+        $model->shouldReceive('shouldBeSearchable')->andReturn(true);
         $model->shouldReceive('searchable');
         $observer->created($model);
     }
@@ -24,10 +25,20 @@ class ModelObserverTest extends AbstractTestCase
         $observer->created($model);
     }
 
+    public function test_created_handler_doesnt_make_model_searchable_when_disabled_per_model_rule()
+    {
+        $observer = new ModelObserver;
+        $model = Mockery::mock();
+        $model->shouldReceive('shouldBeSearchable')->andReturn(false);
+        $model->shouldReceive('searchable')->never();
+        $observer->created($model);
+    }
+
     public function test_updated_handler_makes_model_searchable()
     {
         $observer = new ModelObserver;
         $model = Mockery::mock();
+        $model->shouldReceive('shouldBeSearchable')->andReturn(true);
         $model->shouldReceive('searchable');
         $observer->updated($model);
     }
@@ -44,6 +55,7 @@ class ModelObserverTest extends AbstractTestCase
     {
         $observer = new ModelObserver;
         $model = Mockery::mock();
+        $model->shouldReceive('shouldBeSearchable')->andReturn(true);
         $model->shouldReceive('searchable');
         $observer->restored($model);
     }


### PR DESCRIPTION
Hey.

I've come across this issue where I wanted to conditionally make some models searchable. The example I had is with `Post`s. The posts in my system can be in "draft" or published state. If a post is in the "draft" state, I would not like to make it searchable.

The current state of Scout does not let us disable model syncing per instance but per class only.

To "disable" syncing for posts in the "draft" state, I've ensured that the `searchableArray()` method returns an empty array. While it does indeed ensure that the "draft" posts won't be synced, it sends a request to make the model searchable with empty data which is useless and wasting indexing operation if you're using a driver such as Algolia.

This PR adds a simple "hook" that each model can implement to determine if it should be searchable:

```php
class Post extends Model {
    use Searchable;
    
    public function shouldBeSearchable()
    {
        return $this->isPublished();
    }
}
```

By default, the `shouldBeSearchable()` method is implemented on the `Searchable` trait and returns `true` so this change does not cause any breaking changes.