### PR TITLE
[7.0] DRY queueMakeSearchable. Remove return statement in queueMakeSearchable

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -60,7 +60,7 @@ trait Searchable
         }
 
         if (! config('scout.queue')) {
-            return $models->first()->searchableUsing()->update($models);
+            dispatch_now(new MakeSearchable($models));
         }
 
         dispatch((new MakeSearchable($models))


### PR DESCRIPTION
We have duplicated code in queueMakeSearchable and MakeSearchable. Also, queueMakeSearchable declared 'void' so it must not return a value