### PR TITLE
[7.0] Fix empty update with soft delete

### DIFF
--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -33,9 +33,10 @@ class EngineManager extends Manager
 
         UserAgent::addCustomUserAgent('Laravel Scout', '7.0.0');
 
-        return new AlgoliaEngine(Algolia::create(
-            config('scout.algolia.id'), config('scout.algolia.secret')
-        ));
+        return new AlgoliaEngine(
+            Algolia::create(config('scout.algolia.id'), config('scout.algolia.secret')),
+            config('scout.soft_delete')
+        );
     }
 
     /**

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -16,14 +16,23 @@ class AlgoliaEngine extends Engine
     protected $algolia;
 
     /**
+     * Determines if soft deletes for Scout are enabled or not.
+     *
+     * @var bool
+     */
+    protected $softDelete;
+
+    /**
      * Create a new engine instance.
      *
      * @param  \Algolia\AlgoliaSearch\SearchClient  $algolia
+     * @param  bool  $softDelete
      * @return void
      */
-    public function __construct(Algolia $algolia)
+    public function __construct(Algolia $algolia, $softDelete = false)
     {
         $this->algolia = $algolia;
+        $this->softDelete = $softDelete;
     }
 
     /**
@@ -41,7 +50,7 @@ class AlgoliaEngine extends Engine
 
         $index = $this->algolia->initIndex($models->first()->searchableAs());
 
-        if ($this->usesSoftDelete($models->first()) && config('scout.soft_delete', false)) {
+        if ($this->usesSoftDelete($models->first()) && $this->softDelete) {
             $models->each->pushSoftDeleteMetadata();
         }
 

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -55,15 +55,15 @@ class AlgoliaEngine extends Engine
         }
 
         $objects = $models->map(function ($model) {
-            $array = array_merge(
-                $model->toSearchableArray(), $model->scoutMetadata()
-            );
-
-            if (empty($array)) {
+            if (empty($searchableData = $model->toSearchableArray())) {
                 return;
             }
 
-            return array_merge(['objectID' => $model->getScoutKey()], $array);
+            return array_merge(
+                ['objectID' => $model->getScoutKey()],
+                $searchableData,
+                $model->scoutMetadata()
+            );
         })->filter()->values()->all();
 
         if (! empty($objects)) {

--- a/tests/AlgoliaEngineTest.php
+++ b/tests/AlgoliaEngineTest.php
@@ -117,4 +117,32 @@ class AlgoliaEngineTest extends TestCase
         $engine = new AlgoliaEngine($client);
         $engine->update(Collection::make([new EmptyTestModel]));
     }
+
+    public function test_update_empty_searchable_array_from_soft_deleted_model_does_not_add_objects_to_index()
+    {
+        $client = m::mock('Algolia\AlgoliaSearch\SearchClient');
+        $client->shouldReceive('initIndex')->with('table')->andReturn($index = m::mock('StdClass'));
+        $index->shouldNotReceive('saveObjects');
+
+        $engine = new AlgoliaEngine($client, true);
+        $engine->update(Collection::make([new SoftDeletedEmptySearchableModel]));
+    }
+}
+
+class SoftDeletedEmptySearchableModel extends EmptyTestModel
+{
+    public function toSearchableArray()
+    {
+        return [];
+    }
+
+    public function pushSoftDeleteMetadata()
+    {
+        //
+    }
+
+    public function scoutMetadata()
+    {
+        return ['__soft_deleted' => 1];
+    }
 }


### PR DESCRIPTION
When skipping records during updates on Algolia items, we should ignore any metadata as this shouldn't be a factor on wether to index or not. Only records which have at least one key value pair for indexing should be indexed.
    
This fixes a bug where empty records with soft deleted enabled were still being updated. Fixes https://github.com/laravel/scout/issues/350