### PR TITLE
Improve assertions

### DIFF
--- a/tests/AlgoliaEngineTest.php
+++ b/tests/AlgoliaEngineTest.php
@@ -71,7 +71,7 @@ class AlgoliaEngineTest extends TestCase
             ['objectID' => 1, 'id' => 1],
         ]], $model);
 
-        $this->assertEquals(1, count($results));
+        $this->assertCount(1, $results);
     }
 
     public function test_map_method_respects_order()
@@ -96,7 +96,7 @@ class AlgoliaEngineTest extends TestCase
             ['objectID' => 3, 'id' => 3],
         ]], $model);
 
-        $this->assertEquals(4, count($results));
+        $this->assertCount(4, $results);
 
         // It's important we assert with array keys to ensure
         // they have been reset after sorting.

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -45,7 +45,7 @@ class BuilderTest extends TestCase
         });
 
         $builder = new Builder($model = m::mock(), 'zonda');
-        $this->assertEquals(
+        $this->assertSame(
             'bar', $builder->foo()
         );
     }
@@ -61,6 +61,6 @@ class BuilderTest extends TestCase
     {
         $builder = new Builder($model = m::mock(), 'zonda', null, true);
 
-        $this->assertEquals(0, $builder->wheres['__soft_deleted']);
+        $this->assertSame(0, $builder->wheres['__soft_deleted']);
     }
 }


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` and it can make assertion equals checking strict.
- Using the `assertCount` to assert expected is same as result count.