### PR TITLE
[9.x] Drop old Laravel versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0]
-        laravel: [^6.0, ^7.0, ^8.0]
-        exclude:
-          - php: 7.2
-            laravel: ^8.0
+        php: [7.3, 7.4, 8.0]
+        laravel: [^8.0]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -14,19 +14,19 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
-        "illuminate/bus": "^6.0|^7.0|^8.0",
-        "illuminate/contracts": "^6.0|^7.0|^8.0",
-        "illuminate/database": "^6.0|^7.0|^8.0",
-        "illuminate/http": "^6.0|^7.0|^8.0",
-        "illuminate/pagination": "^6.0|^7.0|^8.0",
-        "illuminate/queue": "^6.0|^7.0|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0"
+        "php": "^7.3|^8.0",
+        "illuminate/bus": "^8.0",
+        "illuminate/contracts": "^8.0",
+        "illuminate/database": "^8.0",
+        "illuminate/http": "^8.0",
+        "illuminate/pagination": "^8.0",
+        "illuminate/queue": "^8.0",
+        "illuminate/support": "^8.0"
     },
     "require-dev": {
         "meilisearch/meilisearch-php": "^0.17",
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^8.0|^9.3"
+        "phpunit/phpunit": "^9.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This removes support for PHP 7.2 and Laravel 6+7.

Basically the same changes done for [laravel/cashier-stripe](https://github.com/laravel/cashier-stripe/pull/1064)