### PR TITLE
[8.x] Call values() after shouldBeSearchable()

### DIFF
--- a/src/SearchableScope.php
+++ b/src/SearchableScope.php
@@ -32,7 +32,7 @@ class SearchableScope implements Scope
     {
         $builder->macro('searchable', function (EloquentBuilder $builder, $chunk = null) {
             $builder->chunkById($chunk ?: config('scout.chunk.searchable', 500), function ($models) {
-                $models->filter->shouldBeSearchable()->searchable();
+                $models->filter->shouldBeSearchable()->values()->searchable();
 
                 event(new ModelsImported($models));
             });


### PR DESCRIPTION
If `$models->filter->shouldBeSearchable()` returns a collection that does not start on index 0 it causes error below.

![image](https://user-images.githubusercontent.com/4642044/81484544-bc51e280-920b-11ea-8a61-8911d5f6b454.png)
