### PR TITLE
Listen to saved event instead of created/updated

### DIFF
--- a/src/ModelObserver.php
+++ b/src/ModelObserver.php
@@ -49,33 +49,22 @@ class ModelObserver
     }
 
     /**
-     * Handle the created event for the model.
+     * Handle the saved event for the model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return void
      */
-    public function created($model)
+    public function saved($model)
     {
         if (static::syncingDisabledFor($model)) {
             return;
         }
-        
+
         if (! $model->shouldBeSearchable()) {
             return;
         }
 
         $model->searchable();
-    }
-
-    /**
-     * Handle the updated event for the model.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return void
-     */
-    public function updated($model)
-    {
-        $this->created($model);
     }
 
     /**
@@ -91,7 +80,7 @@ class ModelObserver
         }
 
         if ($this->usesSoftDelete($model) && config('scout.soft_delete', false)) {
-            $this->updated($model);
+            $this->saved($model);
         } else {
             $model->unsearchable();
         }
@@ -105,7 +94,7 @@ class ModelObserver
      */
     public function restored($model)
     {
-        $this->created($model);
+        $this->saved($model);
     }
 
     /**

--- a/tests/ModelObserverTest.php
+++ b/tests/ModelObserverTest.php
@@ -7,40 +7,31 @@ use Laravel\Scout\ModelObserver;
 
 class ModelObserverTest extends AbstractTestCase
 {
-    public function test_created_handler_makes_model_searchable()
+    public function test_saved_handler_makes_model_searchable()
     {
         $observer = new ModelObserver;
         $model = Mockery::mock();
         $model->shouldReceive('shouldBeSearchable')->andReturn(true);
         $model->shouldReceive('searchable');
-        $observer->created($model);
+        $observer->saved($model);
     }
 
-    public function test_created_handler_doesnt_make_model_searchable_when_disabled()
+    public function test_saved_handler_doesnt_make_model_searchable_when_disabled()
     {
         $observer = new ModelObserver;
         $model = Mockery::mock();
         $observer->disableSyncingFor(get_class($model));
         $model->shouldReceive('searchable')->never();
-        $observer->created($model);
+        $observer->saved($model);
     }
 
-    public function test_created_handler_doesnt_make_model_searchable_when_disabled_per_model_rule()
+    public function test_saved_handler_doesnt_make_model_searchable_when_disabled_per_model_rule()
     {
         $observer = new ModelObserver;
         $model = Mockery::mock();
         $model->shouldReceive('shouldBeSearchable')->andReturn(false);
         $model->shouldReceive('searchable')->never();
-        $observer->created($model);
-    }
-
-    public function test_updated_handler_makes_model_searchable()
-    {
-        $observer = new ModelObserver;
-        $model = Mockery::mock();
-        $model->shouldReceive('shouldBeSearchable')->andReturn(true);
-        $model->shouldReceive('searchable');
-        $observer->updated($model);
+        $observer->saved($model);
     }
 
     public function test_deleted_handler_makes_model_unsearchable()


### PR DESCRIPTION
Related to #251.

Listening to `created` and `updated` events instead of `saved` presents a problem when index includes attributes that come from relationships (ie: product index includes dealer name from another model, post has images that are stored separately etc.), because those events aren't triggered when touching parent timestamps.