### PR TITLE
Import only searchable models when performing a bulk import using EloquentBuilder

### DIFF
--- a/src/SearchableScope.php
+++ b/src/SearchableScope.php
@@ -32,7 +32,7 @@ class SearchableScope implements Scope
     {
         $builder->macro('searchable', function (EloquentBuilder $builder, $chunk = null) {
             $builder->chunk($chunk ?: config('scout.chunk.searchable', 500), function ($models) use ($builder) {
-                $models->searchable();
+                $models->filter->shouldBeSearchable()->searchable();
 
                 event(new ModelsImported($models));
             });


### PR DESCRIPTION
Hey.

This PR is ensuring that when we perform a bulk import using the EloquentBuilder it will only import the models that `shouldBeSearchable()`. We use the EloquentBuilder when we do an import from the command line:

```bash
php artisan scout:import "App\Model"
```

This PR fixes #244 