### PR TITLE
[9.x] Add Searchable contract to complement trait

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -14,7 +14,7 @@ class Builder
     /**
      * The model instance.
      *
-     * @var \Illuminate\Database\Eloquent\Model
+     * @var \Illuminate\Database\Eloquent\Model|\Laravel\Scout\Contracts\Searchable
      */
     public $model;
 

--- a/src/Contracts/Searchable.php
+++ b/src/Contracts/Searchable.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Laravel\Scout\Contracts;
+
+interface Searchable
+{
+    /**
+     * Boot the trait.
+     *
+     * @return void
+     */
+    public static function bootSearchable();
+
+    /**
+     * Register the searchable macros.
+     *
+     * @return void
+     */
+    public function registerSearchableMacros();
+
+    /**
+     * Dispatch the job to make the given models searchable.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @return void
+     */
+    public function queueMakeSearchable($models);
+
+    /**
+     * Dispatch the job to make the given models unsearchable.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @return void
+     */
+    public function queueRemoveFromSearch($models);
+
+    /**
+     * Determine if the model should be searchable.
+     *
+     * @return bool
+     */
+    public function shouldBeSearchable();
+
+    /**
+     * Perform a search against the model's indexed data.
+     *
+     * @param  string  $query
+     * @param  \Closure  $callback
+     * @return \Laravel\Scout\Builder
+     */
+    public static function search($query = '', $callback = null);
+
+    /**
+     * Make all instances of the model searchable.
+     *
+     * @param  int  $chunk
+     * @return void
+     */
+    public static function makeAllSearchable($chunk = null);
+
+    /**
+     * Make the given model instance searchable.
+     *
+     * @return void
+     */
+    public function searchable();
+
+    /**
+     * Remove all instances of the model from the search index.
+     *
+     * @return void
+     */
+    public static function removeAllFromSearch();
+
+    /**
+     * Remove the given model instance from the search index.
+     *
+     * @return void
+     */
+    public function unsearchable();
+
+    /**
+     * Get the requested models from an array of object IDs.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  array  $ids
+     * @return mixed
+     */
+    public function getScoutModelsByIds(\Laravel\Scout\Builder $builder, array $ids);
+
+    /**
+     * Get a query builder for retrieving the requested models from an array of object IDs.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  array  $ids
+     * @return mixed
+     */
+    public function queryScoutModelsByIds(\Laravel\Scout\Builder $builder, array $ids);
+
+    /**
+     * Enable search syncing for this model.
+     *
+     * @return void
+     */
+    public static function enableSearchSyncing();
+
+    /**
+     * Disable search syncing for this model.
+     *
+     * @return void
+     */
+    public static function disableSearchSyncing();
+
+    /**
+     * Temporarily disable search syncing for the given callback.
+     *
+     * @param  callable  $callback
+     * @return mixed
+     */
+    public static function withoutSyncingToSearch($callback);
+
+    /**
+     * Get the index name for the model.
+     *
+     * @return string
+     */
+    public function searchableAs();
+
+    /**
+     * Get the indexable data array for the model.
+     *
+     * @return array
+     */
+    public function toSearchableArray();
+
+    /**
+     * Get the Scout engine for the model.
+     *
+     * @return mixed
+     */
+    public function searchableUsing();
+
+    /**
+     * Get the queue connection that should be used when syncing.
+     *
+     * @return string
+     */
+    public function syncWithSearchUsing();
+
+    /**
+     * Get the queue that should be used with syncing.
+     *
+     * @return string
+     */
+    public function syncWithSearchUsingQueue();
+
+    /**
+     * Sync the soft deleted status for this model into the metadata.
+     *
+     * @return Searchable
+     */
+    public function pushSoftDeleteMetadata();
+
+    /**
+     * Get all Scout related metadata.
+     *
+     * @return array
+     */
+    public function scoutMetadata();
+
+    /**
+     * Set a Scout related metadata.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return Searchable
+     */
+    public function withScoutMetadata($key, $value);
+
+    /**
+     * Get the value used to index the model.
+     *
+     * @return mixed
+     */
+    public function getScoutKey();
+
+    /**
+     * Get the key name used to index the model.
+     *
+     * @return mixed
+     */
+    public function getScoutKeyName();
+}

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -182,7 +182,7 @@ class AlgoliaEngine extends Engine
      *
      * @param  \Laravel\Scout\Builder  $builder
      * @param  mixed  $results
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Scout\Contracts\Searchable  $model
      * @return \Illuminate\Database\Eloquent\Collection
      */
     public function map(Builder $builder, $results, $model)
@@ -209,7 +209,7 @@ class AlgoliaEngine extends Engine
      *
      * @param  \Laravel\Scout\Builder  $builder
      * @param  mixed  $results
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Scout\Contracts\Searchable  $model
      * @return \Illuminate\Support\LazyCollection
      */
     public function lazyMap(Builder $builder, $results, $model)
@@ -244,7 +244,7 @@ class AlgoliaEngine extends Engine
     /**
      * Flush all of the model's records from the engine.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Scout\Contracts\Searchable  $model
      * @return void
      */
     public function flush($model)

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -167,7 +167,7 @@ class CollectionEngine extends Engine
      *
      * @param  \Laravel\Scout\Builder  $builder
      * @param  mixed  $results
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Scout\Contracts\Searchable  $model
      * @return \Illuminate\Database\Eloquent\Collection
      */
     public function map(Builder $builder, $results, $model)
