### PR TITLE
Use custom Key to index a model

### DIFF
--- a/src/Console/FlushCommand.php
+++ b/src/Console/FlushCommand.php
@@ -35,7 +35,7 @@ class FlushCommand extends Command
         $model = new $class;
 
         $events->listen(ModelsFlushed::class, function ($event) use ($class) {
-            $key = $event->models->last()->getKey();
+            $key = $event->models->last()->getScoutKey();
 
             $this->line('<comment>Flushed ['.$class.'] models up to ID:</comment> '.$key);
         });

--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -35,7 +35,7 @@ class ImportCommand extends Command
         $model = new $class;
 
         $events->listen(ModelsImported::class, function ($event) use ($class) {
-            $key = $event->models->last()->getKey();
+            $key = $event->models->last()->getScoutKey();
 
             $this->line('<comment>Imported ['.$class.'] models up to ID:</comment> '.$key);
         });

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -55,7 +55,7 @@ class AlgoliaEngine extends Engine
                 return;
             }
 
-            return array_merge(['objectID' => $model->getKey()], $array);
+            return array_merge(['objectID' => $model->getScoutKey()], $array);
         })->filter()->values()->all());
     }
 
@@ -71,7 +71,7 @@ class AlgoliaEngine extends Engine
 
         $index->deleteObjects(
             $models->map(function ($model) {
-                return $model->getKey();
+                return $model->getScoutKey();
             })->values()->all()
         );
     }

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -281,4 +281,14 @@ trait Searchable
 
         return $this;
     }
+
+    /**
+     * Gets the key which is used to index the model
+     * Override this method to use an other key than the eloquent key
+     *
+     * @return void
+     */
+    public function getScoutKey(){
+        return $this->getKey();
+    }
 }

--- a/tests/AlgoliaEngineTest.php
+++ b/tests/AlgoliaEngineTest.php
@@ -5,6 +5,7 @@ namespace Tests;
 use Mockery;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\AlgoliaEngine;
+use Tests\Fixtures\AlgoliaEngineTestCustomKeyModel;
 use Tests\Fixtures\AlgoliaEngineTestModel;
 use Illuminate\Database\Eloquent\Collection;
 
@@ -64,5 +65,28 @@ class AlgoliaEngineTest extends AbstractTestCase
         ]], $model);
 
         $this->assertEquals(1, count($results));
+    }
+
+    public function test_a_model_is_indexed_with_a_custom_algolia_key()
+    {
+        $client = Mockery::mock('AlgoliaSearch\Client');
+        $client->shouldReceive('initIndex')->with('table')->andReturn($index = Mockery::mock('StdClass'));
+        $index->shouldReceive('addObjects')->with([[
+            'id' => 1,
+            'objectID' => 'my-algolia-key.1',
+        ]]);
+
+        $engine = new AlgoliaEngine($client);
+        $engine->update(Collection::make([new AlgoliaEngineTestCustomKeyModel()]));
+    }
+
+    public function test_a_model_is_removed_with_a_custom_algolia_key()
+    {
+        $client = Mockery::mock('AlgoliaSearch\Client');
+        $client->shouldReceive('initIndex')->with('table')->andReturn($index = Mockery::mock('StdClass'));
+        $index->shouldReceive('deleteObjects')->with(['my-algolia-key.1']);
+
+        $engine = new AlgoliaEngine($client);
+        $engine->delete(Collection::make([new AlgoliaEngineTestCustomKeyModel()]));
     }
 }

--- a/tests/Fixtures/AlgoliaEngineTestCustomKeyModel.php
+++ b/tests/Fixtures/AlgoliaEngineTestCustomKeyModel.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\Fixtures;
+
+class AlgoliaEngineTestCustomKeyModel extends TestModel
+{
+    public function getScoutKey() {
+        return 'my-algolia-key.'.$this->getKey();
+    }
+}

--- a/tests/Fixtures/TestModel.php
+++ b/tests/Fixtures/TestModel.php
@@ -18,6 +18,15 @@ class TestModel extends Model
         return $this->id;
     }
 
+    /**
+     * The default key of Models with Searchable-Trait
+     * @return mixed
+     */
+    public function getScoutKey()
+    {
+        return $this->getKey();
+    }
+
     public function toSearchableArray()
     {
         return ['id' => 1];


### PR DESCRIPTION
I had a problem similar to #44 and #267. My data is indexed with a custom ObjectID which is equal to the Eloquent ID.

I just added a new method "getScoutKey" to the SearchableTrait which returns the Eloquent key by default but can be overwritten.

This should fix both issues mentioned above.