### PR TITLE
[6.0] Use engine to flush records of model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## [v6.0.0 (unreleased)](https://github.com/laravel/framework/compare/v5.0.3...v6.0.0)
+## [v6.0.0 (unreleased)](https://github.com/laravel/scout/compare/v5.0.3...v6.0.0)
 
 ### Changed
 - Flush records of a model using the engine ([#310](https://github.com/laravel/scout/pull/310))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Release Notes
+
+## [v6.0.0 (unreleased)](https://github.com/laravel/framework/compare/v5.0.3...v6.0.0)
+
+### Changed
+- Flush records of a model using the engine ([#310](https://github.com/laravel/scout/pull/310))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,4 @@
 ## [v6.0.0 (unreleased)](https://github.com/laravel/scout/compare/v5.0.3...v6.0.0)
 
 ### Changed
-- Flush records of a model using the engine ([#310](https://github.com/laravel/scout/pull/310))
+- Flush records of a model using the engine. **This removes the emitting of the `ModelsFlushed` event.** ([#310](https://github.com/laravel/scout/pull/310))

--- a/src/Console/FlushCommand.php
+++ b/src/Console/FlushCommand.php
@@ -3,7 +3,6 @@
 namespace Laravel\Scout\Console;
 
 use Illuminate\Console\Command;
-use Laravel\Scout\Events\ModelsFlushed;
 use Illuminate\Contracts\Events\Dispatcher;
 
 class FlushCommand extends Command

--- a/src/Console/FlushCommand.php
+++ b/src/Console/FlushCommand.php
@@ -34,12 +34,6 @@ class FlushCommand extends Command
 
         $model = new $class;
 
-        $events->listen(ModelsFlushed::class, function ($event) use ($class) {
-            $key = $event->models->last()->getScoutKey();
-
-            $this->line('<comment>Flushed ['.$class.'] models up to ID:</comment> '.$key);
-        });
-
         $model::removeAllFromSearch();
 
         $events->forget(ModelsFlushed::class);

--- a/src/Console/FlushCommand.php
+++ b/src/Console/FlushCommand.php
@@ -35,9 +35,7 @@ class FlushCommand extends Command
         $model = new $class;
 
         $model::removeAllFromSearch();
-
-        $events->forget(ModelsFlushed::class);
-
+        
         $this->info('All ['.$class.'] records have been flushed.');
     }
 }

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -195,6 +195,19 @@ class AlgoliaEngine extends Engine
     }
 
     /**
+     * Flush all of the model's records from the engine.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    public function flush($model)
+    {
+        $index = $this->algolia->initIndex($model->searchableAs());
+
+        $index->clearIndex();
+    }
+
+    /**
      * Determine if the given model uses soft deletes.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model

--- a/src/Engines/Engine.php
+++ b/src/Engines/Engine.php
@@ -68,6 +68,14 @@ abstract class Engine
     abstract public function getTotalCount($results);
 
     /**
+     * Flush all of the model's records from the engine.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    abstract public function flush($model);
+
+    /**
      * Get the results of the query as a Collection of primary keys.
      *
      * @param  \Laravel\Scout\Builder  $builder

--- a/src/Engines/NullEngine.php
+++ b/src/Engines/NullEngine.php
@@ -86,4 +86,15 @@ class NullEngine extends Engine
     {
         return count($results);
     }
+
+    /**
+     * Flush all of the model's records from the engine.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    public function flush($model)
+    {
+        //
+    }
 }

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -148,9 +148,7 @@ trait Searchable
     {
         $self = new static();
 
-        $self->newQuery()
-            ->orderBy($self->getKeyName())
-            ->unsearchable();
+        $self->searchableUsing()->flush($self);
     }
 
     /**
@@ -264,7 +262,7 @@ trait Searchable
     /**
      * Get the queue that should be used with syncing
      *
-     * @return  string
+     * @return string
      */
     public function syncWithSearchUsingQueue()
     {

--- a/tests/AlgoliaEngineTest.php
+++ b/tests/AlgoliaEngineTest.php
@@ -89,4 +89,14 @@ class AlgoliaEngineTest extends AbstractTestCase
         $engine = new AlgoliaEngine($client);
         $engine->delete(Collection::make([new AlgoliaEngineTestCustomKeyModel()]));
     }
+
+    public function test_flush_a_model()
+    {
+        $client = Mockery::mock('AlgoliaSearch\Client');
+        $client->shouldReceive('initIndex')->with('table')->andReturn($index = Mockery::mock('StdClass'));
+        $index->shouldReceive('clearIndex');
+
+        $engine = new AlgoliaEngine($client);
+        $engine->flush(new AlgoliaEngineTestCustomKeyModel());
+    }
 }


### PR DESCRIPTION
Instead of iterating over ids from the database we use the engine itself to flush the records of an index/model.

This solves the problem where models would get out of sync with the search records and old records weren't flushed. With this implementation all records are always removed.

If there are engines which don't provide this functionality they can still iterate over the model ids if they want to.

Fixes https://github.com/laravel/scout/issues/101

@julienbourdeau would you mind also taking a look at this if this is correctly implemented? I didn't have the chance to test this with a live implementation of Algolia.