### PR TITLE
[7.0] Calling values() on sorted collection to reset the array keys.

### DIFF
--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -191,7 +191,7 @@ class AlgoliaEngine extends Engine
                 return in_array($model->getScoutKey(), $objectIds);
             })->sortBy(function($model) use ($objectIdPositions) {
                 return $objectIdPositions[$model->getScoutKey()];
-            });
+            })->values();
     }
 
     /**

--- a/tests/AlgoliaEngineTest.php
+++ b/tests/AlgoliaEngineTest.php
@@ -96,15 +96,16 @@ class AlgoliaEngineTest extends TestCase
             ['objectID' => 3, 'id' => 3],
         ]], $model);
 
-        // We purposely refrain from using the pluck() method below since it resets array
-        // keys which we want to preserve to test that the use of the collection as json
-        // data doesn't produce unexpected sorting. We then re-sort the array by key to
-        // simulate its use as json data.
-        $ids = $results->map->id->all();
-        ksort($ids);
+        $this->assertEquals(4, count($results));
 
-        $this->assertEquals(4, count($ids));
-        $this->assertEquals([1, 2, 4, 3], $ids);
+        // It's important we assert with array keys to ensure
+        // they have been reset after sorting.
+        $this->assertEquals([
+            0 => ['id' => 1],
+            1 => ['id' => 2],
+            2 => ['id' => 4],
+            3 => ['id' => 3],
+        ], $results->toArray());
     }
 
     public function test_a_model_is_indexed_with_a_custom_algolia_key()

--- a/tests/AlgoliaEngineTest.php
+++ b/tests/AlgoliaEngineTest.php
@@ -96,8 +96,15 @@ class AlgoliaEngineTest extends TestCase
             ['objectID' => 3, 'id' => 3],
         ]], $model);
 
-        $this->assertEquals(4, count($results));
-        $this->assertEquals([1, 2, 4, 3], $results->pluck('id')->all());
+        // We purposely refrain from using the pluck() method below since it resets array
+        // keys which we want to preserve to test that the use of the collection as json
+        // data doesn't produce unexpected sorting. We then re-sort the array by key to
+        // simulate its use as json data.
+        $ids = $results->map->id->all();
+        ksort($ids);
+
+        $this->assertEquals(4, count($ids));
+        $this->assertEquals([1, 2, 4, 3], $ids);
     }
 
     public function test_a_model_is_indexed_with_a_custom_algolia_key()


### PR DESCRIPTION
This prevents un-expected sorting when working with the json data. The tests still passed because plucking the id from the sorted collection will give you the expected sort order. Working with the data in JS, for example, will not. Not confident enough with testing to devise a test for this I'm sorry :-(
