### PR TITLE
[7.0] Removed legacy phpunit flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.lock
 .DS_Store
 Thumbs.db
 /phpunit.xml
+.phpunit.result.cache

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="Package Test Suite">


### PR DESCRIPTION
This **PR** will:

- Remove legacy phpunit flag,  **syntaxCheck="false"**:
    - That configuration setting has not had an effect in years. It was removed long ago.
- Ignore **.phpunit.result.cache**

**See:**
![phpunit-scout](https://user-images.githubusercontent.com/6556083/65390675-a86a7680-dd37-11e9-91b4-6d41800d4820.png)


