### PR TITLE
[6.0] Add method count to builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,8 @@
 
 ## [v6.0.0 (unreleased)](https://github.com/laravel/scout/compare/v5.0.3...v6.0.0)
 
+### Added
+- Method `count` to Builder ([#314](https://github.com/laravel/scout/pull/314))
+
 ### Changed
 - Flush records of a model using the engine. **This removes the emitting of the `ModelsFlushed` event.** ([#310](https://github.com/laravel/scout/pull/310))

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -252,6 +252,18 @@ class Builder
     }
 
     /**
+     * Count the number of matching results.
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return (int) $this->engine()->getTotalCount(
+            $this->raw()
+        );
+    }
+
+    /**
      * Paginate the given query into a simple paginator.
      *
      * @param  int  $perPage

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -48,4 +48,19 @@ class BuilderTest extends AbstractTestCase
 
         $this->assertEquals(0, $builder->wheres['__soft_deleted']);
     }
+
+    public function test_count()
+    {
+        $builder = new Builder($model = Mockery::mock(), 'zonda');
+        $model->shouldReceive('searchableUsing')->andReturn($engine = Mockery::mock());
+
+        $nbHits = 5;
+        $rawResults = ['nbHits' => $nbHits];
+        $engine->shouldReceive('search')->andReturn($rawResults);
+        $engine->shouldReceive('getTotalCount')
+            ->with($rawResults)
+            ->andReturn($nbHits);
+
+        $this->assertEquals($builder->count(), $nbHits);
+    }
 }


### PR DESCRIPTION
This Pull Request adds the method `count` to the Builder class and it improves the developer experience while interacting with the Builder class.

Before:
```php
$rawResults = Thread::search('zonda')->raw();
$count = (new Thread)->searchableUsing()->getTotalCount($rawResults);
```

Now:
```php
$count = Thread::search('zonda')->count();
```

Fixes #164 and the original idea comes from @julienbourdeau's PR: https://github.com/laravel/scout/pull/183.