### PR TITLE
[9.x] Add the ability to omit the search argument in the CollectionEngine

### DIFF
--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -117,6 +117,10 @@ class CollectionEngine extends Engine
                 return false;
             }
 
+            if (! $builder->query) {
+                return true;
+            }
+
             foreach ($columns as $column) {
                 $attribute = $model->{$column};
 

--- a/tests/Feature/CollectionEngineTest.php
+++ b/tests/Feature/CollectionEngineTest.php
@@ -38,6 +38,13 @@ class CollectionEngineTest extends TestCase
         ]);
     }
 
+    public function test_it_can_retrieve_results_with_empty_search()
+    {
+        $models = SearchableUserModel::search()->get();
+
+        $this->assertCount(2, $models);
+    }
+
     public function test_it_can_retrieve_results()
     {
         $models = SearchableUserModel::search('Taylor')->where('email', 'taylor@laravel.com')->get();


### PR DESCRIPTION
This PR adds the ability to pass an empty search argument, which skips the search filtering step.