### PR TITLE
[7.0] Remove test stub ModelStubForRemoveAllFromSearch

### DIFF
--- a/tests/SearchableTest.php
+++ b/tests/SearchableTest.php
@@ -76,21 +76,6 @@ class ModelStubForMakeAllSearchable extends SearchableTestModel
     }
 }
 
-class ModelStubForRemoveAllFromSearch extends SearchableTestModel
-{
-    public function newQuery()
-    {
-        $mock = \Mockery::mock('Illuminate\Database\Eloquent\Builder');
-
-        $mock->shouldReceive('orderBy')
-            ->with('id')
-            ->andReturnSelf()
-            ->shouldReceive('unsearchable');
-
-        return $mock;
-    }
-}
-
 namespace Laravel\Scout;
 
 function config($arg)


### PR DESCRIPTION
This was added in #105 but wasn't used then and is still not being used.