### PR TITLE
[6.0] Allow people to modify query parameter name

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -220,9 +220,10 @@ class Builder
      * @param  int  $perPage
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  string  $queryName
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
-    public function paginate($perPage = null, $pageName = 'page', $page = null)
+    public function paginate($perPage = null, $pageName = 'page', $page = null, $queryName = 'query')
     {
         $engine = $this->engine();
 
@@ -239,7 +240,7 @@ class Builder
             'pageName' => $pageName,
         ]));
 
-        return $paginator->appends('query', $this->query);
+        return $paginator->appends($queryName, $this->query);
     }
 
     /**
@@ -248,9 +249,10 @@ class Builder
      * @param  int  $perPage
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  string  $queryName
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
-    public function paginateRaw($perPage = null, $pageName = 'page', $page = null)
+    public function paginateRaw($perPage = null, $pageName = 'page', $page = null, $queryName = 'query')
     {
         $engine = $this->engine();
 
@@ -265,7 +267,7 @@ class Builder
             'pageName' => $pageName,
         ]));
 
-        return $paginator->appends('query', $this->query);
+        return $paginator->appends($queryName, $this->query);
     }
 
     /**


### PR DESCRIPTION
With this change you can customize the query parameter name when paginating results.

Sent to 6.0 because this modifies the method signature and is a breaking change.

Fixes https://github.com/laravel/scout/issues/58