### PR TITLE
Fixed non string columns breaking model filter with collection driver

### DIFF
--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -120,6 +120,10 @@ class CollectionEngine extends Engine
             foreach ($columns as $column) {
                 $attribute = $model->{$column};
 
+                if (!is_string($attribute)) {
+                    continue;
+                }
+
                 if (Str::contains(Str::lower($attribute), Str::lower($builder->query))) {
                     return true;
                 }

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -120,7 +120,7 @@ class CollectionEngine extends Engine
             foreach ($columns as $column) {
                 $attribute = $model->{$column};
 
-                if (!is_string($attribute)) {
+                if (! is_string($attribute)) {
                     continue;
                 }
 


### PR DESCRIPTION
This fixes an issue with the collection driver, if you have a column which is not a string, like a JSON column, The collection driver errors when trying to make the attribute lower case.

I have added a continue if the attribute is not a string.
