### PR TITLE
Allow ordering of import command results.

### DIFF
--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -15,7 +15,8 @@ class ImportCommand extends Command
      */
     protected $signature = 'scout:import
             {model : Class name of model to bulk import}
-            {--c|chunk= : The number of records to import at a time (Defaults to configuration value: `scout.chunk.searchable`)}';
+            {--c|chunk= : The number of records to import at a time (Defaults to configuration value: `scout.chunk.searchable`)}
+            {--sort-by= : The order to sort the results by whilst importing, defaults to ascending}';
 
     /**
      * The console command description.
@@ -42,7 +43,7 @@ class ImportCommand extends Command
             $this->line('<comment>Imported ['.$class.'] models up to ID:</comment> '.$key);
         });
 
-        $model::makeAllSearchable($this->option('chunk'));
+        $model::makeAllSearchable($this->option('chunk'), $this->option('sort-by') ?: 'asc');
 
         $events->forget(ModelsImported::class);
 

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -114,9 +114,10 @@ trait Searchable
      * Make all instances of the model searchable.
      *
      * @param  int  $chunk
+     * @param  string $sortBy
      * @return void
      */
-    public static function makeAllSearchable($chunk = null)
+    public static function makeAllSearchable($chunk = null, $sortBy = 'asc')
     {
         $self = new static;
 
@@ -129,7 +130,7 @@ trait Searchable
             ->when($softDelete, function ($query) {
                 $query->withTrashed();
             })
-            ->orderBy($self->getKeyName())
+            ->orderBy($self->getKeyName(), $sortBy)
             ->searchable($chunk);
     }
 


### PR DESCRIPTION
Allow ordering of import command results for certain search engines such as elastic search where the more recent data is more critical to import first to make a smoother transition.