### PR TITLE
Fixed #518 - Searching on custom searchable data when using collection driver

### DIFF
--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -110,9 +110,7 @@ class CollectionEngine extends Engine
             return $models;
         }
 
-        $columns = array_keys($models->first()->toSearchableArray());
-
-        return $models->filter(function ($model) use ($builder, $columns) {
+        return $models->filter(function ($model) use ($builder) {
             if (! $model->shouldBeSearchable()) {
                 return false;
             }
@@ -121,14 +119,10 @@ class CollectionEngine extends Engine
                 return true;
             }
 
-            foreach ($columns as $column) {
-                $attribute = $model->{$column};
+            $searchables = $model->toSearchableArray();
 
-                if (! is_string($attribute)) {
-                    continue;
-                }
-
-                if (Str::contains(Str::lower($attribute), Str::lower($builder->query))) {
+            foreach ($searchables as $value) {
+                if (Str::contains(Str::lower($value), Str::lower($builder->query))) {
                     return true;
                 }
             }

--- a/tests/Feature/CollectionEngineTest.php
+++ b/tests/Feature/CollectionEngineTest.php
@@ -5,6 +5,7 @@ namespace Laravel\Scout\Tests\Feature;
 use Illuminate\Foundation\Testing\WithFaker;
 use Laravel\Scout\ScoutServiceProvider;
 use Laravel\Scout\Tests\Fixtures\SearchableUserModel;
+use Laravel\Scout\Tests\Fixtures\SearchableUserModelWithCustomSearchableData;
 use Orchestra\Testbench\Factories\UserFactory;
 use Orchestra\Testbench\TestCase;
 
@@ -79,6 +80,12 @@ class CollectionEngineTest extends TestCase
 
         $models = SearchableUserModel::search('Abigail')->where('email', 'taylor@laravel.com')->get();
         $this->assertCount(0, $models);
+    }
+
+    public function test_it_can_retrieve_results_matching_to_custom_searchable_data()
+    {
+        $models = SearchableUserModelWithCustomSearchableData::search('rolyaT')->get();
+        $this->assertCount(1, $models);
     }
 
     public function test_it_can_paginate_results()

--- a/tests/Fixtures/SearchableUserModelWithCustomSearchableData.php
+++ b/tests/Fixtures/SearchableUserModelWithCustomSearchableData.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Laravel\Scout\Tests\Fixtures;
+
+use Illuminate\Foundation\Auth\User as Model;
+use Laravel\Scout\Searchable;
+
+class SearchableUserModelWithCustomSearchableData extends Model
+{
+    use Searchable;
+
+    protected $table = 'users';
+
+    public function toSearchableArray(): array
+    {
+        return [
+            'reversed_name' => strrev($this->name),
+        ];
+    }
+}


### PR DESCRIPTION
Fixes #518

This PR adds functionality to search inside custom searchable data when using 'collection' engine.

### The example:
Let's assume there is an e-commerce application which has products and their attributes in separate tables.

 - Products has many Attributes
 - Attributes has many Products

Because of all the key attributes such as price is in the attribute_product pivot table we have to assign those attributes manually in the 'toSearchableArray' method in the Product modal to make the search form price working.

In such situations the collection engine does not currently support searching on custom searchable data such as price in this example.

In this MR the searching will be same as other engines such as Meilisearch engine and Algolia engine

