### PR TITLE
[6.0] Allow to change the builder implementation using the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## [v6.2.0 (unreleased)](https://github.com/laravel/scout/compare/v6.1.0...v6.2.0)
+### Added
+- Builder implementation can be changed using the container ([#322](https://github.com/laravel/scout/pull/322))
+
 ## [v6.1.0](https://github.com/laravel/scout/compare/v6.0.0...v6.1.0)
 
 ### Fixed

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -103,9 +103,12 @@ trait Searchable
      */
     public static function search($query = '', $callback = null)
     {
-        return new Builder(
-            new static, $query, $callback, static::usesSoftDelete() && config('scout.soft_delete', false)
-        );
+        return app(Builder::class, [
+            'model' => new static,
+            'query' => $query,
+            'callback' => $callback,
+            'softDelete'=> static::usesSoftDelete() && config('scout.soft_delete', false)
+        ]);
     }
 
     /**


### PR DESCRIPTION
This Pull Request adds the possibility of changing the concrete implementation of the `Builder::class`. Behind the scenes, the developer can now specify is own implementation doing:
```php
        $this->app->bind(
            \Laravel\Scout\Builder::class,
            \My\Custom\Builder::class
        );
```