### PR TITLE
[6.0] Skip empty updates

### DIFF
--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -46,7 +46,7 @@ class AlgoliaEngine extends Engine
             $models->each->pushSoftDeleteMetadata();
         }
 
-        $index->addObjects($models->map(function ($model) {
+        $objects = $models->map(function ($model) {
             $array = array_merge(
                 $model->toSearchableArray(), $model->scoutMetadata()
             );
@@ -56,7 +56,11 @@ class AlgoliaEngine extends Engine
             }
 
             return array_merge(['objectID' => $model->getScoutKey()], $array);
-        })->filter()->values()->all());
+        })->filter()->values()->all();
+
+        if (!empty($objects)) {
+            $index->addObjects($objects);
+        }
     }
 
     /**

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -58,7 +58,7 @@ class AlgoliaEngine extends Engine
             return array_merge(['objectID' => $model->getScoutKey()], $array);
         })->filter()->values()->all();
 
-        if (!empty($objects)) {
+        if (! empty($objects)) {
             $index->addObjects($objects);
         }
     }

--- a/tests/AlgoliaEngineTest.php
+++ b/tests/AlgoliaEngineTest.php
@@ -7,6 +7,7 @@ use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\AlgoliaEngine;
 use Tests\Fixtures\AlgoliaEngineTestCustomKeyModel;
 use Tests\Fixtures\AlgoliaEngineTestModel;
+use Tests\Fixtures\EmptyTestModel;
 use Illuminate\Database\Eloquent\Collection;
 
 class AlgoliaEngineTest extends AbstractTestCase
@@ -98,5 +99,15 @@ class AlgoliaEngineTest extends AbstractTestCase
 
         $engine = new AlgoliaEngine($client);
         $engine->flush(new AlgoliaEngineTestCustomKeyModel());
+    }
+
+    public function test_update_empty_searchable_array_does_not_add_objects_to_index()
+    {
+        $client = Mockery::mock('AlgoliaSearch\Client');
+        $client->shouldReceive('initIndex')->with('table')->andReturn($index = Mockery::mock('StdClass'));
+        $index->shouldNotReceive('addObjects');
+
+        $engine = new AlgoliaEngine($client);
+        $engine->update(Collection::make([new EmptyTestModel()]));
     }
 }

--- a/tests/Fixtures/EmptyTestModel.php
+++ b/tests/Fixtures/EmptyTestModel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tests\Fixtures;
+
+class EmptyTestModel extends TestModel
+{
+    public function toSearchableArray()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
If a models toSearchableArray() returns an empty array the current behaviour in the AlgoliaEngine basically ends up calling the equivalent to `collect([null])->filter()->values()->all()`which returns [] therefore we call `$index->addObjects([])` and a wasteful API request is made to Algolia, since the code filters out empty data I think the intended behaviour was not to call an indexing operation.