### PR TITLE
Add ability to eager load relations when calling scout:import

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -106,7 +106,7 @@ trait Searchable
             'model' => new static,
             'query' => $query,
             'callback' => $callback,
-            'softDelete'=> static::usesSoftDelete() && config('scout.soft_delete', false),
+            'softDelete' => static::usesSoftDelete() && config('scout.soft_delete', false),
         ]);
     }
 
@@ -123,6 +123,7 @@ trait Searchable
         $softDelete = static::usesSoftDelete() && config('scout.soft_delete', false);
 
         $self->newQuery()
+            ->with($self->searchableEagerLoads())
             ->when($softDelete, function ($query) {
                 $query->withTrashed();
             })
@@ -238,6 +239,16 @@ trait Searchable
     public function toSearchableArray()
     {
         return $this->toArray();
+    }
+
+    /**
+     * Get the relations that should be eager loaded when adding to the search index.
+     *
+     * @return array
+     */
+    public function searchableEagerLoads()
+    {
+        return [];
     }
 
     /**

--- a/tests/SearchableTest.php
+++ b/tests/SearchableTest.php
@@ -66,7 +66,10 @@ class ModelStubForMakeAllSearchable extends SearchableModel
     {
         $mock = m::mock(Builder::class);
 
-        $mock->shouldReceive('orderBy')
+        $mock->shouldReceive('with')
+            ->with([])
+            ->andReturnSelf()
+            ->shouldReceive('orderBy')
             ->with('id')
             ->andReturnSelf()
             ->shouldReceive('searchable');


### PR DESCRIPTION
When loading data into the search index using the `scout:import` command while having a `toSearchableArray()` method that includes data from relationships like so...
```php
public function toSearchableArray() {
        $data = Arr::only($this->toArray(), [
            'id', 'first_name', 'last_name', 'email', 'department'
        ]);
        $data['customer'] = optional($this->customer)->name;
        return $data;
}
```

It introduces an n+1 problem and if you have a lot of data to sync to an index can be burdensome on the database and very slow. 

This PR introduces a new method on the Searchable trait named `searchableEagerLoads()` which is called in the `makeAllSearchable` method, which is what `scout:import` uses under the hood.

Therefore, to solve the above problem, one could add this method to their model and eliminate the n+1 problem:

```php
public function searchableEagerLoads() {
     return ['customer'];
}
```

This is my first PR to a Laravel repo, so I'm open to any feedback/thoughts.