### PR TITLE
[8.x] Optional param for chunk size on scout:import

### DIFF
--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -13,7 +13,9 @@ class ImportCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'scout:import {model}';
+    protected $signature = 'scout:import
+            {model : Class name of model to bulk import}
+            {--c|chunk-size= : Number of items to bulk process at a time (Defaults to config value: `scout.chunk.searchable`)}';
 
     /**
      * The console command description.
@@ -31,6 +33,7 @@ class ImportCommand extends Command
     public function handle(Dispatcher $events)
     {
         $class = $this->argument('model');
+        $chunkSize = $this->option('chunk-size');
 
         $model = new $class;
 
@@ -40,7 +43,7 @@ class ImportCommand extends Command
             $this->line('<comment>Imported ['.$class.'] models up to ID:</comment> '.$key);
         });
 
-        $model::makeAllSearchable();
+        $model::makeAllSearchable($chunkSize);
 
         $events->forget(ModelsImported::class);
 

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -113,9 +113,10 @@ trait Searchable
     /**
      * Make all instances of the model searchable.
      *
+     * @param int $chunkSize
      * @return void
      */
-    public static function makeAllSearchable()
+    public static function makeAllSearchable($chunkSize = null)
     {
         $self = new static;
 
@@ -126,7 +127,7 @@ trait Searchable
                 $query->withTrashed();
             })
             ->orderBy($self->getKeyName())
-            ->searchable();
+            ->searchable($chunkSize);
     }
 
     /**


### PR DESCRIPTION
Allow setting an optional chunk size when running a batch import.

This is particularly helpful if you'd like to index a model using a different batch size than the default set for the app.  Ideally it may be nice to customize batch sizes per model, instead of a single shared config value to be used across the entire app.

This is a functional workaround as it exposes in the CLI an already available chunk size parameter in the `Collection::serializable` extension method.

This is very useful for reducing the overhead of queries/update index calls for simpler indexable models. (For example, being able to batch 10k at a time instead of the default 500).  Same applies for potentially complex indexable items where you'd want to reduce memory overhead by indexing less than the default at a time.