### PR TITLE
allow database query customization in getScoutModelsByIds

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -162,6 +162,18 @@ class Builder
     }
 
     /**
+     * Add a callback to apply on query used to fetch models from database
+     *
+     * @param \Closure $callback
+     * @return $this
+     */
+    public function mapUsing($callback) {
+        $this->model->getScoutModelsUsing = $callback;
+
+        return $this;
+    }
+
+    /**
      * Get the raw results of the search.
      *
      * @return mixed

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -17,6 +17,13 @@ trait Searchable
     protected $scoutMetadata = [];
 
     /**
+     * Callback to customize query when fetching models from database
+     *
+     * @var \Closure
+     */
+    public $getScoutModelsUsing;
+
+    /**
      * Boot the trait.
      *
      * @return void
@@ -172,6 +179,10 @@ trait Searchable
     {
         $builder = in_array(SoftDeletes::class, class_uses_recursive($this))
                             ? $this->withTrashed() : $this->newQuery();
+
+        if ($this->getScoutModelsUsing) {
+            call_user_func($this->getScoutModelsUsing, $builder);
+        }
 
         return $builder->whereIn(
             $this->getScoutKeyName(), $ids


### PR DESCRIPTION
This pull request aims to customize query used to fetch models from database using object IDs.

It could resolve #140, #230, #284 

It can be used easily doing  : 
```php
$authors = Author::search('John')
                  ->mapUsing(function($query) {
                      // $query is Illuminate\Database\Eloquent\Builder
                      return $query->withCount('articles')->with('country');
                  })->get();
// at this point articles_count of all $authors is set with correct value
// and country relation is loaded
```
The callback is runned after engine's search so adding filter will work but can break pagination
```php
$authors = Author::search('John')
                  ->mapUsing(function($query) {
                      return $query->where('country_id', 1);
                  })->get();
```
Does it look good ?