### PR TITLE
[6.0] Use Model collection where appropriate

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -4,7 +4,6 @@ namespace Laravel\Scout;
 
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Traits\Macroable;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Pagination\LengthAwarePaginator;
 
 class Builder
@@ -267,7 +266,7 @@ class Builder
 
         $perPage = $perPage ?: $this->model->getPerPage();
 
-        $results = Collection::make($engine->map(
+        $results = $this->model->newCollection($engine->map(
             $this, $rawResults = $engine->paginate($this, $perPage, $page), $this->model
         ));
 

--- a/src/Engines/Engine.php
+++ b/src/Engines/Engine.php
@@ -3,7 +3,6 @@
 namespace Laravel\Scout\Engines;
 
 use Laravel\Scout\Builder;
-use Illuminate\Database\Eloquent\Collection;
 
 abstract class Engine
 {
@@ -94,8 +93,8 @@ abstract class Engine
      */
     public function get(Builder $builder)
     {
-        return Collection::make($this->map(
+        return $this->map(
             $builder, $this->search($builder), $builder->model
-        ));
+        );
     }
 }

--- a/src/Engines/NullEngine.php
+++ b/src/Engines/NullEngine.php
@@ -4,6 +4,7 @@ namespace Laravel\Scout\Engines;
 
 use Laravel\Scout\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection as BaseCollection;
 
 class NullEngine extends Engine
 {
@@ -61,7 +62,7 @@ class NullEngine extends Engine
      */
     public function mapIds($results)
     {
-        return Collection::make();
+        return BaseCollection::make();
     }
 
     /**

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -3,7 +3,6 @@
 namespace Laravel\Scout;
 
 use Laravel\Scout\Jobs\MakeSearchable;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection as BaseCollection;
 
@@ -137,7 +136,7 @@ trait Searchable
      */
     public function searchable()
     {
-        Collection::make([$this])->searchable();
+        $this->newCollection([$this])->searchable();
     }
 
     /**
@@ -159,7 +158,7 @@ trait Searchable
      */
     public function unsearchable()
     {
-        Collection::make([$this])->unsearchable();
+        $this->newCollection([$this])->unsearchable();
     }
 
     /**

--- a/tests/AlgoliaEngineTest.php
+++ b/tests/AlgoliaEngineTest.php
@@ -63,7 +63,8 @@ class AlgoliaEngineTest extends TestCase
         $model = m::mock('StdClass');
         $model->shouldReceive('newQuery')->andReturn($model);
         $model->shouldReceive('getKeyName')->andReturn('id');
-        $model->shouldReceive('getScoutModelsByIds')->andReturn(Collection::make([new AlgoliaEngineTestModel]));
+        $model->shouldReceive('getScoutModelsByIds')->andReturn($models = Collection::make([new AlgoliaEngineTestModel]));
+        $model->shouldReceive('newCollection')->andReturn($models);
 
         $builder = m::mock(Builder::class);
 

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -30,8 +30,10 @@ class BuilderTest extends TestCase
         $model->shouldReceive('searchableUsing')->andReturn($engine = m::mock());
 
         $engine->shouldReceive('paginate');
-        $engine->shouldReceive('map')->andReturn(Collection::make([new stdClass]));
+        $engine->shouldReceive('map')->andReturn($results = Collection::make([new stdClass]));
         $engine->shouldReceive('getTotalCount');
+
+        $model->shouldReceive('newCollection')->andReturn($results);
 
         $builder->paginate();
     }


### PR DESCRIPTION
This way when the model's collection is overwritten it still gets applied.

Fixes https://github.com/laravel/scout/issues/188

I'm not really sure if this is *breaking* or not. It's best that @nunomaduro has a look first at this. Especially the changes on the Engine's `get` call and the `AlgoliaEngine`'s `map` call need to be reviewed a bit thoroughly.