### PR TITLE
[9.x] Added an ability to retrieve hit metadata for MeiliSearch engine

### DIFF
--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -241,7 +241,7 @@ class MeiliSearchEngine extends Engine
 
         $hits = collect($results['hits'])->keyBy($model->getKeyName());
 
-        $objectIds = collect($results['hits'])->pluck($model->getKeyName())->values()->all();
+        $objectIds = $hits->pluck($model->getKeyName())->values()->all();
         $objectIdPositions = array_flip($objectIds);
 
         return $model->queryScoutModelsByIds(

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -214,17 +214,15 @@ class MeiliSearchEngine extends Engine
         $objectIds = $hits->pluck($model->getKeyName())->values()->all();
         $objectIdPositions = array_flip($objectIds);
 
-        return $model->getScoutModelsByIds($builder, $objectIds)
-            ->filter(function ($model) use ($objectIds) {
-                return in_array($model->getScoutKey(), $objectIds);
-            })
-            ->each(function ($model) use ($hits) {
-                $this->setHitMetadata($model, $hits);
-            })
-            ->sortBy(function ($model) use ($objectIdPositions) {
-                return $objectIdPositions[$model->getScoutKey()];
-            })
-            ->values();
+        return $model->getScoutModelsByIds(
+            $builder, $objectIds
+        )->filter(function ($model) use ($objectIds) {
+            return in_array($model->getScoutKey(), $objectIds);
+        })->each(function ($model) use ($hits) {
+            $this->setHitMetadata($model, $hits);
+        })->sortBy(function ($model) use ($objectIdPositions) {
+            return $objectIdPositions[$model->getScoutKey()];
+        })->values();
     }
 
     /**
@@ -246,18 +244,15 @@ class MeiliSearchEngine extends Engine
         $objectIds = collect($results['hits'])->pluck($model->getKeyName())->values()->all();
         $objectIdPositions = array_flip($objectIds);
 
-        return $model->queryScoutModelsByIds($builder, $objectIds)
-            ->cursor()
-            ->filter(function ($model) use ($objectIds) {
-                return in_array($model->getScoutKey(), $objectIds);
-            })
-            ->each(function ($model) use ($hits) {
-                $this->setHitMetadata($model, $hits);
-            })
-            ->sortBy(function ($model) use ($objectIdPositions) {
-                return $objectIdPositions[$model->getScoutKey()];
-            })
-            ->values();
+        return $model->queryScoutModelsByIds(
+            $builder, $objectIds
+        )->cursor()->filter(function ($model) use ($objectIds) {
+            return in_array($model->getScoutKey(), $objectIds);
+        })->each(function ($model) use ($hits) {
+            $this->setHitMetadata($model, $hits);
+        })->sortBy(function ($model) use ($objectIdPositions) {
+            return $objectIdPositions[$model->getScoutKey()];
+        })->values();
     }
 
     /**

--- a/tests/Fixtures/SearchableModel.php
+++ b/tests/Fixtures/SearchableModel.php
@@ -20,9 +20,4 @@ class SearchableModel extends Model
     {
         return 'table';
     }
-
-    public function scoutMetadata()
-    {
-        return [];
-    }
 }

--- a/tests/Unit/MeiliSearchEngineTest.php
+++ b/tests/Unit/MeiliSearchEngineTest.php
@@ -149,6 +149,28 @@ class MeiliSearchEngineTest extends TestCase
         $this->assertEquals(1, count($results));
     }
 
+    public function test_map_correctly_maps_results_to_models_with_metadata()
+    {
+        $client = m::mock(Client::class);
+        $engine = new MeiliSearchEngine($client);
+
+        $model = m::mock(stdClass::class);
+        $model->shouldReceive(['getKeyName' => 'id']);
+        $model->shouldReceive('getScoutModelsByIds')->andReturn(Collection::make([new SearchableModel(['id' => 1])]));
+        $builder = m::mock(Builder::class);
+
+        $results = $engine->map($builder, [
+            'nbHits' => 1,
+            'hits' => [
+                ['id' => 1, '_formatted' => ['id' => 1]],
+            ],
+        ], $model);
+
+        $this->assertEquals(1, count($results));
+
+        $this->assertSame(['_formatted' => ['id' => 1]], $results->first()->scoutMetadata());
+    }
+
     public function test_map_method_respects_order()
     {
         $client = m::mock(Client::class);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hi all.

What do you think about an ability for retrieving hit metadata for MeiliSearch from response like for Algolia Retrieve hit metadata?

It is needed for retrieving the result of the search from MeiliSearch as Attributes to highlight or something else for instances of the searchable models.

Currently we need to manually write this logic:

get raw search results from MeiliSearch
get models by ids from search result from db
map needed properties from search result (for highlight attributes we have _formatted property in raw data) to our instances
Thanks.

https://github.com/laravel/scout/issues/496
