### PR TITLE
Collection Engine

### DIFF
--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -8,6 +8,7 @@ use Algolia\AlgoliaSearch\Support\UserAgent;
 use Exception;
 use Illuminate\Support\Manager;
 use Laravel\Scout\Engines\AlgoliaEngine;
+use Laravel\Scout\Engines\CollectionEngine;
 use Laravel\Scout\Engines\MeiliSearchEngine;
 use Laravel\Scout\Engines\NullEngine;
 use MeiliSearch\Client as MeiliSearch;
@@ -124,7 +125,17 @@ class EngineManager extends Manager
     }
 
     /**
-     * Create a Null engine instance.
+     * Create a database engine instance.
+     *
+     * @return \Laravel\Scout\Engines\CollectionEngine
+     */
+    public function createCollectionDriver()
+    {
+        return new CollectionEngine;
+    }
+
+    /**
+     * Create a null engine instance.
      *
      * @return \Laravel\Scout\Engines\NullEngine
      */

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -125,7 +125,7 @@ class EngineManager extends Manager
     }
 
     /**
-     * Create a database engine instance.
+     * Create a collection engine instance.
      *
      * @return \Laravel\Scout\Engines\CollectionEngine
      */

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -172,7 +172,7 @@ class CollectionEngine extends Engine
         $results = $results['results'];
 
         if (count($results) === 0) {
-            return LazyCollection::make($model->newCollection());
+            return LazyCollection::empty();
         }
 
         $objectIds = collect($results)

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -83,12 +83,13 @@ class CollectionEngine extends Engine
     protected function searchModels(Builder $builder)
     {
         $models = $builder->model->query()
+                        ->when(count($builder->wheres) > 0, function ($query) use ($builder) {
+                            foreach ($builder->wheres as $key => $value) {
+                                $query->where($key, $value);
+                            }
+                        })
                         ->orderBy($builder->model->getKeyName(), 'desc')
                         ->cursor();
-
-        foreach ($builder->wheres as $key => $value) {
-            $models = $models->where($key, $value);
-        }
 
         $models = $models->values();
 

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace Laravel\Scout\Engines;
+
+use Illuminate\Support\LazyCollection;
+use Illuminate\Support\Str;
+use Laravel\Scout\Builder;
+
+class CollectionEngine extends Engine
+{
+    /**
+     * Create a new engine instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Update the given model in the index.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @return void
+     */
+    public function update($models)
+    {
+        //
+    }
+
+    /**
+     * Remove the given model from the index.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @return void
+     */
+    public function delete($models)
+    {
+        //
+    }
+
+    /**
+     * Perform the given search on the engine.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return mixed
+     */
+    public function search(Builder $builder)
+    {
+        $models = $this->searchModels($builder);
+
+        return [
+            'results' => $models->take($builder->limit)->all(),
+            'total' => count($models),
+        ];
+    }
+
+    /**
+     * Perform the given search on the engine.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  int  $perPage
+     * @param  int  $page
+     * @return mixed
+     */
+    public function paginate(Builder $builder, $perPage, $page)
+    {
+        $models = $this->searchModels($builder);
+
+        return [
+            'results' => $models->forPage($page - 1, $perPage)->all(),
+            'total' => count($models),
+        ];
+    }
+
+    /**
+     * Get the Eloquent models for the given builder.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    protected function searchModels(Builder $builder)
+    {
+        $models = $builder->model->query()->get();
+
+        foreach ($builder->wheres as $key => $value) {
+            $models = $models->where($key, $value);
+        }
+
+        $models = $models->values();
+
+        if (count($models) === 0) {
+            return $models;
+        }
+
+        $columns = array_keys($models[0]->toSearchableArray());
+
+        return $models->filter(function ($model) use ($builder, $columns) {
+            foreach ($columns as $column) {
+                $attribute = $model->{$column};
+
+                if (Str::contains($attribute, $builder->query)) {
+                    return true;
+                }
+            }
+
+            return false;
+        })->values();
+    }
+
+    /**
+     * Pluck and return the primary keys of the given results.
+     *
+     * @param  mixed  $results
+     * @return \Illuminate\Support\Collection
+     */
+    public function mapIds($results)
+    {
+        $results = $results['results'];
+
+        return count($results) > 0
+                    ? collect($results)->pluck($results[0]->getKeyName())->values()
+                    : collect();
+    }
+
+    /**
+     * Map the given results to instances of the given model.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  mixed  $results
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function map(Builder $builder, $results, $model)
+    {
+        $results = $results['results'];
+
+        if (count($results) === 0) {
+            return $model->newCollection();
+        }
+
+        $objectIds = collect($results)
+                ->pluck($model->getKeyName())
+                ->values()
+                ->all();
+
+        $objectIdPositions = array_flip($objectIds);
+
+        return $model->getScoutModelsByIds(
+            $builder, $objectIds
+        )->filter(function ($model) use ($objectIds) {
+            return in_array($model->getScoutKey(), $objectIds);
+        })->sortBy(function ($model) use ($objectIdPositions) {
+            return $objectIdPositions[$model->getScoutKey()];
+        })->values();
+    }
+
+    /**
+     * Map the given results to instances of the given model via a lazy collection.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  mixed  $results
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Support\LazyCollection
+     */
+    public function lazyMap(Builder $builder, $results, $model)
+    {
+        $results = $results['results'];
+
+        if (count($results) === 0) {
+            return LazyCollection::make($model->newCollection());
+        }
+
+        $objectIds = collect($results)
+                ->pluck($model->getKeyName())
+                ->values()->all();
+
+        $objectIdPositions = array_flip($objectIds);
+
+        return $model->queryScoutModelsByIds(
+                $builder, $objectIds
+            )->cursor()->filter(function ($model) use ($objectIds) {
+                return in_array($model->getScoutKey(), $objectIds);
+            })->sortBy(function ($model) use ($objectIdPositions) {
+                return $objectIdPositions[$model->getScoutKey()];
+            })->values();
+    }
+
+    /**
+     * Get the total count from a raw result returned by the engine.
+     *
+     * @param  mixed  $results
+     * @return int
+     */
+    public function getTotalCount($results)
+    {
+        return $results['total'];
+    }
+
+    /**
+     * Flush all of the model's records from the engine.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    public function flush($model)
+    {
+        //
+    }
+
+    /**
+     * Create a search index.
+     *
+     * @param  string  $name
+     * @param  array  $options
+     * @return mixed
+     *
+     * @throws \Exception
+     */
+    public function createIndex($name, array $options = [])
+    {
+        //
+    }
+
+    /**
+     * Delete a search index.
+     *
+     * @param  string  $name
+     * @return mixed
+     */
+    public function deleteIndex($name)
+    {
+        //
+    }
+}

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -51,7 +51,7 @@ class CollectionEngine extends Engine
         $models = $this->searchModels($builder);
 
         return [
-            'results' => $models->take($builder->limit)->all(),
+            'results' => $models->all(),
             'total' => count($models),
         ];
     }
