### PR TITLE
Remove custom unserialize from RemoveFromSearch

### DIFF
--- a/src/Jobs/RemoveFromSearch.php
+++ b/src/Jobs/RemoveFromSearch.php
@@ -4,7 +4,6 @@ namespace Laravel\Scout\Jobs;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Queue\SerializesModels;
 
 class RemoveFromSearch implements ShouldQueue
@@ -39,26 +38,5 @@ class RemoveFromSearch implements ShouldQueue
         if ($this->models->isNotEmpty()) {
             $this->models->first()->searchableUsing()->delete($this->models);
         }
-    }
-
-    /**
-     * Restore a queueable collection instance.
-     *
-     * @param  \Illuminate\Contracts\Database\ModelIdentifier  $value
-     * @return \Illuminate\Database\Eloquent\Collection
-     */
-    protected function restoreCollection($value)
-    {
-        if (! $value->class || count($value->id) === 0) {
-            return new EloquentCollection;
-        }
-
-        return new EloquentCollection(
-            collect($value->id)->map(function ($id) use ($value) {
-                return tap(new $value->class, function ($model) use ($id) {
-                    $model->forceFill([$model->getKeyName() => $id]);
-                });
-            })
-        );
     }
 }

--- a/tests/Unit/RemoveFromSearchTest.php
+++ b/tests/Unit/RemoveFromSearchTest.php
@@ -5,7 +5,6 @@ namespace Laravel\Scout\Tests\Unit;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Config;
 use Laravel\Scout\Jobs\RemoveFromSearch;
-use Laravel\Scout\Tests\Fixtures\SearchableModel;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -30,20 +29,5 @@ class RemoveFromSearchTest extends TestCase
         $model->shouldReceive('searchableUsing->delete')->with($collection);
 
         $job->handle();
-    }
-
-    public function test_models_are_deserialized_without_the_database()
-    {
-        $job = new RemoveFromSearch($collection = Collection::make([
-            $model = new SearchableModel(['id' => 1234]),
-        ]));
-
-        $job = unserialize(serialize($job));
-
-        $this->assertInstanceOf(Collection::class, $job->models);
-        $this->assertCount(1, $job->models);
-        $this->assertInstanceOf(SearchableModel::class, $job->models->first());
-        $this->assertTrue($model->is($job->models->first()));
-        $this->assertEquals(1234, $job->models->first()->getScoutKey());
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
The custom unserialization process in the `RemoveFromSearch` job does not take a customized scout key into account correctly.

Given a model with an overriden key like below that relies on other data on the model, the engines won't be able to process the models since they only have their primary key to work with.
```php
public function getScoutKey()
{
    return $this->custom_id;
}
```

In the case of the MeiliSearch engine, it will queue a request to delete a model with the key of `null`. This request continues on to MeiliSearch proper and it processes the request just fine, resulting in nothing being deleted. I'm not sure what the result would be on any other engine, but I would expect it to be similar.

The original PR that added this functionality added a test `test_models_are_deserialized_without_the_database`. In the process of creating this PR, I tried to think of ways to preserve that functionality by possibly customizing the serialization as well, or altering what the constructor does. I failed to come up with a clean and simple way to preserve that functionality. Every attempt I tried felt brittle.

Instead, I feel that this job being able to deserialize a model without the database is beyond the scope of what this package is aiming to provide, especially since the same feature is not available on the `MakeSearchable` job. If this avoiding the database for deserialization is required by an application, a custom version of the job could be used instead thanks to #476.