### PR TITLE
[7.0] Tests against Laravel 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
 env:
   matrix:
     - LARAVEL=5.5.*
+    - LARAVEL=5.6.*
     - LARAVEL=5.7.*
     - LARAVEL=5.8.*
     - LARAVEL=^6.0


### PR DESCRIPTION
Update **.travis.yml** file to run tests against Laravel **5.6** version.
