### PR TITLE
Adds default $query value on Searchable::search

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -102,7 +102,7 @@ trait Searchable
      * @param  Closure  $callback
      * @return \Laravel\Scout\Builder
      */
-    public static function search($query, $callback = null)
+    public static function search($query = '', $callback = null)
     {
         return new Builder(
             new static, $query, $callback, config('scout.soft_delete', false)


### PR DESCRIPTION
This Pull Request addresses the **developer experience** while interacting with the method `Searchable::search` - adding a default value to the `$query` param.

This can be useful if the developer just want an instance of the `Builder::class`:

Before:
```php
$results = Thread::search('')->where(...)->get();
```

After:
```php
$results = Thread::search()->where(...)->get();
```