### PR TITLE
[10.x] Refactor the use of getScoutKeyName

### DIFF
--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -100,7 +100,9 @@ class CollectionEngine extends Engine
                                 $query->whereIn($key, $values);
                             }
                         })
-                        ->orderBy($builder->model->getScoutKeyName(), 'desc');
+                        ->orderBy(
+                            $builder->model->qualifyColumn($builder->model->getScoutKeyName()), 'desc'
+                        );
 
         $models = $this->ensureSoftDeletesAreHandled($builder, $query)
                         ->get()

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -100,7 +100,7 @@ class CollectionEngine extends Engine
                                 $query->whereIn($key, $values);
                             }
                         })
-                        ->orderBy($builder->model->getKeyName(), 'desc');
+                        ->orderBy($builder->model->getScoutKeyName(), 'desc');
 
         $models = $this->ensureSoftDeletesAreHandled($builder, $query)
                         ->get()
@@ -165,7 +165,7 @@ class CollectionEngine extends Engine
         $results = $results['results'];
 
         return count($results) > 0
-                    ? collect($results)->pluck($results[0]->getKeyName())->values()
+                    ? collect($results)->pluck($results[0]->getScoutKeyName())->values()
                     : collect();
     }
 
@@ -186,7 +186,7 @@ class CollectionEngine extends Engine
         }
 
         $objectIds = collect($results)
-                ->pluck($model->getKeyName())
+                ->pluck($model->getScoutKeyName())
                 ->values()
                 ->all();
 
@@ -218,7 +218,7 @@ class CollectionEngine extends Engine
         }
 
         $objectIds = collect($results)
-                ->pluck($model->getKeyName())
+                ->pluck($model->getScoutKeyName())
                 ->values()->all();
 
         $objectIdPositions = array_flip($objectIds);

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -65,7 +65,7 @@ class MeiliSearchEngine extends Engine
         })->filter()->values()->all();
 
         if (! empty($objects)) {
-            $index->addDocuments($objects, $models->first()->getKeyName());
+            $index->addDocuments($objects, $models->first()->getScoutKeyName());
         }
     }
 
@@ -197,7 +197,7 @@ class MeiliSearchEngine extends Engine
             return $model->newCollection();
         }
 
-        $objectIds = collect($results['hits'])->pluck($model->getKeyName())->values()->all();
+        $objectIds = collect($results['hits'])->pluck($model->getScoutKeyName())->values()->all();
 
         $objectIdPositions = array_flip($objectIds);
 
@@ -224,7 +224,7 @@ class MeiliSearchEngine extends Engine
             return LazyCollection::make($model->newCollection());
         }
 
-        $objectIds = collect($results['hits'])->pluck($model->getKeyName())->values()->all();
+        $objectIds = collect($results['hits'])->pluck($model->getScoutKeyName())->values()->all();
         $objectIdPositions = array_flip($objectIds);
 
         return $model->queryScoutModelsByIds(

--- a/src/Jobs/RemoveFromSearch.php
+++ b/src/Jobs/RemoveFromSearch.php
@@ -6,7 +6,6 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Str;
 
 class RemoveFromSearch implements ShouldQueue
 {
@@ -57,24 +56,9 @@ class RemoveFromSearch implements ShouldQueue
         return new EloquentCollection(
             collect($value->id)->map(function ($id) use ($value) {
                 return tap(new $value->class, function ($model) use ($id) {
-                    $keyName = $this->getUnqualifiedScoutKeyName(
-                        $model->getScoutKeyName()
-                    );
-
-                    $model->forceFill([$keyName => $id]);
+                    $model->forceFill([$model->getScoutKeyName() => $id]);
                 });
             })
         );
-    }
-
-    /**
-     * Get the unqualified Scout key name.
-     *
-     * @param string $keyName
-     * @return string
-     */
-    protected function getUnqualifiedScoutKeyName($keyName)
-    {
-        return Str::afterLast($keyName, '.');
     }
 }

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -144,7 +144,7 @@ trait Searchable
             ->when($softDelete, function ($query) {
                 $query->withTrashed();
             })
-            ->orderBy($self->getKeyName())
+            ->orderBy($self->getScoutKeyName())
             ->searchable($chunk);
     }
 
