### PR TITLE
[9.x] Correct meilisearch config reference

### DIFF
--- a/src/ScoutServiceProvider.php
+++ b/src/ScoutServiceProvider.php
@@ -20,7 +20,7 @@ class ScoutServiceProvider extends ServiceProvider
 
         if (class_exists(MeiliSearch::class)) {
             $this->app->singleton(MeiliSearch::class, function ($app) {
-                $config = $app['config']['meilisearch'];
+                $config = $app['config']['scout']['meilisearch'];
 
                 return new MeiliSearch($config['host'], $config['key']);
             });

--- a/src/ScoutServiceProvider.php
+++ b/src/ScoutServiceProvider.php
@@ -20,7 +20,7 @@ class ScoutServiceProvider extends ServiceProvider
 
         if (class_exists(MeiliSearch::class)) {
             $this->app->singleton(MeiliSearch::class, function ($app) {
-                $config = $app['config']['scout']['meilisearch'];
+                $config = $app['config']->get('scout.meilisearch');
 
                 return new MeiliSearch($config['host'], $config['key']);
             });


### PR DESCRIPTION

### Description:

The meilisearch config is pulled like so:

https://github.com/laravel/scout/blob/13968539d7757ca662942a50983165d18d195dc3/src/ScoutServiceProvider.php#L22-L26

However, when trying to use this, it errors:

```php
php artisan scout:import App\\Models\\Model
[2021-04-06 02:48:37] local.ERROR: Trying to access array offset on value of type null {"exception":"[object] (ErrorException(code: 0): Trying to access array offset on value of type null at /application/vendor/laravel/scout/src/ScoutServiceProvider.php:25)
```

This is due to `$app['config']['meilisearch']` not existing; rather, it is available via `$app['config']['scout']['meilisearch']`. and changing line 23 fixes this error.
