### PR TITLE
[8.x] Run observer callbacks after database transactions have committed

### DIFF
--- a/src/ModelObserver.php
+++ b/src/ModelObserver.php
@@ -7,6 +7,13 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class ModelObserver
 {
     /**
+     * Only dispatch the observer's events after all database transactions have committed.
+     *
+     * @var bool
+     */
+    public $afterCommit = true;
+
+    /**
      * The class names that syncing is disabled for.
      *
      * @var array


### PR DESCRIPTION
This PR sets `public $afterCommit = true` on Scout's `ModelObserver` class, so that the `saved`, `deleted`, `forceDeleted`, and `restored` model event callbacks, if they are triggered inside a database transaction, are not executed until that transaction has committed.

**Background**

This fixes an existing issue where incorrect data is synced to a search index if a model event Scout listens for, such as `saved`, is fired inside a database transaction.

If Scout is not set up to queue search index updates, this issue affects all code that fires the above model events inside database transactions, because Scout's observer method is executed immediately—before the transaction has committed or been rolled back—syncing stale or invalid data.

If Scout _is_ set up to use the queue this issue will appear intermittently, when the queue workers pick up and execute the syncing job before the transaction has committed or rolled back. In my experience this happens almost all the time.

See #152 and laravel/nova-issues#1906.

It wasn't really possible to address this at all up until now, but transaction-aware code execution was just added to Laravel core (see laravel/framework#35373 and laravel/framework#35434). In Laravel 8.17.0 and later, it's trivial to delay any listeners and observers until open database transactions have committed.

**Backwards compatibility**

Theoretically this could change some behaviour in existing Scout installations, but I would argue that that behaviour is a bug and should be fixed. I can't imagine a situation where an application would be relying on stale or invalid data being persisted to a search index, so I doubt this change would break anything.

**Tests**

Since model observers are basically just larger listener classes, in my opinion this PR is covered by Laravel's tests for delaying listener execution until transactions have committed: https://github.com/laravel/framework/blob/8.x/tests/Integration/Events/ListenerTest.php.