### PR TITLE
Add getScoutKeyName() and mapScoutSearchResults() functions.

### DIFF
--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -176,11 +176,11 @@ class AlgoliaEngine extends Engine
         )->keyBy($modelKey);
 
         return Collection::make($results['hits'])->map(function ($hit) use ($models, $modelKey) {
-            $key = $hit[$modelKey];
+            $key = $hit['objectID'];
 
-            if (isset($models[$key])) {
-                return $models[$key];
-            }
+            return $models->first(function ($model) use ($key) {
+                return $model->getScoutKey() === $key;
+            });
         })->filter()->values();
     }
 

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -169,16 +169,14 @@ class AlgoliaEngine extends Engine
             return Collection::make();
         }
 
-        $builder = in_array(SoftDeletes::class, class_uses_recursive($model))
-                    ? $model->withTrashed() : $model->newQuery();
+        $modelKey = $model->getKeyName();
 
-        $models = $builder->whereIn(
-            $model->getQualifiedKeyName(),
+        $models = $model->mapScoutSearchResults(
             collect($results['hits'])->pluck('objectID')->values()->all()
-        )->get()->keyBy($model->getKeyName());
+        )->keyBy($modelKey);
 
-        return Collection::make($results['hits'])->map(function ($hit) use ($models) {
-            $key = $hit['objectID'];
+        return Collection::make($results['hits'])->map(function ($hit) use ($models, $modelKey) {
+            $key = $hit[$modelKey];
 
             if (isset($models[$key])) {
                 return $models[$key];

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -292,4 +292,27 @@ trait Searchable
     {
         return $this->getKey();
     }
+
+    /**
+     * Get the key name used to index the model.
+     *
+     * @return mixed
+     */
+    public function getScoutKeyName()
+    {
+        return $this->getQualifiedKeyName();
+    }
+
+    /**
+     * Hydrate the models from an array of objectIds;
+     *
+     * @return mixed
+     */
+    public function mapScoutSearchResults(array $objectIds)
+    {
+        $builder = in_array(SoftDeletes::class, class_uses_recursive($this))
+                    ? $this->withTrashed() : $this->newQuery();
+
+        return $builder->whereIn($this->getScoutKeyName(), $objectIds)->get();
+    }
 }

--- a/tests/AlgoliaEngineTest.php
+++ b/tests/AlgoliaEngineTest.php
@@ -56,9 +56,7 @@ class AlgoliaEngineTest extends AbstractTestCase
         $model = Mockery::mock('StdClass');
         $model->shouldReceive('newQuery')->andReturn($model);
         $model->shouldReceive('getKeyName')->andReturn('id');
-        $model->shouldReceive('getQualifiedKeyName')->andReturn('id');
-        $model->shouldReceive('whereIn')->once()->with('id', [1])->andReturn($model);
-        $model->shouldReceive('get')->once()->andReturn(Collection::make([new AlgoliaEngineTestModel]));
+        $model->shouldReceive('mapScoutSearchResults')->andReturn(Collection::make([new AlgoliaEngineTestModel]));
 
         $results = $engine->map(['nbHits' => 1, 'hits' => [
             ['objectID' => 1, 'id' => 1],


### PR DESCRIPTION
This PR fixes issue #274.

The issue is that the function `getScoutKey()` can be used to make a custom index for the model. However, the Algolia engine had no idea how to turn this custom index back into the Eloquent models. This PR provides two ways to do this, a simple, and a complex one.

The simple method is `getScoutKeyName()` which you can use to provide the Algolia engine with the name of the key to use to hydrate the Eloquent models.

```php
    public function getScoutKey()
    {
        return $this->email;
    }

   public function getScoutKeyName()
   {
       return 'email';
   }
```
However, the `getScoutKey()` method does not require that a single model attribute be returned. It could be a compound key.

```php
    public function getScoutKey()
    {
        return $this->email . '-' . $this->name;
    }
```

In this case, we cannot use the `getScoutKeyName()` function. We can use the `mapScoutSearchResults()` method.

```php
public function mapScoutSearchResults(array $objectIds)
{
    $query = $this->newQuery();
    foreach($objectIds as $objectId) {
        list($email, $name) = explode('-', $objectId);
        $query->orWhere(function($query) use($email, $name) {
            $query->where('email', $email);
            $query->where('name', $name);
        });
    }
    return $query->get();
}
```