### PR TITLE
Update NullEngine.php: add missing Builder parameter

### DIFF
--- a/src/Engines/NullEngine.php
+++ b/src/Engines/NullEngine.php
@@ -67,11 +67,12 @@ class NullEngine extends Engine
     /**
      * Map the given results to instances of the given model.
      *
+     * @param  \Laravel\Scout\Builder  $builder
      * @param  mixed  $results
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    public function map($results, $model)
+    public function map(Builder $builder, $results, $model)
     {
         return Collection::make();
     }


### PR DESCRIPTION
Fixing the map function from amends a few days ago, appears to be missing the Builder parameter added to Engine.php