### PR TITLE
[9.x] Explicitly use `map()` or `lazyMap()`.

### DIFF
--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -5,6 +5,7 @@ namespace Laravel\Scout\Engines;
 use Algolia\AlgoliaSearch\SearchClient as Algolia;
 use Exception;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;
 
 class AlgoliaEngine extends Engine
@@ -180,7 +181,20 @@ class AlgoliaEngine extends Engine
      */
     public function map(Builder $builder, $results, $model)
     {
-        return $this->lazyMap($builder, $results, $model)->collect();
+        if (count($results['hits']) === 0) {
+            return $model->newCollection();
+        }
+
+        $objectIds = collect($results['hits'])->pluck('objectID')->values()->all();
+        $objectIdPositions = array_flip($objectIds);
+
+        return $model->getScoutModelsByIds(
+            $builder, $objectIds
+        )->filter(function ($model) use ($objectIds) {
+            return in_array($model->getScoutKey(), $objectIds);
+        })->sortBy(function ($model) use ($objectIdPositions) {
+            return $objectIdPositions[$model->getScoutKey()];
+        })->values();
     }
 
     /**
@@ -194,7 +208,7 @@ class AlgoliaEngine extends Engine
     public function lazyMap(Builder $builder, $results, $model)
     {
         if (count($results['hits']) === 0) {
-            return $model->newCollection();
+            return LazyCollection::make($model->newCollection());
         }
 
         $objectIds = collect($results['hits'])->pluck('objectID')->values()->all();

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -186,6 +186,7 @@ class AlgoliaEngine extends Engine
         }
 
         $objectIds = collect($results['hits'])->pluck('objectID')->values()->all();
+
         $objectIdPositions = array_flip($objectIds);
 
         return $model->getScoutModelsByIds(

--- a/src/Engines/Engine.php
+++ b/src/Engines/Engine.php
@@ -133,7 +133,7 @@ abstract class Engine
      */
     public function cursor(Builder $builder)
     {
-        return $this->map(
+        return $this->lazyMap(
             $builder, $this->search($builder), $builder->model
         );
     }

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -186,6 +186,7 @@ class MeiliSearchEngine extends Engine
         }
 
         $objectIds = collect($results['hits'])->pluck($model->getKeyName())->values()->all();
