### PR TITLE
[8.x] Allow running observer callbacks after database transactions have committed

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -45,6 +45,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Database Transactions
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to control if the operations that sync your
+    | data with your search engines are only executed afterall open
+    | database transactions have committed.
+    |
+    */
+
+    'after_commit' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Chunk Sizes
     |--------------------------------------------------------------------------
     |

--- a/src/ModelObserver.php
+++ b/src/ModelObserver.php
@@ -7,11 +7,28 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class ModelObserver
 {
     /**
+     * Only dispatch the observer's events after all database transactions have committed.
+     *
+     * @var bool
+     */
+    public $afterCommit;
+
+    /**
      * The class names that syncing is disabled for.
      *
      * @var array
      */
     protected static $syncingDisabledFor = [];
+
+    /**
+     * Create a new observer instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->afterCommit = config('scout.after_commit', false);
+    }
 
     /**
      * Enable syncing for the given class.


### PR DESCRIPTION
This PR re-implements #436 but makes it configurable. I added `$afterCommit` to Scout's `ModelObserver` again, but this time instead of setting it to `true` I set it based on a new config file entry called `after_commit`.

Since this PR defaults these values to `false`, this approach is completely backwards-compatible with all existing Scout installs, in application _and_ test code. I'm targeting the `8.x` branch so that apps that need it can start using this functionality immediately, and I'll submit another PR to `master` to turn it on by default in the next major version of Scout.

Closes #437.

**Alternatives**

I'm sure there are other ways to tackle this, and I'm happy to explore them, but this seemed like the simplest by far. Two other ideas I played with briefly:
- Adding an `afterCommit` _method_ to the `ModelObserver`, and updating Laravel's event dispatcher to look for that method and allow it to override the property when present. This pattern feels familiar to me, in line with things like the `shouldDiscoverEvents` method in the `EventServiceProvider`, but it could get confusing because in other places (queue-related) there are `afterCommit` methods that explicitly set it to `true` and don't allow the logic to be customized. This approach would also still require a config option, because users still wouldn't be able to override the method.
- Making `$afterCommit` static, which would allow it to be overridden globally for a specific listener/observer, for example in a service provider or base test case. This is powerful and simple but feels hacky.