### PR TITLE
[9.x] Add MeiliSearch in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 
 ## Introduction
 
-Laravel Scout provides a simple, driver-based solution for adding full-text search to your Eloquent models. Once Scout is installed and configured, it will automatically sync your model changes to your search indexes. Currently, Scout supports [Algolia](https://www.algolia.com/), a blazing-fast and hosted search service.
+Laravel Scout provides a simple, driver-based solution for adding full-text search to your Eloquent models. Once Scout is installed and configured, it will automatically sync your model changes to your search indexes. Currently, Scout supports:
+- [Algolia](https://www.algolia.com/), a blazing-fast and hosted search service
+- [MeiliSearch](https://github.com/meilisearch/meilisearch), an **open-source**, lightning fast, relevant, search api.
 
 ## Official Documentation
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@
 ## Introduction
 
 Laravel Scout provides a simple, driver-based solution for adding full-text search to your Eloquent models. Once Scout is installed and configured, it will automatically sync your model changes to your search indexes. Currently, Scout supports:
-- [Algolia](https://www.algolia.com/), a blazing-fast and hosted search service.
-- [MeiliSearch](https://github.com/meilisearch/meilisearch), an **open-source**, lightning fast, relevant, search api.
+
+- [Algolia](https://www.algolia.com/)
+- [MeiliSearch](https://github.com/meilisearch/meilisearch)
 
 ## Official Documentation
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Introduction
 
 Laravel Scout provides a simple, driver-based solution for adding full-text search to your Eloquent models. Once Scout is installed and configured, it will automatically sync your model changes to your search indexes. Currently, Scout supports:
-- [Algolia](https://www.algolia.com/), a blazing-fast and hosted search service
+- [Algolia](https://www.algolia.com/), a blazing-fast and hosted search service.
 - [MeiliSearch](https://github.com/meilisearch/meilisearch), an **open-source**, lightning fast, relevant, search api.
 
 ## Official Documentation


### PR DESCRIPTION
This PR adds MeiliSearch as a supported search engine per #454 and #455 in the README. I used the slogan but I feel there is a kinda of word-battle between `blazing fast` and `lighting fast`. Should we remove both and just say: `hosted` and `open source` ? 

The benefit of this addition would be to know via the README that laravel scout supports MeiliSearch.

I changed the branch to master because of this line: 
> Minor features that are fully backward compatible with the current release may be sent to the latest stable branch.

If I'm mistaken tell me I'll change the branch! 