### PR TITLE
HasManyThrough::macro('unsearchable') fix

### DIFF
--- a/src/SearchableScope.php
+++ b/src/SearchableScope.php
@@ -57,9 +57,9 @@ class SearchableScope implements Scope
 
         HasManyThrough::macro('unsearchable', function ($chunk = null) {
             $this->chunkById($chunk ?: config('scout.chunk.searchable', 500), function ($models) {
-                $models->filter->shouldBeSearchable()->searchable();
+                $models->unsearchable();
 
-                event(new ModelsImported($models));
+                event(new ModelsFlushed($models));
             });
         });
     }


### PR DESCRIPTION
Looks like `HasManyThrough::macro('unsearchable')` accidentaly defined same as `HasManyThrough::macro('searchable')` and makes models searchable... 

PS: I'm not tested this, because it is not used in our application.