@@ -382,7 +382,7 @@ trait Searchable
      */
     public function getScoutKeyName()
     {
-        return $this->getQualifiedKeyName();
+        return $this->getKeyName();
     }
 
     /**

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -144,7 +144,9 @@ trait Searchable
             ->when($softDelete, function ($query) {
                 $query->withTrashed();
             })
-            ->orderBy($self->getScoutKeyName())
+            ->orderBy(
+                $self->qualifyColumn($self->getScoutKeyName())
+            )
             ->searchable($chunk);
     }
 
@@ -240,7 +242,7 @@ trait Searchable
         }
 
         return $query->whereIn(
-            $this->getScoutKeyName(), $ids
+            $this->qualifyColumn($this->getScoutKeyName()), $ids
         );
     }
 

--- a/tests/Feature/SearchableTest.php
+++ b/tests/Feature/SearchableTest.php
@@ -149,7 +149,7 @@ class ModelStubForMakeAllSearchable extends SearchableModel
                 });
 
         $mock->shouldReceive('orderBy')
-            ->with('id')
+            ->with('model_stub_for_make_all_searchables.id')
             ->andReturnSelf()
             ->shouldReceive('searchable');
 

--- a/tests/Fixtures/SearchableModelWithCustomKey.php
+++ b/tests/Fixtures/SearchableModelWithCustomKey.php
@@ -23,6 +23,6 @@ class SearchableModelWithCustomKey extends Model
 
     public function getScoutKeyName()
     {
-        return $this->qualifyColumn('other_id');
+        return 'other_id';
     }
 }

--- a/tests/Unit/MeiliSearchEngineTest.php
+++ b/tests/Unit/MeiliSearchEngineTest.php
@@ -136,7 +136,7 @@ class MeiliSearchEngineTest extends TestCase
         $engine = new MeiliSearchEngine($client);
 
         $model = m::mock(stdClass::class);
-        $model->shouldReceive(['getKeyName' => 'id']);
+        $model->shouldReceive(['getScoutKeyName' => 'id']);
         $model->shouldReceive('getScoutModelsByIds')->andReturn($models = Collection::make([new SearchableModel(['id' => 1])]));
         $builder = m::mock(Builder::class);
 
@@ -155,7 +155,7 @@ class MeiliSearchEngineTest extends TestCase
         $engine = new MeiliSearchEngine($client);
 
         $model = m::mock(stdClass::class);
-        $model->shouldReceive(['getKeyName' => 'id']);
+        $model->shouldReceive(['getScoutKeyName' => 'id']);
         $model->shouldReceive('getScoutModelsByIds')->andReturn($models = Collection::make([
             new SearchableModel(['id' => 1]),
             new SearchableModel(['id' => 2]),
@@ -189,7 +189,7 @@ class MeiliSearchEngineTest extends TestCase
         $engine = new MeiliSearchEngine($client);
 
         $model = m::mock(stdClass::class);
-        $model->shouldReceive(['getKeyName' => 'id']);
+        $model->shouldReceive(['getScoutKeyName' => 'id']);
         $model->shouldReceive('queryScoutModelsByIds->cursor')->andReturn($models = LazyCollection::make([new SearchableModel(['id' => 1])]));
         $builder = m::mock(Builder::class);
 
@@ -208,7 +208,7 @@ class MeiliSearchEngineTest extends TestCase
         $engine = new MeiliSearchEngine($client);
 
         $model = m::mock(stdClass::class);
-        $model->shouldReceive(['getKeyName' => 'id']);
+        $model->shouldReceive(['getScoutKeyName' => 'id']);
         $model->shouldReceive('queryScoutModelsByIds->cursor')->andReturn($models = LazyCollection::make([
             new SearchableModel(['id' => 1]),
             new SearchableModel(['id' => 2]),

--- a/tests/Unit/RemoveFromSearchTest.php
+++ b/tests/Unit/RemoveFromSearchTest.php
@@ -67,7 +67,7 @@ class RemoveFromSearchTest extends TestCase
         $this->assertInstanceOf(SearchableModelWithCustomKey::class, $job->models->first());
         $this->assertTrue($model->is($job->models->first()));
         $this->assertEquals(1234, $job->models->first()->getScoutKey());
-        $this->assertEquals('searchable_model_with_custom_keys.other_id', $job->models->first()->getScoutKeyName());
+        $this->assertEquals('other_id', $job->models->first()->getScoutKeyName());
     }
 
     public function test_removeable_scout_collection_returns_scout_keys()


### PR DESCRIPTION
This PR changes the use of getScoutKeyName. The most significant change is the removal of the use of the qualified column name in the `getScoutKeyName` method. Other changes are using the `getScoutKeyName` instead of `getKeyName` so people can modify what column is used to index search records. This was already possible with Algolia but not with Meilisearch.

The reason why the qualified column was removed was that if someone were to override `getScoutKeyName` (with the other changes in mind from this PR) the `toSearchableArray` wouldn't be compatible anymore as it won't append the correct column name and thus search records in Meilisearch won't index properly anymore. If we want to make `getScoutKeyName` adjustable for Meilisearch as well (as currently stated in the docs) then this change is necessary. As pointed out by @mmachatschek in https://github.com/laravel/scout/pull/484#issuecomment-863189618, Algolia doesn't suffer from this as it's using its own internal objectID mapping. 

The upgrade path for this unfortunately is that people will have to re-index their search records. If that's not wanted then we should re-consider removing the ability to override the key name. 

I'm also not entirely sure what the original reason for the use of the qualified column name was. I do not know if there will be a breaking change because if this.

I'd appreciate a review from you @mmachatschek before I mark this as ready to review for Taylor. 