@@ -199,7 +199,7 @@ class CollectionEngine extends Engine
      *
      * @param  \Laravel\Scout\Builder  $builder
      * @param  mixed  $results
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Scout\Contracts\Searchable  $model
      * @return \Illuminate\Support\LazyCollection
      */
     public function lazyMap(Builder $builder, $results, $model)
@@ -239,7 +239,7 @@ class CollectionEngine extends Engine
     /**
      * Flush all of the model's records from the engine.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Scout\Contracts\Searchable  $model
      * @return void
      */
     public function flush($model)

--- a/src/Engines/Engine.php
+++ b/src/Engines/Engine.php
@@ -53,7 +53,7 @@ abstract class Engine
      *
      * @param  \Laravel\Scout\Builder  $builder
      * @param  mixed  $results
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Scout\Contracts\Searchable  $model
      * @return \Illuminate\Database\Eloquent\Collection
      */
     abstract public function map(Builder $builder, $results, $model);
@@ -63,7 +63,7 @@ abstract class Engine
      *
      * @param  \Laravel\Scout\Builder  $builder
      * @param  mixed  $results
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Scout\Contracts\Searchable  $model
      * @return \Illuminate\Support\LazyCollection
      */
     abstract public function lazyMap(Builder $builder, $results, $model);
@@ -79,7 +79,7 @@ abstract class Engine
     /**
      * Flush all of the model's records from the engine.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Scout\Contracts\Searchable  $model
      * @return void
      */
     abstract public function flush($model);

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -192,7 +192,7 @@ class MeiliSearchEngine extends Engine
      *
      * @param  \Laravel\Scout\Builder  $builder
      * @param  mixed  $results
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Scout\Contracts\Searchable  $model
      * @return \Illuminate\Database\Eloquent\Collection
      */
     public function map(Builder $builder, $results, $model)
@@ -219,7 +219,7 @@ class MeiliSearchEngine extends Engine
      *
      * @param  \Laravel\Scout\Builder  $builder
      * @param  mixed  $results
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Scout\Contracts\Searchable  $model
      * @return \Illuminate\Support\LazyCollection
      */
     public function lazyMap(Builder $builder, $results, $model)
@@ -254,7 +254,7 @@ class MeiliSearchEngine extends Engine
     /**
      * Flush all of the model's records from the engine.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Scout\Contracts\Searchable  $model
      * @return void
      */
     public function flush($model)

--- a/src/Engines/NullEngine.php
+++ b/src/Engines/NullEngine.php
@@ -71,7 +71,7 @@ class NullEngine extends Engine
      *
      * @param  \Laravel\Scout\Builder  $builder
      * @param  mixed  $results
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Scout\Contracts\Searchable  $model
      * @return \Illuminate\Database\Eloquent\Collection
      */
     public function map(Builder $builder, $results, $model)
@@ -84,7 +84,7 @@ class NullEngine extends Engine
      *
      * @param  \Laravel\Scout\Builder  $builder
      * @param  mixed  $results
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Scout\Contracts\Searchable  $model
      * @return \Illuminate\Support\LazyCollection
      */
     public function lazyMap(Builder $builder, $results, $model)
@@ -106,7 +106,7 @@ class NullEngine extends Engine
     /**
      * Flush all of the model's records from the engine.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Scout\Contracts\Searchable  $model
      * @return void
      */
     public function flush($model)

--- a/src/ModelObserver.php
+++ b/src/ModelObserver.php
@@ -69,7 +69,7 @@ class ModelObserver
     /**
      * Handle the saved event for the model.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Scout\Contracts\Searchable  $model
      * @return void
      */
     public function saved($model)
@@ -90,7 +90,7 @@ class ModelObserver
     /**
      * Handle the deleted event for the model.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Scout\Contracts\Searchable  $model
      * @return void
      */
     public function deleted($model)
@@ -109,7 +109,7 @@ class ModelObserver
     /**
      * Handle the force deleted event for the model.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Scout\Contracts\Searchable  $model
      * @return void
      */
     public function forceDeleted($model)
@@ -124,7 +124,7 @@ class ModelObserver
     /**
      * Handle the restored event for the model.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Scout\Contracts\Searchable  $model
      * @return void
      */
     public function restored($model)


### PR DESCRIPTION
In a recent project using Scout I wanted to check if a class uses the `Searchable` trait. Currently this can only be achieved by one of the following options:

```php
// A. check trait usage
if (! in_array(Searchable::class, class_uses($model)) {
    throw new Exception();
}

// B. check method existence
if (! method_exists($model, 'searchableAs')) {
    throw new Exception();
}
```

* Option A will work, but static analysis will not understand that `$model` has a specific set of methods.
* Option B does support static analysis, but is messy, because it doesn't really check for the trait (or specific contract).

Therefore I've added a contract to complement the trait.

```php
use Laravel\Scout\Contracts\Searchable as SearchableContract;

if (! $model instanceof SearchableContract::class) {
    throw new Exception();
}
```

This contract is not required for general use of Scout and is not a breaking change.
