### PR TITLE
[9.x] Improve observer strategy

### DIFF
--- a/src/ModelObserver.php
+++ b/src/ModelObserver.php
@@ -79,7 +79,9 @@ class ModelObserver
         }
 
         if (! $model->shouldBeSearchable()) {
-            $model->unsearchable();
+            if ($model->wasSearchableBeforeUpdate()) {
+                $model->unsearchable();
+            }
 
             return;
         }
@@ -96,6 +98,10 @@ class ModelObserver
     public function deleted($model)
     {
         if (static::syncingDisabledFor($model)) {
+            return;
+        }
+
+        if (! $model->wasSearchableBeforeDelete()) {
             return;
         }
 

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -364,4 +364,32 @@ trait Searchable
     {
         return in_array(SoftDeletes::class, class_uses_recursive(get_called_class()));
     }
+
+    /**
+     * Was the model searchable before the update happened?
+     *
+     * @return bool
+     */
+    public function wasSearchableBeforeUpdate(): bool
+    {
+        return (clone $this)->forceFill($this->getOriginal())->shouldBeSearchable();
+    }
+
+    /**
+     * Was the model searchable before the deletion happened?
+     *
+     * To be used only when the model gets deleted using `delete`.
+     *
+     * @return bool
+     */
+    public function wasSearchableBeforeDelete(): bool
+    {
+        if (! method_exists($this, 'getDeletedAtColumn')) {
+            return $this->shouldBeSearchable();
+        }
+
+        return (clone $this)->forceFill([
+            $this->getDeletedAtColumn() => null,
+        ])->shouldBeSearchable();
+    }
 }

--- a/tests/Feature/SearchableTest.php
+++ b/tests/Feature/SearchableTest.php
@@ -3,7 +3,6 @@
 namespace Laravel\Scout\Tests\Feature;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Queue;
 use Laravel\Scout\Jobs\MakeSearchable;
 use Laravel\Scout\Jobs\RemoveFromSearch;
@@ -11,6 +10,7 @@ use Laravel\Scout\Scout;
 use Laravel\Scout\Tests\Fixtures\OverriddenMakeSearchable;
 use Laravel\Scout\Tests\Fixtures\OverriddenRemoveFromSearch;
 use Laravel\Scout\Tests\Fixtures\SearchableModel;
+use Laravel\Scout\Tests\Fixtures\SearchableModelWithSoftDeletes;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
 
@@ -103,7 +103,7 @@ class SearchableTest extends TestCase
 
     public function test_was_searchable_on_model_with_soft_deletes()
     {
-        $model = new SearchableSoftDeleteModel;
+        $model = new SearchableModelWithSoftDeletes;
         $model->syncOriginal();
 
         $this->assertTrue($model->wasSearchableBeforeUpdate());
@@ -139,9 +139,4 @@ class ModelStubForMakeAllSearchable extends SearchableModel
 
         return $mock;
     }
-}
-
-class SearchableSoftDeleteModel extends SearchableModel
-{
-    use SoftDeletes;
 }

--- a/tests/Feature/SearchableTest.php
+++ b/tests/Feature/SearchableTest.php
@@ -101,13 +101,44 @@ class SearchableTest extends TestCase
         $this->assertTrue($model->wasSearchableBeforeDelete());
     }
 
-    public function test_was_searchable_on_model_with_soft_deletes()
+    public function test_was_searchable_before_update_works_from_false_to_true()
     {
-        $model = new SearchableModelWithSoftDeletes;
+        $model = new SearchableModelWithSoftDeletes([
+            'published_at' => null,
+        ]);
         $model->syncOriginal();
 
+        $model->published_at = now();
+
+        $this->assertFalse($model->wasSearchableBeforeUpdate());
+        $this->assertTrue($model->shouldBeSearchable());
+    }
+
+    public function test_was_searchable_before_update_works_from_true_to_false()
+    {
+        $model = new SearchableModelWithSoftDeletes([
+            'published_at' => now(),
+        ]);
+        $model->syncOriginal();
+
+        $model->published_at = null;
+
         $this->assertTrue($model->wasSearchableBeforeUpdate());
+        $this->assertFalse($model->shouldBeSearchable());
+    }
+
+    public function test_was_searchable_before_delete_works_when_deleting()
+    {
+        $model = new SearchableModelWithSoftDeletes([
+            'published_at' => now(),
+        ]);
+        $model->syncOriginal();
+
+        // Mark as deleted!
+        $model->setAttribute($model->getDeletedAtColumn(), now());
+
         $this->assertTrue($model->wasSearchableBeforeDelete());
+        $this->assertFalse($model->shouldBeSearchable());
     }
 
     public function test_make_all_searchable_uses_order_by()

--- a/tests/Feature/SearchableTest.php
+++ b/tests/Feature/SearchableTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Scout\Tests\Feature;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Queue;
 use Laravel\Scout\Jobs\MakeSearchable;
 use Laravel\Scout\Jobs\RemoveFromSearch;
@@ -91,6 +92,24 @@ class SearchableTest extends TestCase
         Scout::removeFromSearchUsing(RemoveFromSearch::class);
     }
 
+    public function test_was_searchable_on_model_without_soft_deletes()
+    {
+        $model = new SearchableModel;
+        $model->syncOriginal();
+
+        $this->assertTrue($model->wasSearchableBeforeUpdate());
+        $this->assertTrue($model->wasSearchableBeforeDelete());
+    }
+
+    public function test_was_searchable_on_model_with_soft_deletes()
+    {
+        $model = new SearchableSoftDeleteModel;
+        $model->syncOriginal();
+
+        $this->assertTrue($model->wasSearchableBeforeUpdate());
+        $this->assertTrue($model->wasSearchableBeforeDelete());
+    }
+
     public function test_make_all_searchable_uses_order_by()
     {
         ModelStubForMakeAllSearchable::makeAllSearchable();
@@ -120,4 +139,9 @@ class ModelStubForMakeAllSearchable extends SearchableModel
 
         return $mock;
     }
