### PR TITLE
Sync conditional models

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -74,6 +74,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Sync unsearchables
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to control whether to make the model unsearchable
+    | in case a model should not be searchable anymore. This can be helpful
+    | when an entity was active, but deactivated when saving for example.
+    |
+    */
+
+    'sync_unsearchables' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Algolia Configuration
     |--------------------------------------------------------------------------
     |

--- a/config/scout.php
+++ b/config/scout.php
@@ -74,19 +74,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Sync unsearchables
-    |--------------------------------------------------------------------------
-    |
-    | This option allows you to control whether to make the model unsearchable
-    | in case a model should not be searchable anymore. This can be helpful
-    | when an entity was active, but deactivated when saving for example.
-    |
-    */
-
-    'sync_unsearchables' => false,
-
-    /*
-    |--------------------------------------------------------------------------
     | Algolia Configuration
     |--------------------------------------------------------------------------
     |

--- a/src/ModelObserver.php
+++ b/src/ModelObserver.php
@@ -128,7 +128,7 @@ class ModelObserver
     /**
      * Sync the unsearchable model if configured to do so.
      *
-     * @param \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return void
      */
     protected function syncUnsearchable($model)

--- a/src/ModelObserver.php
+++ b/src/ModelObserver.php
@@ -61,7 +61,7 @@ class ModelObserver
         }
 
         if (! $model->shouldBeSearchable()) {
-            $this->syncUnsearchable($model);
+            $model->unsearchable();
 
             return;
         }
@@ -123,20 +123,5 @@ class ModelObserver
     protected function usesSoftDelete($model)
     {
         return in_array(SoftDeletes::class, class_uses_recursive($model));
-    }
-
-    /**
-     * Sync the unsearchable model if configured to do so.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return void
-     */
-    protected function syncUnsearchable($model)
-    {
-        if (! config('scout.sync_unsearchables', false)) {
-            return;
-        }
-
-        $model->unsearchable();
     }
 }

--- a/src/ModelObserver.php
+++ b/src/ModelObserver.php
@@ -81,7 +81,7 @@ class ModelObserver
             return;
         }
 
-        if ($this->shouldSyncSoftDeletes($model)) {
+        if ($this->usesSoftDelete($model) && config('scout.soft_delete', false)) {
             $this->saved($model);
         } else {
             $model->unsearchable();
@@ -133,36 +133,10 @@ class ModelObserver
      */
     protected function syncUnsearchable($model)
     {
-        if (! $this->shouldSyncUnsearchable($model)) {
+        if (! config('scout.sync_unsearchables', false)) {
             return;
         }
 
-        $this->deleted($model);
-    }
-
-    /**
-     * Determine if soft deletes should be synced for the given model.
-     *
-     * @param \Illuminate\Database\Eloquent\Model  $model
-     * @return bool
-     */
-    protected function shouldSyncSoftDeletes($model)
-    {
-        return $this->usesSoftDelete($model) && config('scout.soft_delete', false);
-    }
-
-    /**
-     * Determine if unsearchable models should be synced.
-     *
-     * @param \Illuminate\Database\Eloquent\Model  $model
-     * @return bool
-     */
-    protected function shouldSyncUnsearchable($model)
-    {
-        if (! config('scout.sync_unsearchables', false)) {
-            return false;
-        }
-
-        return ! $this->shouldSyncSoftDeletes($model);
+        $model->unsearchable();
     }
 }

--- a/tests/ModelObserverTest.php
+++ b/tests/ModelObserverTest.php
@@ -39,7 +39,6 @@ class ModelObserverTest extends AbstractTestCase
         $observer = new ModelObserver;
         $model = Mockery::mock();
         $model->shouldReceive('shouldBeSearchable')->andReturn(false);
-        $model->shouldReceive('shouldSyncUnsearchable')->andReturn(true);
         $model->shouldReceive('searchable')->never();
         $model->shouldReceive('unsearchable');
         $observer->saved($model);

--- a/tests/ModelObserverTest.php
+++ b/tests/ModelObserverTest.php
@@ -34,6 +34,17 @@ class ModelObserverTest extends AbstractTestCase
         $observer->saved($model);
     }
 
+    public function test_saved_handler_makes_model_unsearchable_when_disabled_per_model_rule_and_configured_to_sync()
+    {
+        $observer = new ModelObserver;
+        $model = Mockery::mock();
+        $model->shouldReceive('shouldBeSearchable')->andReturn(false);
+        $model->shouldReceive('shouldSyncUnsearchable')->andReturn(true);
+        $model->shouldReceive('searchable')->never();
+        $model->shouldReceive('unsearchable');
+        $observer->saved($model);
+    }
+
     public function test_deleted_handler_makes_model_unsearchable()
     {
         $observer = new ModelObserver;

--- a/tests/ModelObserverTest.php
+++ b/tests/ModelObserverTest.php
@@ -25,16 +25,7 @@ class ModelObserverTest extends AbstractTestCase
         $observer->saved($model);
     }
 
-    public function test_saved_handler_doesnt_make_model_searchable_when_disabled_per_model_rule()
-    {
-        $observer = new ModelObserver;
-        $model = Mockery::mock();
-        $model->shouldReceive('shouldBeSearchable')->andReturn(false);
-        $model->shouldReceive('searchable')->never();
-        $observer->saved($model);
-    }
-
-    public function test_saved_handler_makes_model_unsearchable_when_disabled_per_model_rule_and_configured_to_sync()
+    public function test_saved_handler_makes_model_unsearchable_when_disabled_per_model_rule()
     {
         $observer = new ModelObserver;
         $model = Mockery::mock();


### PR DESCRIPTION
As mentioned in #263 the models where `shouldBeSearchable()` returns `false` are not deleted from the search engine.

This PR makes sure those models are made unsearchable to prevent your search engine exposing data that shouldn't be available.

This PR fixes #249 