### PR TITLE
Fixing PHPdoc referencing session driver

### DIFF
--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -68,7 +68,7 @@ class EngineManager extends Manager
     }
 
     /**
-     * Get the default session driver name.
+     * Get the default Scout driver name.
      *
      * @return string
      */


### PR DESCRIPTION
I think this is a copy/paste from https://github.com/laravel/framework/blob/e6c8aa0e39d8f91068ad1c299546536e9f25ef63/src/Illuminate/Session/SessionManager.php#L204 and is not meant to say `session` but rather `Scout`.