### PR TITLE
[8.x] Use the Config facade instead

### DIFF
--- a/src/ModelObserver.php
+++ b/src/ModelObserver.php
@@ -3,6 +3,7 @@
 namespace Laravel\Scout;
 
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Config;
 
 class ModelObserver
 {
@@ -27,7 +28,7 @@ class ModelObserver
      */
     public function __construct()
     {
-        $this->afterCommit = config('scout.after_commit', false);
+        $this->afterCommit = Config::get('scout.after_commit', false);
     }
 
     /**

--- a/tests/AlgoliaEngineTest.php
+++ b/tests/AlgoliaEngineTest.php
@@ -4,6 +4,7 @@ namespace Laravel\Scout\Tests;
 
 use Algolia\AlgoliaSearch\SearchClient;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Config;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\AlgoliaEngine;
 use Laravel\Scout\Tests\Fixtures\SearchableModel;
@@ -13,6 +14,11 @@ use stdClass;
 
 class AlgoliaEngineTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Config::shouldReceive('get')->with('scout.after_commit', m::any())->andReturn(false);
+    }
+
     protected function tearDown(): void
     {
         m::close();

--- a/tests/ModelObserverTest.php
+++ b/tests/ModelObserverTest.php
@@ -2,12 +2,18 @@
 
 namespace Laravel\Scout\Tests;
 
+use Illuminate\Support\Facades\Config;
 use Laravel\Scout\ModelObserver;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
 class ModelObserverTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Config::shouldReceive('get')->with('scout.after_commit', m::any())->andReturn(false);
+    }
+
     protected function tearDown(): void
     {
         m::close();


### PR DESCRIPTION
## Description

This PR replaces the use of the `config()` helper to retrieve the `after_commit` value when creating the `ModelObserver`.

The reason why we would want to have this change is, we would be able to mock the configuration object when `not` extending the application within unit tests.

As these changes stand by now, they break all tests that call/create `models` using the `searchable` trait when extending the PHPUnit tests case class `[PHPUnit\Framework\TestCase]`.

Even though it is known we could use these helpers and we should be extending the framework test case class to work on apps tests, they are not resolved if the Laravel app is not present (in the unit context).

Reference: https://github.com/laravel/scout/pull/440

Thank you.  
