### PR TITLE
[9.x] Support rename of filters to filter in meilisearch 0.21.x

### DIFF
--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -127,9 +127,9 @@ class MeiliSearchEngine extends Engine
     {
         $meilisearch = $this->meilisearch->index($builder->index ?: $builder->model->searchableAs());
 
-        // from 0.21.0 onwards, `filters` is renamed to `filter`
         if (version_compare(MeiliSearch::VERSION, '0.21.0') >= 0) {
             $searchParams['filter'] = $searchParams['filters'];
+
             unset($searchParams['filters']);
         }
 

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -4,7 +4,8 @@ namespace Laravel\Scout\Engines;
 
 use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;
-use MeiliSearch\Client as MeiliSearch;
+use MeiliSearch\Client as MeiliSearchClient;
+use MeiliSearch\MeiliSearch;
 use MeiliSearch\Search\SearchResult;
 
 class MeiliSearchEngine extends Engine
@@ -30,7 +31,7 @@ class MeiliSearchEngine extends Engine
      * @param  bool  $softDelete
      * @return void
      */
-    public function __construct(MeiliSearch $meilisearch, $softDelete = false)
+    public function __construct(MeiliSearchClient $meilisearch, $softDelete = false)
     {
         $this->meilisearch = $meilisearch;
         $this->softDelete = $softDelete;
@@ -127,7 +128,7 @@ class MeiliSearchEngine extends Engine
         $meilisearch = $this->meilisearch->index($builder->index ?: $builder->model->searchableAs());
 
         // from 0.21.0 onwards, `filters` is renamed to `filter`
-        if (version_compare($this->getInstalledMeilisearchVersion(), '0.21.0') >= 0) {
+        if (version_compare(MeiliSearch::VERSION, '0.21.0') >= 0) {
             $searchParams['filter'] = $searchParams['filters'];
             unset($searchParams['filters']);
         }
@@ -314,15 +315,5 @@ class MeiliSearchEngine extends Engine
     public function __call($method, $parameters)
     {
         return $this->meilisearch->$method(...$parameters);
-    }
-
-    /**
-     * Get the version of the meilisearch/meilisearch-php package intalled by Composer.
-     *
-     * @return string
-     */
-    protected function getInstalledMeilisearchVersion()
-    {
-        return \MeiliSearch\MeiliSearch::VERSION;
     }
 }

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Scout\Engines;
 
-use Composer\InstalledVersions;
 use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;
 use MeiliSearch\Client as MeiliSearch;
@@ -320,14 +319,10 @@ class MeiliSearchEngine extends Engine
     /**
      * Get the version of the meilisearch/meilisearch-php package intalled by Composer.
      *
-     * @return string|null
+     * @return string
      */
     protected function getInstalledMeilisearchVersion()
     {
-        try {
-            return InstalledVersions::getVersion('meilisearch/meilisearch-php');
-        } catch (\OutOfBoundsException $e) {
-            return null;
-        }
+        return \MeiliSearch\MeiliSearch::VERSION;
     }
 }


### PR DESCRIPTION
Meilisearch 0.21.0 [contains a breaking change](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.21.0) regarding the `filters` attribute. It was renamed to `filter` instead.
This PR addresses that by checking what version of the SDK was installed, and handling the attribute accordingly.

Not that user would need to manually add the attributes they want to filter on to the `filterableAttributes` setting, they can not be used on any field any more as one could before version 0.21.