### PR TITLE
[8.0] Rename and change queueMakeSearchable and queueRemoveFromSearch. Add RemoveFromSearch job

### DIFF
--- a/src/Jobs/RemoveFromSearch.php
+++ b/src/Jobs/RemoveFromSearch.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Laravel\Scout\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class RemoveFromSearch implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * The models to be made searchable.
+     *
+     * @var \Illuminate\Database\Eloquent\Collection
+     */
+    public $models;
+
+    /**
+     * Create a new job instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @return void
+     */
+    public function __construct($models)
+    {
+        $this->models = $models;
+    }
+
+    /**
+     * Handle the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (count($this->models) === 0) {
+            return;
+        }
+
+        $this->models->first()->searchableUsing()->delete($this->models);
+    }
+}

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -60,7 +60,7 @@ trait Searchable
         }
 
         if (! config('scout.queue')) {
-            return $models->first()->searchableUsing()->update($models);
+            dispatch_now(new MakeSearchable($models));
         }
 
         dispatch((new MakeSearchable($models))

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -61,11 +61,11 @@ trait Searchable
 
         if (! config('scout.queue')) {
             dispatch_now(new MakeSearchable($models));
+        } else {
+            dispatch((new MakeSearchable($models))
+            ->onQueue($models->first()->syncWithSearchUsingQueue())
+            ->onConnection($models->first()->syncWithSearchUsing()));
         }
-
-        dispatch((new MakeSearchable($models))
-                ->onQueue($models->first()->syncWithSearchUsingQueue())
-                ->onConnection($models->first()->syncWithSearchUsing()));
     }
 
     /**

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -41,12 +41,11 @@ trait Searchable
     {
         $self = $this;
         BaseCollection::macro('searchable', function ($dispatcher) use ($self) {
-            $self->dispatchMakeSearchable(app(Dispatcher::class), $this, config('scout.queue'));
+            $self->dispatchMakeSearchable(app(Dispatcher::class), $this, !config('scout.queue'));
         });
 
         BaseCollection::macro('unsearchable', function () use ($self) {
-
-            $self->dispatchRemoveFromSearch(app(Dispatcher::class), $this, config('scout.queue'));
+            $self->dispatchRemoveFromSearch(app(Dispatcher::class), $this, !config('scout.queue'));
         });
     }
 

--- a/tests/RemoveFromSearchTest.php
+++ b/tests/RemoveFromSearchTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Laravel\Scout\Tests;
+
+use Laravel\Scout\Jobs\RemoveFromSearch;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Eloquent\Collection;
+
+class RemoveFromSearchTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function test_handle_passes_the_collection_to_engine()
+    {
+        $job = new RemoveFromSearch($collection = Collection::make([
+            $model = m::mock(),
+        ]));
+
+        $model->shouldReceive('searchableUsing->delete')->with($collection);
+
+        $job->handle();
+    }
+}

--- a/tests/SearchableTest.php
+++ b/tests/SearchableTest.php
@@ -2,6 +2,10 @@
 
 namespace Laravel\Scout\Tests;
 
+use Illuminate\Contracts\Bus\Dispatcher;
+use Illuminate\Support\Facades\Queue;
+use Laravel\Scout\Jobs\MakeSearchable;
+use Laravel\Scout\Jobs\RemoveFromSearch;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Laravel\Scout\Tests\Fixtures\SearchableTestModel;
@@ -13,44 +17,80 @@ class SearchableTest extends TestCase
         m::close();
     }
 
-    public function test_searchable_using_update_is_called_on_collection()
+    public function test_searchable_make_searchable_dispatched_immediately_if_now_is_true()
     {
-        $collection = m::mock();
-        $collection->shouldReceive('isEmpty')->andReturn(false);
-        $collection->shouldReceive('first->searchableUsing->update')->with($collection);
-
         $model = new SearchableTestModel;
-        $model->queueMakeSearchable($collection);
+
+        $collection = $model->newCollection([$model]);
+
+        $dispatcher = m::mock(Dispatcher::class);
+        $dispatcher->shouldReceive('dispatchNow')->withArgs(function ($arg) use($collection){
+            if ($arg->models === $collection && $arg instanceof MakeSearchable) {
+                return true;
+            }
+            return false;
+        });
+
+        $now = true;
+
+        $model->dispatchMakeSearchable($dispatcher, $collection, $now);
     }
 
-    public function test_searchable_using_update_is_not_called_on_empty_collection()
+    public function test_searchable_make_searchable_dispatched_in_queue_if_now_is_false()
     {
-        $collection = m::mock();
-        $collection->shouldReceive('isEmpty')->andReturn(true);
-        $collection->shouldNotReceive('first->searchableUsing->update');
-
         $model = new SearchableTestModel;
-        $model->queueMakeSearchable($collection);
+
+        $collection = $model->newCollection([$model]);
+
+        $dispatcher = m::mock(Dispatcher::class);
+        $dispatcher->shouldReceive('dispatch')->withArgs(function ($arg) use($collection){
+            if ($arg->models === $collection && $arg instanceof MakeSearchable) {
+                return true;
+            }
+            return false;
+        });
+
+        $now = false;
+
+        $model->dispatchMakeSearchable($dispatcher, $collection, $now);
     }
 
-    public function test_searchable_using_delete_is_called_on_collection()
+    public function test_searchable_remove_from_search_dispatched_immediately_if_now_is_true()
     {
-        $collection = m::mock();
-        $collection->shouldReceive('isEmpty')->andReturn(false);
-        $collection->shouldReceive('first->searchableUsing->delete')->with($collection);
-
         $model = new SearchableTestModel;
-        $model->queueRemoveFromSearch($collection);
+
+        $collection = $model->newCollection([$model]);
+
+        $dispatcher = m::mock(Dispatcher::class);
+        $dispatcher->shouldReceive('dispatchNow')->withArgs(function ($arg) use($collection){
+            if ($arg->models === $collection && $arg instanceof RemoveFromSearch) {
+                return true;
+            }
+            return false;
+        });
+
+        $now = true;
+
+        $model->dispatchRemoveFromSearch($dispatcher, $collection, $now);
     }
 
-    public function test_searchable_using_delete_is_not_called_on_empty_collection()
+    public function test_searchable_remove_from_search_dispatched_in_queue_if_now_is_false()
     {
-        $collection = m::mock();
-        $collection->shouldReceive('isEmpty')->andReturn(true);
-        $collection->shouldNotReceive('first->searchableUsing->delete');
-
         $model = new SearchableTestModel;
-        $model->queueRemoveFromSearch($collection);
+
+        $collection = $model->newCollection([$model]);
+
+        $dispatcher = m::mock(Dispatcher::class);
+        $dispatcher->shouldReceive('dispatch')->withArgs(function ($arg) use($collection){
+            if ($arg->models === $collection && $arg instanceof RemoveFromSearch) {
+                return true;
+            }
+            return false;
+        });
+
+        $now = false;
+
+        $model->dispatchRemoveFromSearch($dispatcher, $collection, $now);
     }
 
     public function test_make_all_searchable_uses_order_by()


### PR DESCRIPTION
queueMakeSearchable has code duplication with MakeSearchable job
queueMakeSearchable must not return value as it declared as void
queueRemoveFromSearch and queueMakeSearchable renamed because it dispatches job but doesn't push it to queue if scout.queue is false
I can't write tests for the methods because package don't have 'config' 'dispatch' and 'dispatch_now' helpers so I should change signatures of  queueMakeSearchable and queueRemoveFromSearch methods and pass dependencies as arguments
Added RemoveFromSearch job
ifEmpty check on collection removed because of it duplicated in MakeSearchable and RemoveFromSearch jobs