### PR TITLE
Add __call() method to AlgoliaEngine

### DIFF
--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -228,4 +228,16 @@ class AlgoliaEngine extends Engine
     {
         return in_array(SoftDeletes::class, class_uses_recursive($model));
     }
+    
+    /**
+     * Dynamically call the Algolia client instance.
+     *
+     * @param  string  $method
+     * @param  array   $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->algolia->$method(...$parameters);
+    }
 }

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -228,7 +228,7 @@ class AlgoliaEngine extends Engine
     {
         return in_array(SoftDeletes::class, class_uses_recursive($model));
     }
-    
+
     /**
      * Dynamically call the Algolia client instance.
      *


### PR DESCRIPTION
This allows calling methods like `multipleQueries()` on the Algolia search client easily.

I'm not sure if tests are needed for this. Please advise.

This PR allows calls like this:

```php
User::searchableUsing()->multipleQueries();

// or

app(EngineManager::class)->engine()->multipleQueries($indices);
```