### PR TITLE
[8.x] Add option to disable global query scopes

### DIFF
--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -15,7 +15,8 @@ class ImportCommand extends Command
      */
     protected $signature = 'scout:import
             {model : Class name of model to bulk import}
-            {--c|chunk= : The number of records to import at a time (Defaults to configuration value: `scout.chunk.searchable`)}';
+            {--c|chunk= : The number of records to import at a time (Defaults to configuration value: `scout.chunk.searchable`)}
+            {--disable-scopes : Disables all global scopes for the model while fetching entities to index}';
 
     /**
      * The console command description.
@@ -42,7 +43,7 @@ class ImportCommand extends Command
             $this->line('<comment>Imported ['.$class.'] models up to ID:</comment> '.$key);
         });
 
-        $model::makeAllSearchable($this->option('chunk'));
+        $model::makeAllSearchable($this->option('chunk'), $this->option('disable-scopes'));
 
         $events->forget(ModelsImported::class);
 

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -114,17 +114,20 @@ trait Searchable
      * Make all instances of the model searchable.
      *
      * @param  int  $chunk
+     * @param  bool $disableGlobalScopes
      * @return void
      */
-    public static function makeAllSearchable($chunk = null)
+    public static function makeAllSearchable($chunk = null, $disableGlobalScopes = null)
     {
         $self = new static;
 
         $softDelete = static::usesSoftDelete() && config('scout.soft_delete', false);
 
         $self->newQuery()
-            ->when(true, function ($query) use ($self) {
-                $self->makeAllSearchableUsing($query);
+            ->when(true, function ($query) use ($self, $disableGlobalScopes) {
+                $self->makeAllSearchableUsing(
+                    $disableGlobalScopes ? $query->withoutGlobalScopes() : $query
+                );
             })
             ->when($softDelete, function ($query) {
                 $query->withTrashed();


### PR DESCRIPTION
Initial problem: while using Scout's import command, Scout received only a fraction of model entries from the database because I have a global query scope defined.

This pull requests includes two changes:
- The `makeAllSearchable()` function in the `Searchable` trait now accepts a second option `$disableGlobalScopes`, that disables global query scopes using the withoutGlobalScopes() function.
- The import command accepts a new `--disable-scopes` option, which passes the option to the makeAllSearchable() function mentioned above.

I tested this feature with both the Algolia and the TNT Search driver. In both cases all model entries were successfully imported.