### PR TITLE
Fix meilisearch where in

### DIFF
--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -152,21 +152,17 @@ class MeiliSearchEngine extends Engine
             return is_numeric($value)
                             ? sprintf('%s=%s', $key, $value)
                             : sprintf('%s="%s"', $key, $value);
-        })->values()->implode(' AND ');
-
-        if (empty($builder->whereIns)) {
-            return $filters;
-        }
+        });
 
         foreach ($builder->whereIns as $key => $values) {
-            $filters = $filters.' AND ('.collect($values)->map(function ($value) use ($key) {
+            $filters->push(sprintf("(%s)", collect($values)->map(function ($value) use ($key) {
                 return filter_var($value, FILTER_VALIDATE_INT) !== false
                                 ? sprintf('%s=%s', $key, $value)
                                 : sprintf('%s="%s"', $key, $value);
-            })->values()->implode(' OR ').')';
+            })->values()->implode(' OR ')));
         }
 
-        return $filters;
+        return $filters->values()->implode(' AND ');
     }
 
     /**

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -155,7 +155,7 @@ class MeiliSearchEngine extends Engine
         });
 
         foreach ($builder->whereIns as $key => $values) {
-            $filters->push(sprintf("(%s)", collect($values)->map(function ($value) use ($key) {
+            $filters->push(sprintf('(%s)', collect($values)->map(function ($value) use ($key) {
                 return filter_var($value, FILTER_VALIDATE_INT) !== false
                                 ? sprintf('%s=%s', $key, $value)
                                 : sprintf('%s="%s"', $key, $value);


### PR DESCRIPTION
Right now using only `whereIn` conditions, the filters string is always preprended with `' AND '` and the generated filter query is invalid for meilisearch.
With this change `where` and `whereIn` conditions are concateneted in the last step and the generated string is valid