### PR TITLE
[8.0] Use chunkById instead of chunk

### DIFF
--- a/src/SearchableScope.php
+++ b/src/SearchableScope.php
@@ -31,7 +31,7 @@ class SearchableScope implements Scope
     public function extend(EloquentBuilder $builder)
     {
         $builder->macro('searchable', function (EloquentBuilder $builder, $chunk = null) {
-            $builder->chunk($chunk ?: config('scout.chunk.searchable', 500), function ($models) {
+            $builder->chunkById($chunk ?: config('scout.chunk.searchable', 500), function ($models) {
                 $models->filter->shouldBeSearchable()->searchable();
 
                 event(new ModelsImported($models));
@@ -39,7 +39,7 @@ class SearchableScope implements Scope
         });
 
         $builder->macro('unsearchable', function (EloquentBuilder $builder, $chunk = null) {
-            $builder->chunk($chunk ?: config('scout.chunk.unsearchable', 500), function ($models) {
+            $builder->chunkById($chunk ?: config('scout.chunk.unsearchable', 500), function ($models) {
                 $models->unsearchable();
 
                 event(new ModelsFlushed($models));

--- a/tests/SearchableScopeTest.php
+++ b/tests/SearchableScopeTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Laravel\Scout\Tests;
+
+use Illuminate\Database\Eloquent\Builder;
+use Laravel\Scout\SearchableScope;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class SearchableScopeTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function test_chunks_by_id()
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('macro')->with('searchable', m::on(function ($callback) use ($builder) {
+            $builder->shouldReceive('chunkById')->with(500, m::type(\Closure::class));
+            $callback($builder, 500);
+            return true;
+        }));
+        $builder->shouldReceive('macro')->with('unsearchable', m::on(function ($callback) use ($builder) {
+            $builder->shouldReceive('chunkById')->with(500, m::type(\Closure::class));
+            $callback($builder, 500);
+            return true;
+        }));
+
+        (new SearchableScope())->extend($builder);
+    }
+}


### PR DESCRIPTION
Using chunkById is dramatically faster when importing millions of rows.  This issue was originally reported in #182.

On a table with 1,632,576 rows, using the null scout driver so we don't have any noise from HTTP requests, an import goes from 29 minutes and 57 seconds to 28 seconds.

Before:

```
$ time php artisan scout:import "App\User"
All [App\User] records have been imported.
php artisan scout:import "App\User"  14.80s user 3.69s system 1% cpu 29:57.14 total
```

After:

```
$ time php artisan scout:import "App\User"
php artisan scout:import "App\User"  17.18s user 4.06s system 73% cpu 28.809 total
```

Concerns:

`chunkById` currently removes all ORDER BY clauses.  If someone had called `searchable` like this it wouldn't work as expected anymore:

```php
App\Order::where('price', '>', 100)->orderBy('price')->searchable();
```

I doubt that anyone actually needs that behavior?  If they do there are a few options:

- Make this opt in with a config setting, i.e. `config('scout.chunk.by_id')`
- Make `chunkById` preserve order by clauses.  This is [explained here](https://use-the-index-luke.com/sql/partial-results/fetch-next-page) but it's a little confusing.  I've implemented this before for a proprietary ElasticSearch indexer.  It shouldn't be too difficult to add to Eloquent.