### PR TITLE
[8.x] Revert "[8.x] Run observer callbacks after database transactions have committed"

### DIFF
--- a/src/ModelObserver.php
+++ b/src/ModelObserver.php
@@ -7,13 +7,6 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class ModelObserver
 {
     /**
-     * Only dispatch the observer's events after all database transactions have committed.
-     *
-     * @var bool
-     */
-    public $afterCommit = true;
-
-    /**
      * The class names that syncing is disabled for.
      *
      * @var array


### PR DESCRIPTION
Reverts laravel/scout#436

I'm reverting this because this causes test suites that have the `DatabaseTransactions` trait applied to fail.

Fixes https://github.com/laravel/scout/issues/437