+}
+
+class SearchableSoftDeleteModel extends SearchableModel
+{
+    use SoftDeletes;
 }

--- a/tests/Fixtures/SearchableModelWithSoftDeletes.php
+++ b/tests/Fixtures/SearchableModelWithSoftDeletes.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Scout\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class SearchableModelWithSoftDeletes extends SearchableModel
+{
+    use SoftDeletes;
+}

--- a/tests/Fixtures/SearchableModelWithSoftDeletes.php
+++ b/tests/Fixtures/SearchableModelWithSoftDeletes.php
@@ -20,6 +20,6 @@ class SearchableModelWithSoftDeletes extends Model
 
     public function shouldBeSearchable()
     {
-        return !$this->trashed() && ! is_null($this->published_at);
+        return ! $this->trashed() && ! is_null($this->published_at);
     }
 }

--- a/tests/Fixtures/SearchableModelWithSoftDeletes.php
+++ b/tests/Fixtures/SearchableModelWithSoftDeletes.php
@@ -2,9 +2,24 @@
 
 namespace Laravel\Scout\Tests\Fixtures;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Laravel\Scout\Searchable;
 
-class SearchableModelWithSoftDeletes extends SearchableModel
+class SearchableModelWithSoftDeletes extends Model
 {
     use SoftDeletes;
+    use Searchable;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = ['published_at'];
+
+    public function shouldBeSearchable()
+    {
+        return !$this->trashed() && ! is_null($this->published_at);
+    }
 }

--- a/tests/Unit/ModelObserverTest.php
+++ b/tests/Unit/ModelObserverTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Scout\Tests\Unit;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Config;
 use Laravel\Scout\ModelObserver;
 use Mockery as m;
@@ -24,7 +25,7 @@ class ModelObserverTest extends TestCase
         $observer = new ModelObserver;
         $model = m::mock();
         $model->shouldReceive('shouldBeSearchable')->andReturn(true);
-        $model->shouldReceive('searchable');
+        $model->shouldReceive('searchable')->once();
         $observer->saved($model);
     }
 
@@ -35,6 +36,7 @@ class ModelObserverTest extends TestCase
         $observer->disableSyncingFor(get_class($model));
         $model->shouldReceive('searchable')->never();
         $observer->saved($model);
+        $observer->enableSyncingFor(get_class($model));
     }
 
     public function test_saved_handler_makes_model_unsearchable_when_disabled_per_model_rule()
@@ -42,15 +44,37 @@ class ModelObserverTest extends TestCase
         $observer = new ModelObserver;
         $model = m::mock();
         $model->shouldReceive('shouldBeSearchable')->andReturn(false);
+        $model->shouldReceive('wasSearchableBeforeUpdate')->andReturn(true);
         $model->shouldReceive('searchable')->never();
-        $model->shouldReceive('unsearchable');
+        $model->shouldReceive('unsearchable')->once();
         $observer->saved($model);
+    }
+
+    public function test_saved_handler_doesnt_make_model_unsearchable_when_disabled_per_model_rule_and_already_unsearchable()
+    {
+        $observer = new ModelObserver;
+        $model = m::mock(Model::class)->makePartial();
+        $model->shouldReceive('shouldBeSearchable')->andReturn(false);
+        $model->shouldReceive('wasSearchableBeforeUpdate')->andReturn(false);
+        $model->shouldReceive('searchable')->never();
+        $model->shouldReceive('unsearchable')->never();
+        $observer->saved($model);
+    }
+
+    public function test_deleted_handler_doesnt_make_model_unsearchable_when_already_unsearchable()
+    {
+        $observer = new ModelObserver;
+        $model = m::mock();
+        $model->shouldReceive('wasSearchableBeforeDelete')->andReturn(false);
+        $model->shouldReceive('unsearchable')->never();
+        $observer->deleted($model);
     }
 
     public function test_deleted_handler_makes_model_unsearchable()
     {
         $observer = new ModelObserver;
         $model = m::mock();
+        $model->shouldReceive('wasSearchableBeforeDelete')->andReturn(true);
         $model->shouldReceive('unsearchable');
         $observer->deleted($model);
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

# Problem

The current `ModelObserver` implementation calls `unsearchable` every time a model gets deleted. Practically, it means that the underlying engine (in our case, at StuDocu, Algolia) would be asked to delete the model from its index regardless of it actually being in the index or not.

# Solution

Two methods named `wasSearchableBeforeUpdate` and `wasSearchableBeforeDelete` are implemented to respectively check if a model was searchable before being updated or deleted. `ModelObserver` gets smarter and first checks if a model was actually searchable before calling `unsearchable`, thanks to one or the other method.

Now, the flow is as follow:

* When a model gets updated and is not searchable, we first check if it was searchable using `wasSearchableBeforeUpdate`. If it was, it is made unsearchable. If it wasn't, there is no need to make it unsearchable.
* When a model gets deleted, we first check if it was searchable using `wasSearchableBeforeDelete`. If it was, it is made unsearchable. If it wasn't, there is no need to make it unsearchable.

# Additional fix

The `ModelObserverTest` unit tests were not asserting anything and were actually broken after calling `disableSyncingFor` in `test_saved_handler_doesnt_make_model_searchable_when_disabled`. They're now fixed and extended to cover the use cases described above.