### PR TITLE
Update builder class pagination methods to resolve LengthAwarePaginator using container

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Scout;
 
+use Illuminate\Container\Container;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Traits\Macroable;
@@ -270,10 +271,16 @@ class Builder
             $this, $rawResults = $engine->paginate($this, $perPage, $page), $this->model
         )->all());
 
-        $paginator = (new LengthAwarePaginator($results, $engine->getTotalCount($rawResults), $perPage, $page, [
-            'path' => Paginator::resolveCurrentPath(),
-            'pageName' => $pageName,
-        ]));
+        $paginator = Container::getInstance()->makeWith(LengthAwarePaginator::class, [
+            'items' => $results,
+            'total' => $engine->getTotalCount($rawResults),
+            'perPage' => $perPage,
+            'currentPage' => $page,
+            'options' => [
+                'path' => Paginator::resolveCurrentPath(),
+                'pageName' => $pageName,
+            ],
+        ]);
 
         return $paginator->appends('query', $this->query);
     }
@@ -296,10 +303,16 @@ class Builder
 
         $results = $engine->paginate($this, $perPage, $page);
 
-        $paginator = (new LengthAwarePaginator($results, $engine->getTotalCount($results), $perPage, $page, [
-            'path' => Paginator::resolveCurrentPath(),
-            'pageName' => $pageName,
-        ]));
+        $paginator = Container::getInstance()->makeWith(LengthAwarePaginator::class, [
+            'items' => $results,
+            'total' => $engine->getTotalCount($results),
+            'perPage' => $perPage,
+            'currentPage' => $page,
+            'options' => [
+                'path' => Paginator::resolveCurrentPath(),
+                'pageName' => $pageName,
+            ],
+        ]);
 
         return $paginator->appends('query', $this->query);
     }


### PR DESCRIPTION
This PR attempts to address to fix #371. The LengthAwarePaginator was being instantiated directly in the pagination methods. This solution intends to use the container to resolve that class instead. This will give other container-based configurations a chance to hook into the paginators emitted by Scout in the same way that they can hook into Paginators emitted by Eloquent.

The specific use case that leads me down this path was an observation that the following Laravel-specific code was not affecting LengthAwarePaginators from Scout.

```php
        $app->resolving(LengthAwarePaginator::class, static function (LengthAwarePaginator $paginator) {
            return $paginator->appends(request()->query());
        });

        $app->resolving(Paginator::class, static function (Paginator $paginator) {
            return $paginator->appends(request()->query());
        });
```

The test coverage for this class was pretty sparse. No existing tests break. I am happy to write some more specific tests to exercise the container work if needed.
