### PR TITLE
[9.x] Meilisearch index command

### DIFF
--- a/src/Console/IndexCommand.php
+++ b/src/Console/IndexCommand.php
@@ -39,7 +39,7 @@ class IndexCommand extends Command
             if ($this->option('delete')) {
                 $engine->deleteIndex($this->argument('name'));
 
-                $this->info('Index "' . $this->argument('name') . '" deleted.');
+                $this->info('Index "'.$this->argument('name').'" deleted.');
 
                 return;
             }
@@ -52,7 +52,7 @@ class IndexCommand extends Command
 
             $engine->createIndex($this->argument('name'), $options);
 
-            $this->info('Index "' . $this->argument('name') . '" created.');
+            $this->info('Index "'.$this->argument('name').'" created.');
         } catch (Exception $exception) {
             $this->error($exception->getMessage());
         }

--- a/src/Console/IndexCommand.php
+++ b/src/Console/IndexCommand.php
@@ -2,9 +2,9 @@
 
 namespace Laravel\Scout\Console;
 
+use Exception;
 use Illuminate\Console\Command;
-use MeiliSearch\Client;
-use MeiliSearch\Exceptions\ApiException;
+use Laravel\Scout\EngineManager;
 
 class IndexCommand extends Command
 {
@@ -14,9 +14,9 @@ class IndexCommand extends Command
      * @var string
      */
     protected $signature = 'scout:index
+            {name : The name of the index}
             {--d|delete : Delete an existing index}
-            {--k|key= : The name of primary key}
-            {name : The name of the index}';
+            {--k|key= : The name of primary key}';
 
     /**
      * The console command description.
@@ -28,16 +28,18 @@ class IndexCommand extends Command
     /**
      * Execute the console command.
      *
-     * @param  \MeiliSearch\Client  $client
+     * @param  \Laravel\Scout\EngineManager  $manager
      * @return void
      */
-    public function handle(Client $client)
+    public function handle(EngineManager $manager)
     {
+        $engine = $manager->engine();
+
         try {
             if ($this->option('delete')) {
-                $client->deleteIndex($this->argument('name'));
+                $engine->deleteIndex($this->argument('name'));
 
-                $this->info('Index "'.$this->argument('name').'" deleted.');
+                $this->info('Index "' . $this->argument('name') . '" deleted.');
 
                 return;
             }
@@ -48,10 +50,10 @@ class IndexCommand extends Command
                 $options = ['primaryKey' => $this->option('key')];
             }
 
-            $client->createIndex($this->argument('name'), $options);
+            $engine->createIndex($this->argument('name'), $options);
 
-            $this->info('Index "'.$this->argument('name').'" created.');
-        } catch (ApiException $exception) {
+            $this->info('Index "' . $this->argument('name') . '" created.');
+        } catch (Exception $exception) {
             $this->error($exception->getMessage());
         }
     }

--- a/src/Console/IndexCommand.php
+++ b/src/Console/IndexCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Laravel\Scout\Console;
+
+use Illuminate\Console\Command;
+use MeiliSearch\Client;
+use MeiliSearch\Exceptions\ApiException;
+
+class IndexCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'scout:index
+            {--d|delete : Delete an existing index}
+            {--k|key= : The name of primary key}
+            {name : The name of the index}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create or delete an index';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \MeiliSearch\Client  $client
+     * @return void
+     */
+    public function handle(Client $client)
+    {
+        try {
+            if ($this->option('delete')) {
+                $client->deleteIndex($this->argument('name'));
+
+                $this->info('Index "'.$this->argument('name').'" deleted.');
+
+                return;
+            }
+
+            $options = [];
+
+            if ($this->option('key')) {
+                $options = ['primaryKey' => $this->option('key')];
+            }
+
+            $client->createIndex($this->argument('name'), $options);
+
+            $this->info('Index "'.$this->argument('name').'" created.');
+        } catch (ApiException $exception) {
+            $this->error($exception->getMessage());
+        }
+    }
+}

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -18,7 +18,7 @@ class EngineManager extends Manager
      * Get a driver instance.
      *
      * @param  string|null  $name
-     * @return mixed
+     * @return \Laravel\Scout\Engines\Engine
      */
     public function engine($name = null)
     {

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -3,6 +3,7 @@
 namespace Laravel\Scout\Engines;
 
 use Algolia\AlgoliaSearch\SearchClient as Algolia;
+use Exception;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Laravel\Scout\Builder;
 
@@ -230,6 +231,31 @@ class AlgoliaEngine extends Engine
         $index = $this->algolia->initIndex($model->searchableAs());
 
         $index->clearObjects();
+    }
+
+    /**
+     * Create a search index.
+     *
+     * @param  string  $name
+     * @param  array  $options
+     * @return mixed
+     *
+     * @throws \Exception
+     */
+    public function createIndex($name, array $options = [])
+    {
+        throw new Exception('Algolia indexes are created automatically upon adding objects.');
+    }
+
+    /**
+     * Delete a search index.
+     *
+     * @param  string  $name
+     * @return mixed
+     */
+    public function deleteIndex($name)
+    {
+        return $this->algolia->initIndex($name)->delete();
     }
 
     /**

--- a/src/Engines/Engine.php
+++ b/src/Engines/Engine.php
@@ -85,6 +85,23 @@ abstract class Engine
     abstract public function flush($model);
 
     /**
+     * Create a search index.
+     *
+     * @param  string  $name
+     * @param  array  $options
+     * @return mixed
+     */
+    abstract public function createIndex($name, array $options = []);
+
+    /**
+     * Delete a search index.
+     *
+     * @param  string  $name
+     * @return mixed
+     */
+    abstract public function deleteIndex($name);
+
+    /**
      * Get the results of the query as a Collection of primary keys.
      *
      * @param  \Laravel\Scout\Builder  $builder

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -234,6 +234,33 @@ class MeiliSearchEngine extends Engine
     }
 
     /**
+     * Create a search index.
+     *
+     * @param  string  $name
+     * @param  array  $options
+     * @return mixed
+     *
+     * @throws \MeiliSearch\Exceptions\ApiException
+     */
+    public function createIndex($name, array $options = [])
+    {
+        return $this->meilisearch->createIndex($name, $options);
+    }
+
+    /**
+     * Delete a search index.
+     *
+     * @param  string  $name
+     * @return mixed
+     *
+     * @throws \MeiliSearch\Exceptions\ApiException
+     */
+    public function deleteIndex($name)
+    {
+        return $this->meilisearch->deleteIndex($name);
+    }
+
+    /**
      * Determine if the given model uses soft deletes.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model

--- a/src/ScoutServiceProvider.php
+++ b/src/ScoutServiceProvider.php
@@ -5,6 +5,7 @@ namespace Laravel\Scout;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Scout\Console\FlushCommand;
 use Laravel\Scout\Console\ImportCommand;
+use Laravel\Scout\Console\IndexCommand;
 use MeiliSearch\Client as MeiliSearch;
 
 class ScoutServiceProvider extends ServiceProvider
@@ -40,8 +41,9 @@ class ScoutServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->commands([
-                ImportCommand::class,
                 FlushCommand::class,
+                ImportCommand::class,
+                IndexCommand::class,
             ]);
 
             $this->publishes([


### PR DESCRIPTION
Ports over the `IndexCommand` from Meilisearch which is pretty handy for managing your indexes. I've also implemented a generic way so it works for all engines.