### PR TITLE
Downcase attribute and query for case-insensitive search

### DIFF
--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -117,7 +117,7 @@ class CollectionEngine extends Engine
             foreach ($columns as $column) {
                 $attribute = $model->{$column};
 
-                if (Str::contains($attribute, $builder->query)) {
+                if (Str::contains(Str::lower($attribute), Str::lower($builder->query))) {
                     return true;
                 }
             }

--- a/tests/Feature/CollectionEngineTest.php
+++ b/tests/Feature/CollectionEngineTest.php
@@ -54,6 +54,9 @@ class CollectionEngineTest extends TestCase
         $models = SearchableUserModel::search('Taylor')->where('email', 'taylor@laravel.com')->get();
         $this->assertCount(1, $models);
 
+        $models = SearchableUserModel::search('otwell')->get();
+        $this->assertCount(2, $models);
+
         $models = SearchableUserModel::search('laravel')->get();
         $this->assertCount(2, $models);
 


### PR DESCRIPTION
A minor change to the collection engine that allows case-insensitive search by simply downcasing the attribute and query arguments before calling `contains`. Using the test data at the moment a search for a lowercase `otwell` wouldn't match either of you because your names are capitalised.