### PR TITLE
[9.x] Add support for cursor and LazyCollection on scout.

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -252,6 +252,16 @@ class Builder
     }
 
     /**
+     * Get a lazy collection of the search.
+     *
+     * @return \Illuminate\Support\LazyCollection
+     */
+    public function cursor()
+    {
+        return $this->engine()->cursor($this);
+    }
+
+    /**
      * Paginate the given query into a simple paginator.
      *
      * @param  int  $perPage

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -179,6 +179,19 @@ class AlgoliaEngine extends Engine
      */
     public function map(Builder $builder, $results, $model)
     {
+        return $this->lazyMap($builder, $results, $model)->collect();
+    }
+
+    /**
+     * Lazy-Map the given results to instances of the given model.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  mixed  $results
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Support\LazyCollection
+     */
+    public function lazyMap(Builder $builder, $results, $model)
+    {
         if (count($results['hits']) === 0) {
             return $model->newCollection();
         }
@@ -186,9 +199,9 @@ class AlgoliaEngine extends Engine
         $objectIds = collect($results['hits'])->pluck('objectID')->values()->all();
         $objectIdPositions = array_flip($objectIds);
 
-        return $model->getScoutModelsByIds(
+        return $model->queryScoutModelsByIds(
                 $builder, $objectIds
-            )->filter(function ($model) use ($objectIds) {
+            )->cursor()->filter(function ($model) use ($objectIds) {
                 return in_array($model->getScoutKey(), $objectIds);
             })->sortBy(function ($model) use ($objectIdPositions) {
                 return $objectIdPositions[$model->getScoutKey()];

--- a/src/Engines/Engine.php
+++ b/src/Engines/Engine.php
@@ -59,6 +59,16 @@ abstract class Engine
     abstract public function map(Builder $builder, $results, $model);
 
     /**
+     * Lazy-Map the given results to instances of the given model.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  mixed  $results
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Support\LazyCollection
+     */
+    abstract public function lazyMap(Builder $builder, $results, $model);
+
+    /**
      * Get the total count from a raw result returned by the engine.
      *
      * @param  mixed  $results
@@ -92,6 +102,19 @@ abstract class Engine
      * @return \Illuminate\Database\Eloquent\Collection
      */
     public function get(Builder $builder)
+    {
+        return $this->map(
+            $builder, $this->search($builder), $builder->model
+        );
+    }
+
+    /**
+     * Get a lazy collection for the given query mapped onto models.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function cursor(Builder $builder)
     {
         return $this->map(
             $builder, $this->search($builder), $builder->model

--- a/src/Engines/NullEngine.php
+++ b/src/Engines/NullEngine.php
@@ -4,6 +4,7 @@ namespace Laravel\Scout\Engines;
 
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;
 
 class NullEngine extends Engine
@@ -76,6 +77,19 @@ class NullEngine extends Engine
     public function map(Builder $builder, $results, $model)
     {
         return Collection::make();
+    }
+
+    /**
+     * Map the given results to instances of the given model.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  mixed  $results
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function lazyMap(Builder $builder, $results, $model)
+    {
+        return LazyCollection::make();
     }
 
     /**

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -185,6 +185,18 @@ trait Searchable
      */
     public function getScoutModelsByIds(Builder $builder, array $ids)
     {
+        return $this->queryScoutModelsByIds($builder, $ids)->get();
+    }
+
+    /**
+     * Get the requested models from an array of object IDs.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  array  $ids
+     * @return mixed
+     */
+    public function queryScoutModelsByIds(Builder $builder, array $ids)
+    {
         $query = static::usesSoftDelete()
             ? $this->withTrashed() : $this->newQuery();
 
@@ -194,7 +206,7 @@ trait Searchable
 
         return $query->whereIn(
             $this->getScoutKeyName(), $ids
-        )->get();
+        );
     }
 
     /**

--- a/tests/AlgoliaEngineTest.php
+++ b/tests/AlgoliaEngineTest.php
@@ -4,6 +4,7 @@ namespace Laravel\Scout\Tests;
 
 use Algolia\AlgoliaSearch\SearchClient;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\AlgoliaEngine;
 use Laravel\Scout\Tests\Fixtures\SearchableModel;
@@ -61,9 +62,9 @@ class AlgoliaEngineTest extends TestCase
         $engine = new AlgoliaEngine($client);
 
         $model = m::mock(stdClass::class);
-        $model->shouldReceive('getScoutModelsByIds')->andReturn($models = Collection::make([
+        $model->shouldReceive('queryScoutModelsByIds->cursor')->andReturn(new LazyCollection($models = Collection::make([
             new SearchableModel(['id' => 1]),
-        ]));
+        ])));
 
         $builder = m::mock(Builder::class);
 
@@ -80,12 +81,12 @@ class AlgoliaEngineTest extends TestCase
         $engine = new AlgoliaEngine($client);
 
         $model = m::mock(stdClass::class);
-        $model->shouldReceive('getScoutModelsByIds')->andReturn($models = Collection::make([
+        $model->shouldReceive('queryScoutModelsByIds->cursor')->andReturn(new LazyCollection($models = Collection::make([
             new SearchableModel(['id' => 1]),
             new SearchableModel(['id' => 2]),
             new SearchableModel(['id' => 3]),
             new SearchableModel(['id' => 4]),
-        ]));
+        ])));
 
         $builder = m::mock(Builder::class);
 


### PR DESCRIPTION
At the moment Laravel Scout doesn't utilised `cursor` or `LazyCollection` which could be useful when searching large set of data. This PR bring the ability to use `get()` or `cursor()` from Eloquent query builder whenever possible.

* Add `Laravel\Scout\Searchable::queryScoutModelsByIds()` to return `Illuminate\Database\Query\Builder`.
* Add `Laravel\Scout\Builder::cursor()` to return results as `LazyCollection`
* Add `Laravel\Scout\Engines\Engine::lazyMap()` to map to `LazyCollection`

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
