### PR TITLE
support operators in filters

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -111,12 +111,17 @@ class Builder
      * Add a constraint to the search query.
      *
      * @param  string  $field
+     * @param  string  $operator
      * @param  mixed  $value
      * @return $this
      */
-    public function where($field, $value)
+    public function where($field, $operator, $value = null)
     {
-        $this->wheres[$field] = $value;
+        if(func_num_args() == 2){
+            $value = $operator;
+            $operator = '=';
+        }
+        $this->wheres[$field] = [$operator, $value];
 
         return $this;
     }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -117,7 +117,7 @@ class Builder
      */
     public function where($field, $operator, $value = null)
     {
-        if(func_num_args() == 2){
+        if (func_num_args() == 2) {
             $value = $operator;
             $operator = '=';
         }

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -155,8 +155,9 @@ class AlgoliaEngine extends Engine
      */
     protected function filters(Builder $builder)
     {
-        $wheres = collect($builder->wheres)->map(function ($value, $key) {
-            return $key.'='.$value;
+        $wheres = collect($builder->wheres)->map(function ($operation, $key) {
+            [$operator,  $value] = $operation;
+            return $key.$operator.$value;
         })->values();
 
         return $wheres->merge(collect($builder->whereIns)->map(function ($values, $key) {

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -89,9 +89,10 @@ class CollectionEngine extends Engine
                             call_user_func($builder->callback, $query, $builder, $builder->query);
                         })
                         ->when(! $builder->callback && count($builder->wheres) > 0, function ($query) use ($builder) {
-                            foreach ($builder->wheres as $key => $value) {
+                            foreach ($builder->wheres as $key => $operation) {
+                                [$operator, $value] = $operation;
                                 if ($key !== '__soft_deleted') {
-                                    $query->where($key, $value);
+                                    $query->where($key, $operator, $value);
                                 }
                             }
                         })

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -161,7 +161,7 @@ class MeiliSearchEngine extends Engine
 
             if (is_bool($value)) {
                 return sprintf('%s%s%s', $key, $operator, $value ? 'true' : 'false');
-            } else if (is_numeric($value)) {
+            } elseif (is_numeric($value)) {
                 return sprintf('%s%s%s', $key, $operator, $value);
             }
 

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -156,14 +156,15 @@ class MeiliSearchEngine extends Engine
      */
     protected function filters(Builder $builder)
     {
-        $filters = collect($builder->wheres)->map(function ($value, $key) {
+        $filters = collect($builder->wheres)->map(function ($operation, $key) {
+            [$operator,  $value] = $operation;
             if (is_bool($value)) {
-                return sprintf('%s=%s', $key, $value ? 'true' : 'false');
+                return sprintf('%s%s%s', $key, $operator, $value ? 'true' : 'false');
             }
 
             return is_numeric($value)
-                            ? sprintf('%s=%s', $key, $value)
-                            : sprintf('%s="%s"', $key, $value);
+                            ? sprintf('%s%s%s', $key, $operator, $value)
+                            : sprintf('%s%s"%s"', $key, $operator, $value);
         });
 
         foreach ($builder->whereIns as $key => $values) {

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -158,13 +158,14 @@ class MeiliSearchEngine extends Engine
     {
         $filters = collect($builder->wheres)->map(function ($operation, $key) {
             [$operator,  $value] = $operation;
+
             if (is_bool($value)) {
                 return sprintf('%s%s%s', $key, $operator, $value ? 'true' : 'false');
+            } else if (is_numeric($value)) {
+                return sprintf('%s%s%s', $key, $operator, $value);
             }
 
-            return is_numeric($value)
-                            ? sprintf('%s%s%s', $key, $operator, $value)
-                            : sprintf('%s%s"%s"', $key, $operator, $value);
+            return sprintf('%s%s"%s"', $key, $operator, $value);
         });
 
         foreach ($builder->whereIns as $key => $values) {

--- a/tests/Unit/AlgoliaEngineTest.php
+++ b/tests/Unit/AlgoliaEngineTest.php
@@ -248,7 +248,7 @@ class AlgoliaEngineTest extends TestCase
 
         $engine = new AlgoliaEngine($client);
         $builder = new Builder(new SearchableModel, 'zonda');
-        $builder->where('foo', 1)->where('bar','<>',1);
+        $builder->where('foo', 1)->where('bar', '<>', 1);
         $engine->search($builder);
     }
 }

--- a/tests/Unit/AlgoliaEngineTest.php
+++ b/tests/Unit/AlgoliaEngineTest.php
@@ -237,6 +237,20 @@ class AlgoliaEngineTest extends TestCase
         $engine = new AlgoliaEngine($client, true);
         $engine->update(Collection::make([new SoftDeletedEmptySearchableModel]));
     }
+
+    public function test_search_supports_operators_in_where_clause()
+    {
+        $client = m::mock(SearchClient::class);
+        $client->shouldReceive('initIndex')->with('table')->andReturn($index = m::mock(stdClass::class));
+        $index->shouldReceive('search')->with('zonda', [
+            'numericFilters' => ['foo=1', 'bar<>1'],
+        ]);
+
+        $engine = new AlgoliaEngine($client);
+        $builder = new Builder(new SearchableModel, 'zonda');
+        $builder->where('foo', 1)->where('bar','<>',1);
+        $engine->search($builder);
+    }
 }
 
 class AlgoliaCustomKeySearchableModel extends SearchableModel

--- a/tests/Unit/MeiliSearchEngineTest.php
+++ b/tests/Unit/MeiliSearchEngineTest.php
@@ -400,6 +400,24 @@ class MeiliSearchEngineTest extends TestCase
         $engine = new MeiliSearchEngine($client);
         $engine->search($builder);
     }
+
+    public function test_where_conditions_can_be_numeric_or_boolean()
+    {
+        $builder = new Builder(new SearchableModel(), '');
+        $builder->where('foo', '=', 'bar');
+        $builder->where('bar', '>', 85);
+        $builder->where('baz', '<>', true);
+
+        $client = m::mock(Client::class);
+        $client->shouldReceive('index')->once()->andReturn($index = m::mock(Indexes::class));
+        $index->shouldReceive('rawSearch')->once()->with($builder->query, array_filter([
+            'filter' => 'foo="bar" AND bar>85 AND baz<>true',
+            'limit' => $builder->limit,
+        ]))->andReturn([]);
+
+        $engine = new MeiliSearchEngine($client);
+        $engine->search($builder);
+    }
 }
 
 class MeiliSearchCustomKeySearchableModel extends SearchableModel

--- a/tests/Unit/MeiliSearchEngineTest.php
+++ b/tests/Unit/MeiliSearchEngineTest.php
@@ -383,6 +383,23 @@ class MeiliSearchEngineTest extends TestCase
             'nbHits' => 3,
         ]));
     }
+
+    public function test_where_conditions_can_have_an_operator()
+    {
+        $builder = new Builder(new SearchableModel(), '');
+        $builder->where('foo', '=', 'bar');
+        $builder->where('bar', '<>', 'baz');
+
+        $client = m::mock(Client::class);
+        $client->shouldReceive('index')->once()->andReturn($index = m::mock(Indexes::class));
+        $index->shouldReceive('rawSearch')->once()->with($builder->query, array_filter([
+            'filter' => 'foo="bar" AND bar<>"baz"',
+            'limit' => $builder->limit,
+        ]))->andReturn([]);
+
+        $engine = new MeiliSearchEngine($client);
+        $engine->search($builder);
+    }
 }
 
 class MeiliSearchCustomKeySearchableModel extends SearchableModel


### PR DESCRIPTION
TL;DR;
Support for query operators like `->where('foo','>','1')` short (old) version still works `->where('foo','1')`



Both Algolia and MeiliSearch supports different operators when filtering:
` <, <=, =, !=, >=, > ` are available for both engine

[Algolia docs](https://www.algolia.com/doc/guides/managing-results/refine-results/filtering/how-to/filter-by-numeric-value/#applying-a-numeric-filter)
[MeiliSearch docs](https://docs.meilisearch.com/reference/features/filtering_and_faceted_search.html#using-filters)

this PR enables the user to choose a different operator from the default (`=`) while maintaining backward compatibility

solves #529