### PR TITLE
[7.0] Allow a query scope when importing via `scout:import`

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -122,6 +122,9 @@ trait Searchable
         $softDelete = static::usesSoftDelete() && config('scout.soft_delete', false);
 
         $self->newQuery()
+            ->when(method_exists($self, 'scopeOnlySearchable'), function ($query) {
+                $query->onlySearchable();
+            })
             ->when($softDelete, function ($query) {
                 $query->withTrashed();
             })


### PR DESCRIPTION
I have a table with a few hundred thousand records, but only want to index a subset of them.

The `shouldBeSearchable` is too slow for this purpose because it iterates over each record individually after it's already fetched it. This lets you add a database query scope in your model so it's much faster.