+
         $objectIdPositions = array_flip($objectIds);
 
         return $model->getScoutModelsByIds(

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Scout\Engines;
 
+use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;
 use MeiliSearch\Client as MeiliSearch;
 use MeiliSearch\Search\SearchResult;
@@ -180,7 +181,20 @@ class MeiliSearchEngine extends Engine
      */
     public function map(Builder $builder, $results, $model)
     {
-        return $this->lazyMap($builder, $results, $model);
+        if (is_null($results) || 0 === count($results['hits'])) {
+            return $model->newCollection();
+        }
+
+        $objectIds = collect($results['hits'])->pluck($model->getKeyName())->values()->all();
+        $objectIdPositions = array_flip($objectIds);
+
+        return $model->getScoutModelsByIds(
+            $builder, $objectIds
+        )->filter(function ($model) use ($objectIds) {
+            return in_array($model->getScoutKey(), $objectIds);
+        })->sortBy(function ($model) use ($objectIdPositions) {
+            return $objectIdPositions[$model->getScoutKey()];
+        })->values();
     }
 
     /**
@@ -193,8 +207,8 @@ class MeiliSearchEngine extends Engine
      */
     public function lazyMap(Builder $builder, $results, $model)
     {
-        if (is_null($results) || 0 === count($results['hits'])) {
-            return $model->newCollection();
+        if (count($results['hits']) === 0) {
+            return LazyCollection::make($model->newCollection());
         }
 
         $objectIds = collect($results['hits'])->pluck($model->getKeyName())->values()->all();

--- a/tests/Unit/AlgoliaEngineTest.php
+++ b/tests/Unit/AlgoliaEngineTest.php
@@ -70,9 +70,9 @@ class AlgoliaEngineTest extends TestCase
         $engine = new AlgoliaEngine($client);
 
         $model = m::mock(stdClass::class);
-        $model->shouldReceive('queryScoutModelsByIds->cursor')->andReturn(new LazyCollection($models = Collection::make([
+        $model->shouldReceive('getScoutModelsByIds')->andReturn($models = Collection::make([
             new SearchableModel(['id' => 1]),
-        ])));
+        ]));
 
         $builder = m::mock(Builder::class);
 
@@ -89,16 +89,69 @@ class AlgoliaEngineTest extends TestCase
         $engine = new AlgoliaEngine($client);
 
         $model = m::mock(stdClass::class);
-        $model->shouldReceive('queryScoutModelsByIds->cursor')->andReturn(new LazyCollection($models = Collection::make([
+        $model->shouldReceive('getScoutModelsByIds')->andReturn($models = Collection::make([
             new SearchableModel(['id' => 1]),
             new SearchableModel(['id' => 2]),
             new SearchableModel(['id' => 3]),
             new SearchableModel(['id' => 4]),
-        ])));
+        ]));
 
         $builder = m::mock(Builder::class);
 
         $results = $engine->map($builder, ['nbHits' => 4, 'hits' => [
+            ['objectID' => 1, 'id' => 1],
+            ['objectID' => 2, 'id' => 2],
+            ['objectID' => 4, 'id' => 4],
+            ['objectID' => 3, 'id' => 3],
+        ]], $model);
+
+        $this->assertCount(4, $results);
+
+        // It's important we assert with array keys to ensure
+        // they have been reset after sorting.
+        $this->assertEquals([
+            0 => ['id' => 1],
+            1 => ['id' => 2],
+            2 => ['id' => 4],
+            3 => ['id' => 3],
+        ], $results->toArray());
+    }
+
+    public function test_lazy_map_correctly_maps_results_to_models()
+    {
+        $client = m::mock(SearchClient::class);
+        $engine = new AlgoliaEngine($client);
+
+        $model = m::mock(stdClass::class);
+        $model->shouldReceive('queryScoutModelsByIds->cursor')->andReturn($models = LazyCollection::make([
+            new SearchableModel(['id' => 1]),
+        ]));
+
+        $builder = m::mock(Builder::class);
+
+        $results = $engine->lazyMap($builder, ['nbHits' => 1, 'hits' => [
+            ['objectID' => 1, 'id' => 1],
+        ]], $model);
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_lazy_map_method_respects_order()
+    {
+        $client = m::mock(SearchClient::class);
+        $engine = new AlgoliaEngine($client);
+
+        $model = m::mock(stdClass::class);
+        $model->shouldReceive('queryScoutModelsByIds->cursor')->andReturn($models = LazyCollection::make([
+            new SearchableModel(['id' => 1]),
+            new SearchableModel(['id' => 2]),
+            new SearchableModel(['id' => 3]),
+            new SearchableModel(['id' => 4]),
+        ]));
+
+        $builder = m::mock(Builder::class);
+
+        $results = $engine->lazyMap($builder, ['nbHits' => 4, 'hits' => [
             ['objectID' => 1, 'id' => 1],
             ['objectID' => 2, 'id' => 2],
             ['objectID' => 4, 'id' => 4],


### PR DESCRIPTION
When I first created PR #439 it was under the impression we can use `QueryBuilder::cursor()` and everything works the same. However new feedback from @JosephSilber there are some limitations to doing this, including eager loading. 

![image](https://user-images.githubusercontent.com/172966/116114975-7a57d000-a6ec-11eb-9841-e09c6a146fb2.png)

### Changes

* `Engine::map()` will use `Searchable::getScoutModelsByIds()` which will return eloquent collection.
* `Engine::lazyMap()` will use `Searchable::queryScoutModelsByIds()` which will return eloquent builder (where we can use `cursor()`).

### Limitation

I not sure if we are able to use `lazy()` or `lazyById()` as far as I know since chunking the result as we need to sort by relevant search results.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>
