### PR TITLE
Removes Algolia Dev Dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "illuminate/support": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "algolia/algoliasearch-client-php": "^2.2",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^8.0|^9.3"
     },


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR removes the Aloglia dev dependency.

I believe this is a good idea for a number of reasons:

- While many developers will be using Algolia with this package it isn't a requirement
- If the Algolia package is missing and you attempt to use the Algolia engine an exception is thrown which explains what to do. See [src/EngineManager.php#L54](https://github.com/laravel/scout/blob/8.x/src/EngineManager.php#L54)
- Having it as a dev dependency means it's possible for an application to work in a local environment where dev packages are installed but when deployed to a production environment, where dev dependencies aren't installed, it will break.
- It allows #425 to be merged