### PR TITLE
Rename Index command

### DIFF
--- a/src/Console/CreateIndexCommand.php
+++ b/src/Console/CreateIndexCommand.php
@@ -6,7 +6,7 @@ use Exception;
 use Illuminate\Console\Command;
 use Laravel\Scout\EngineManager;
 
-class IndexCommand extends Command
+class CreateIndexCommand extends Command
 {
     /**
      * The name and signature of the console command.

--- a/src/ScoutServiceProvider.php
+++ b/src/ScoutServiceProvider.php
@@ -6,7 +6,7 @@ use Illuminate\Support\ServiceProvider;
 use Laravel\Scout\Console\DeleteIndexCommand;
 use Laravel\Scout\Console\FlushCommand;
 use Laravel\Scout\Console\ImportCommand;
-use Laravel\Scout\Console\IndexCommand;
+use Laravel\Scout\Console\CreateIndexCommand;
 use MeiliSearch\Client as MeiliSearch;
 
 class ScoutServiceProvider extends ServiceProvider
@@ -44,7 +44,7 @@ class ScoutServiceProvider extends ServiceProvider
             $this->commands([
                 FlushCommand::class,
                 ImportCommand::class,
-                IndexCommand::class,
+                CreateIndexCommand::class,
                 DeleteIndexCommand::class,
             ]);
 


### PR DESCRIPTION
Doesn't really matter but the class only creates an index now since the [delete part](https://github.com/laravel/scout/commit/c30f194c9005da3cff4868e3a228fbf71cda2a3a) was moved to a new command so I thought I'd give it a more descriptive name.