### PR TITLE
[9.x] - Collection Engine: add support for non-scalar values

### DIFF
--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -122,6 +122,9 @@ class CollectionEngine extends Engine
             $searchables = $model->toSearchableArray();
 
             foreach ($searchables as $value) {
+                if (! is_scalar($value)) {
+                    $value = json_encode($value);
+                }
                 if (Str::contains(Str::lower($value), Str::lower($builder->query))) {
                     return true;
                 }

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -125,6 +125,7 @@ class CollectionEngine extends Engine
                 if (! is_scalar($value)) {
                     $value = json_encode($value);
                 }
+
                 if (Str::contains(Str::lower($value), Str::lower($builder->query))) {
                     return true;
                 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
The Algolia and MeiliSearch engines both allow searchable data to be non-scalar values (e.g., an [array of ingredients](https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/how-to/setting-searchable-attributes/) or [genres](https://docs.meilisearch.com/reference/features/filtering_and_faceted_search.html#example-2)).

The Collection engine, however, expects all values to be scalar, and during search, throws a `TypeError` if a model’s `toSearchableArray()` returns any non-scalar key.

```
TypeError: mb_strtolower(): Argument #1 ($string) must be of type string, array given in /path/to/project/vendor/laravel/framework/src/Illuminate/Support/Str.php:361
Stack trace:
#0 /path/to/project/vendor/laravel/framework/src/Illuminate/Support/Str.php(361): mb_strtolower(Array, 'UTF-8')
// etc.
```

This PR is a stupid-simple fix that just JSON-encodes non-scalar values on the theory that it will result in a string that `Str::contains()` will be able to inspect for the search term.