@@ -82,7 +82,9 @@ class CollectionEngine extends Engine
      */
     protected function searchModels(Builder $builder)
     {
-        $models = $builder->model->query()->get();
+        $models = $builder->model->query()
+                        ->orderBy($builder->model->getKeyName(), 'desc')
+                        ->cursor();
 
         foreach ($builder->wheres as $key => $value) {
             $models = $models->where($key, $value);
@@ -94,7 +96,7 @@ class CollectionEngine extends Engine
             return $models;
         }
 
-        $columns = array_keys($models[0]->toSearchableArray());
+        $columns = array_keys($models->first()->toSearchableArray());
 
         return $models->filter(function ($model) use ($builder, $columns) {
             foreach ($columns as $column) {

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -89,7 +89,7 @@ class CollectionEngine extends Engine
                             }
                         })
                         ->orderBy($builder->model->getKeyName(), 'desc')
-                        ->cursor();
+                        ->get();
 
         $models = $models->values();
 

--- a/tests/Feature/CollectionEngineTest.php
+++ b/tests/Feature/CollectionEngineTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Laravel\Scout\Tests\Feature;
+
+use Illuminate\Foundation\Testing\WithFaker;
+use Laravel\Scout\ScoutServiceProvider;
+use Laravel\Scout\Tests\Fixtures\SearchableUserModel;
+use Orchestra\Testbench\Factories\UserFactory;
+use Orchestra\Testbench\TestCase;
+
+class CollectionEngineTest extends TestCase
+{
+    use WithFaker;
+
+    protected function getPackageProviders($app)
+    {
+        return [ScoutServiceProvider::class];
+    }
+
+    protected function defineEnvironment($app)
+    {
+        $app->make('config')->set('scout.driver', 'collection');
+    }
+
+    protected function defineDatabaseMigrations()
+    {
+        $this->setUpFaker();
+        $this->loadLaravelMigrations();
+
+        UserFactory::new()->create([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        UserFactory::new()->create([
+            'name' => 'Abigail Otwell',
+            'email' => 'abigail@laravel.com',
+        ]);
+    }
+
+    public function test_it_can_retrieve_results()
+    {
+        $models = SearchableUserModel::search('Taylor')->where('email', 'taylor@laravel.com')->get();
+        $this->assertCount(1, $models);
+        $this->assertEquals(1, $models[0]->id);
+
+        $models = SearchableUserModel::search('Abigail')->where('email', 'abigail@laravel.com')->get();
+        $this->assertCount(1, $models);
+        $this->assertEquals(2, $models[0]->id);
+
+        $models = SearchableUserModel::search('Taylor')->where('email', 'abigail@laravel.com')->get();
+        $this->assertCount(0, $models);
+
+        $models = SearchableUserModel::search('Taylor')->where('email', 'taylor@laravel.com')->get();
+        $this->assertCount(1, $models);
+
+        $models = SearchableUserModel::search('laravel')->get();
+        $this->assertCount(2, $models);
+
+        $models = SearchableUserModel::search('foo')->get();
+        $this->assertCount(0, $models);
+
+        $models = SearchableUserModel::search('Abigail')->where('email', 'taylor@laravel.com')->get();
+        $this->assertCount(0, $models);
+    }
+
+    public function test_it_can_paginate_results()
+    {
+        $models = SearchableUserModel::search('Taylor')->where('email', 'taylor@laravel.com')->paginate();
+        $this->assertCount(1, $models);
+
+        $models = SearchableUserModel::search('Taylor')->where('email', 'abigail@laravel.com')->paginate();
+        $this->assertCount(0, $models);
+
+        $models = SearchableUserModel::search('Taylor')->where('email', 'taylor@laravel.com')->paginate();
+        $this->assertCount(1, $models);
+
+        $models = SearchableUserModel::search('laravel')->paginate();
+        $this->assertCount(2, $models);
+    }
+}


### PR DESCRIPTION
Over the weekend, I was hacking on something where I wanted to quickly use Scout without setting up any other external dependencies like Algolia or MeiliSearch.

I cooked up this quick driver that is intended for usage in **local development and small staging environments only**. It is not performant on large datasets and does not have robust fuzzy matching or anything. However, it is perfectly adequate in local development environments where you often don't have more than a couple hundred models.

However, this driver uses Eloquent's cursor method to retrieve filtered results and then uses `Str::contains` against the `LazyCollection` to match against all of the searchable columns. Note it is not possible to do those checks in the database because we do not know the data types of the columns and some RDBMS like Postgres will throw an error if you try to execute a `where like` clause against an integer column like an ID.

**So, in summary, this driver gives you a quick way to use Scout locally and get some generally sensible results from it just so you can continue building your application's search UI and functionality without worrying about the robustness of the search results themselves.**

I decided against calling this a `database` engine because it does not perform any sort of FULLTEXT column searching or use database search features. It iterates through a `LazyCollection` of all models of a given type and filters their column's values against the query within PHP.