### PR TITLE
Keep Scout Builder uncoupled from the config and the framework helpers

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -50,7 +50,7 @@ return [
     |
     | These options allow you to control the maximum chunk size when you are
     | mass importing data into the search engine. This allows you to fine
-    | tune these chunk sizes based on the capabilites of your machines.
+    | tune these chunk sizes based on the capabilities of your machines.
     |
     */
 
@@ -58,6 +58,16 @@ return [
         'searchable' => 500,
         'unsearchable' => 500,
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Soft Deletes
+    |--------------------------------------------------------------------------
+    |
+    | This option allows to control whether to keep soft deleted records.
+    |
+    */
+    'soft_delete' => false,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -63,18 +63,18 @@ class Builder
     /**
      * Create a new search builder instance.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @param  string  $query
-     * @param  \Closure  $callback
-     * @return void
+     * @param  \Illuminate\Database\Eloquent\Model $model
+     * @param  string $query
+     * @param  \Closure $callback
+     * @param bool $soft_delete
      */
-    public function __construct($model, $query, $callback = null)
+    public function __construct($model, $query, $callback = null, $soft_delete = false)
     {
         $this->model = $model;
         $this->query = $query;
         $this->callback = $callback;
 
-        if (config('scout.soft_delete', false)) {
+        if ($soft_delete) {
             $this->wheres['__soft_deleted'] = 0;
         }
     }

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -92,7 +92,7 @@ trait Searchable
      */
     public static function search($query, $callback = null)
     {
-        return new Builder(new static, $query, $callback);
+        return new Builder(new static, $query, $callback, config('scout.soft_delete', false));
     }
 
     /**

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -30,7 +30,7 @@ class BuilderTest extends AbstractTestCase
         $builder->paginate();
     }
 
-    public function testMacroable()
+    public function test_macroable()
     {
         Builder::macro('foo', function () {
             return 'bar';
@@ -40,5 +40,12 @@ class BuilderTest extends AbstractTestCase
         $this->assertEquals(
             'bar', $builder->foo()
         );
+    }
+
+    public function test_soft_delete_sets_wheres()
+    {
+        $builder = new Builder($model = Mockery::mock(), 'zonda', null, true);
+
+        $this->assertEquals(0, $builder->wheres['__soft_deleted']);
     }
 }


### PR DESCRIPTION
This PR attempts to uncouple Scout's `Builder` from the config and the framework helpers (`config()` specifically in this case) that was most likely inadvertently introduced by #236.

It also adds the `soft_delete` option to the `config/scout.php` file so that users know it's available.

I don't necessarily insist in this particular implementation but strongly believe that keeping `Builder` uncoupled is a good thing.