### PR TITLE
[9.x] Fix removing queued models with custom Scout keys

### DIFF
--- a/src/Jobs/RemoveFromSearch.php
+++ b/src/Jobs/RemoveFromSearch.php
@@ -2,11 +2,11 @@
 
 namespace Laravel\Scout\Jobs;
 
-use Illuminate\Support\Str;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Str;
 
 class RemoveFromSearch implements ShouldQueue
 {

--- a/src/Jobs/RemoveFromSearch.php
+++ b/src/Jobs/RemoveFromSearch.php
@@ -15,7 +15,7 @@ class RemoveFromSearch implements ShouldQueue
     /**
      * The models to be removed from the search index.
      *
-     * @var RemoveableScoutCollection
+     * @var \Illuminate\Database\Eloquent\Collection
      */
     public $models;
 

--- a/src/Jobs/RemoveableScoutCollection.php
+++ b/src/Jobs/RemoveableScoutCollection.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Laravel\Scout\Jobs;
+
+use Laravel\Scout\Searchable;
+use Illuminate\Database\Eloquent\Collection;
+
+class RemoveableScoutCollection extends Collection
+{
+    /**
+     * Get the Scout identifiers for all of the entities.
+     *
+     * @return array
+     */
+    public function getQueueableIds()
+    {
+        if ($this->isEmpty()) {
+            return [];
+        }
+
+        return in_array(Searchable::class, class_uses_recursive($this->first()))
+                    ? $this->map->getScoutKey()->all()
+                    : parent::getQueueableIds();
+    }
+}

--- a/src/Jobs/RemoveableScoutCollection.php
+++ b/src/Jobs/RemoveableScoutCollection.php
@@ -2,8 +2,8 @@
 
 namespace Laravel\Scout\Jobs;
 
-use Laravel\Scout\Searchable;
 use Illuminate\Database\Eloquent\Collection;
+use Laravel\Scout\Searchable;
 
 class RemoveableScoutCollection extends Collection
 {

--- a/tests/Fixtures/SearchableModelWithCustomKey.php
+++ b/tests/Fixtures/SearchableModelWithCustomKey.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Laravel\Scout\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Scout\Searchable;
+
+class SearchableModelWithCustomKey extends Model
+{
+    use Searchable;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = ['other_id'];
+
+    public function getScoutKey()
+    {
+        return $this->other_id;
+    }
+
+    public function getScoutKeyName()
+    {
+        return $this->qualifyColumn('other_id');
+    }
+}

--- a/tests/Unit/RemoveFromSearchTest.php
+++ b/tests/Unit/RemoveFromSearchTest.php
@@ -4,8 +4,10 @@ namespace Laravel\Scout\Tests\Unit;
 
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Config;
+use Laravel\Scout\Jobs\RemoveableScoutCollection;
 use Laravel\Scout\Jobs\RemoveFromSearch;
 use Laravel\Scout\Tests\Fixtures\SearchableModel;
+use Laravel\Scout\Tests\Fixtures\SearchableModelWithCustomKey;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -34,7 +36,7 @@ class RemoveFromSearchTest extends TestCase
 
     public function test_models_are_deserialized_without_the_database()
     {
-        $job = new RemoveFromSearch($collection = Collection::make([
+        $job = new RemoveFromSearch(Collection::make([
             $model = new SearchableModel(['id' => 1234]),
         ]));
 
@@ -45,5 +47,38 @@ class RemoveFromSearchTest extends TestCase
         $this->assertInstanceOf(SearchableModel::class, $job->models->first());
         $this->assertTrue($model->is($job->models->first()));
         $this->assertEquals(1234, $job->models->first()->getScoutKey());
+    }
+
+    public function test_models_are_deserialized_without_the_database_using_custom_scout_key()
+    {
+        $job = new RemoveFromSearch(Collection::make([
+            $model = new SearchableModelWithCustomKey(['other_id' => 1234]),
+        ]));
+
+        $job = unserialize(serialize($job));
+        
+        $this->assertInstanceOf(Collection::class, $job->models);
+        $this->assertCount(1, $job->models);
+        $this->assertInstanceOf(SearchableModelWithCustomKey::class, $job->models->first());
+        $this->assertTrue($model->is($job->models->first()));
+        $this->assertEquals(1234, $job->models->first()->getScoutKey());
+        $this->assertEquals('searchable_model_with_custom_keys.other_id', $job->models->first()->getScoutKeyName());
+    }
+
+    public function test_removeable_scout_collection_returns_scout_keys()
+    {
+        $collection = RemoveableScoutCollection::make([
+            new SearchableModelWithCustomKey(['other_id' => 1234]),
+            new SearchableModelWithCustomKey(['other_id' => 2345]),
+            new SearchableModel(['id' => 3456]),
+            new SearchableModel(['id' => 7891]),
+        ]);
+
+        $this->assertEquals([
+            1234,
+            2345,
+            3456,
+            7891,
+        ], $collection->getQueueableIds());
     }
 }

--- a/tests/Unit/RemoveFromSearchTest.php
+++ b/tests/Unit/RemoveFromSearchTest.php
@@ -25,11 +25,15 @@ class RemoveFromSearchTest extends TestCase
 
     public function test_handle_passes_the_collection_to_engine()
     {
-        $job = new RemoveFromSearch($collection = Collection::make([
+        $job = new RemoveFromSearch(Collection::make([
             $model = m::mock(),
         ]));
 
-        $model->shouldReceive('searchableUsing->delete')->with($collection);
+        $model->shouldReceive('searchableUsing->delete')->with(
+            m::on(function ($collection) use ($model) {
+                return $collection instanceof RemoveableScoutCollection && $collection->first() === $model;
+            })
+        );
 
         $job->handle();
     }

--- a/tests/Unit/RemoveFromSearchTest.php
+++ b/tests/Unit/RemoveFromSearchTest.php
@@ -60,7 +60,7 @@ class RemoveFromSearchTest extends TestCase
         ]));
 
         $job = unserialize(serialize($job));
-        
+
         $this->assertInstanceOf(Collection::class, $job->models);
         $this->assertCount(1, $job->models);
         $this->assertInstanceOf(SearchableModelWithCustomKey::class, $job->models->first());


### PR DESCRIPTION
## Purpose

This PR patches the issue described in PR https://github.com/laravel/scout/pull/479.

## Description

This PR fixes the issue described above. However, if developers are customizing their Scout key via `getScoutKey()` and are utilizing queuing, they must also modify the `getScoutKeyName()` to return the name of this custom key, so that the models can be hydrated and be properly removed from indexes. I can also submit a PR to the docs repo if this gets merged in so it can instruct developers to perform this step when queuing using custom scout keys.

The `RemoveableScoutCollection` class extends the Eloquent collection class, and pulls the queueable ID's from the model's `getScoutKey()` method. This is the cleanest solution I was able to come up with the least possible intrusion and work on the developers side.

In regards to the issue posted in the above PR, they would simply have to add this into their model after this patch:

```php
public function getScoutKey()
{
    return $this->custom_id;
}

public function getScoutKeyName()
{
    return $this->qualifyColumn('custom_id');
}
```

Let me know if there's any issues/comments/concerns with this approach. Thanks for your time! ❤️ 
