### PR TITLE
[8.x] Auto identify user

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "illuminate/bus": "^6.0|^7.0",
         "illuminate/contracts": "^6.0|^7.0",
         "illuminate/database": "^6.0|^7.0",
+        "illuminate/http": "^6.0|^7.0",
         "illuminate/pagination": "^6.0|^7.0",
         "illuminate/queue": "^6.0|^7.0",
         "illuminate/support": "^6.0|^7.0"

--- a/config/scout.php
+++ b/config/scout.php
@@ -77,11 +77,11 @@ return [
     | Auto Identify User
     |--------------------------------------------------------------------------
     |
-    | This option allows to control whether to automatically
-    | identify the currently authenticated user with your
-    | search engine of choice. Disabled by default.
+    | This option allows you to control whether to automatically
+    | identify the currently authenticated user with a search
+    | search engine of choice. It is turned off by default.
     |
-    | Support engines: "algolia"
+    | Supported engines: "algolia"
     |
     */
 

--- a/config/scout.php
+++ b/config/scout.php
@@ -74,6 +74,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Auto Identify User
+    |--------------------------------------------------------------------------
+    |
+    | This option allows to control whether to automatically
+    | identify the currently authenticated user with your
+    | search engine of choice. Disabled by default.
+    |
+    | Support engines: "algolia"
+    |
+    */
+
+    'user' => env('SCOUT_USER', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Algolia Configuration
     |--------------------------------------------------------------------------
     |

--- a/config/scout.php
+++ b/config/scout.php
@@ -79,13 +79,13 @@ return [
     |
     | This option allows you to control whether to automatically
     | identify the currently authenticated user with a search
-    | search engine of choice. It is turned off by default.
+    | engine that is supported. By default it's turned off.
     |
     | Supported engines: "algolia"
     |
     */
 
-    'user' => env('SCOUT_USER', false),
+    'identify_user' => env('SCOUT_IDENTIFY_USER', false),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -6,7 +6,6 @@ use Algolia\AlgoliaSearch\Config\SearchConfig;
 use Algolia\AlgoliaSearch\SearchClient as Algolia;
 use Algolia\AlgoliaSearch\Support\UserAgent;
 use Exception;
-use Illuminate\Http\Request;
 use Illuminate\Support\Manager;
 use Laravel\Scout\Engines\AlgoliaEngine;
 use Laravel\Scout\Engines\NullEngine;
@@ -72,18 +71,20 @@ class EngineManager extends Manager
      */
     protected function defaultAlgoliaHeaders()
     {
-        if (! config('scout.user')) {
+        if (! config('scout.identify_user')) {
             return [];
         }
 
         $headers = [];
-        $request = $this->container->make(Request::class);
 
-        if (filter_var($ip = $request->ip(), FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
+        if (
+            ! config('app.debug') &&
+            filter_var($ip = request()->ip(), FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)
+        ) {
             $headers['X-Forwarded-For'] = $ip;
         }
 
-        if ($user = $request->user()) {
+        if ($user = request()->user()) {
             $headers['X-Algolia-UserToken'] = $user->getKey();
         }
 
@@ -107,10 +108,10 @@ class EngineManager extends Manager
      */
     public function getDefaultDriver()
     {
-        if (is_null($this->container['config']['scout.driver'])) {
+        if (is_null($driver = config('scout.driver'))) {
             return 'null';
         }
 
-        return $this->container['config']['scout.driver'];
+        return $driver;
     }
 }

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -66,7 +66,7 @@ class EngineManager extends Manager
     }
 
     /**
-     * Set the default an Algolia config headers.
+     * Set the default Algolia config headers.
      *
      * @return array
      */


### PR DESCRIPTION
This PR will auto set the user to be identified through Algolia through a config option. Other engines can make use of this new option as well if they want. Turned off by default to avoid breaking changes but I'd recommend to turn this on by default in the next major version.

However: I'm currently not seeing user stats appearing in the dashboard when I test:

<img width="1358" alt="Screenshot 2020-07-30 at 21 45 05" src="https://user-images.githubusercontent.com/594614/88967558-47dc8c00-d2ae-11ea-943e-d9f4e7823501.png">

Headers are being set properly and all so I don't know what I'm missing here. Need to ping @nunomaduro about it. In draft until this is resolved.

Closes https://github.com/laravel/scout/issues/385