### PR TITLE
[6.0] Removes elasticsearch service from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ php:
 
 sudo: false
 
-services:
-    - elasticsearch
-
 before_install:
   - phpenv config-rm xdebug.ini || true
 


### PR DESCRIPTION
This Pull Request removes the need of `elasticsearch` service from `.travis.yml`. Unless I am missing something we don't need it right?