### PR TITLE
allow database query customization in getScoutModelsByIds

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -162,6 +162,18 @@ class Builder
     }
 
     /**
+     * Add a callback to apply on query used to fetch models from database
+     *
+     * @param \Closure $callback
+     * @return $this
+     */
+    public function mapUsing($callback) {
+        $this->model = new SearchableProxy($this->model, $callback);
+
+        return $this;
+    }
+
+    /**
      * Get the raw results of the search.
      *
      * @return mixed

--- a/src/SearchableProxy.php
+++ b/src/SearchableProxy.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Laravel\Scout;
+
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class SearchableProxy
+{
+    /**
+     * The model instance
+     *
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    private $model;
+
+    /**
+     * Callback before database query execution
+     *
+     * @var \Closure
+     */
+    private $callback;
+
+    /**
+     * Create the SearchableProxy
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @param \Closure $callback
+     */
+    public function __construct($model, $callback)
+    {
+        $this->model = $model;
+        $this->callback = $callback;
+    }
+
+    /**
+     * Get the requested models from an array of object IDs;
+     *
+     * @param  array  $ids
+     * @return mixed
+     */
+    public function getScoutModelsByIds(array $ids)
+    {
+        $builder = in_array(SoftDeletes::class, class_uses_recursive($this->model))
+            ? $this->withTrashed() : $this->newQuery();
+
+        call_user_func($this->callback, $builder);
+
+        return $builder->whereIn(
+            $this->getScoutKeyName(), $ids
+        )->get();
+    }
+
+    /**
+     * Determine if an attribute exists on the model.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function __isset($key)
+    {
+        return isset($this->model->{$key});
+    }
+
+    /**
+     * Unset an attribute on the model.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    public function __unset($key)
+    {
+        unset($this->model->{$key});
+    }
+
+    /**
+     * Dynamically get properties from the underlying model.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return $this->model->{$key};
+    }
+
+    /**
+     * Dynamically pass method calls to the underlying model.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->model->{$method}(...$parameters);
+    }
+}


### PR DESCRIPTION
Second try, without the issue of model serialization.

This pull request aims to customize query used to fetch models from database using object IDs.

It could resolve #140, #230, #284 

It can be used easily doing  : 
```php
$authors = Author::search('John')
                  ->mapUsing(function($query) {
                      // $query is Illuminate\Database\Eloquent\Builder
                      return $query->withCount('articles')->with('country');
                  })->get();
// at this point articles_count of all $authors is set with correct value
// and country relation is loaded
```
The callback is runned after engine's search so adding filter will work but can break pagination
```php
$authors = Author::search('John')
                  ->mapUsing(function($query) {
                      return $query->where('country_id', 1);
                  })->get();
```
Does it look good ? Does the SearchableProxy need more/less magic methods ? 

SearchableProxy can be renamed, I do not have a lot of inspiration at this time...