### PR TITLE
[8.x] Add simplePaginateRaw query

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -289,6 +289,41 @@ class Builder
     }
 
     /**
+     * Paginate the given query into a simple paginator with raw data.
+     *
+     * @param  int  $perPage
+     * @param  string  $pageName
+     * @param  int|null  $page
+     * @return \Illuminate\Contracts\Pagination\Paginator
+     */
+    public function simplePaginateRaw($perPage = null, $pageName = 'page', $page = null)
+    {
+        $engine = $this->engine();
+
+        $page = $page ?: Paginator::resolveCurrentPage($pageName);
+
+        $perPage = $perPage ?: $this->model->getPerPage();
+
+        $results = $engine->paginate($this, $perPage, $page);
+
+        $total = $engine->getTotalCount($rawResults);
+
+        $hasMorePages = ($perPage * $page) < $engine->getTotalCount($rawResults);
+
+        $paginator = Container::getInstance()->makeWith(Paginator::class, [
+            'items' => $results,
+            'perPage' => $perPage,
+            'currentPage' => $page,
+            'options' => [
+                'path' => Paginator::resolveCurrentPath(),
+                'pageName' => $pageName,
+            ],
+        ])->hasMorePagesWhen($hasMorePages);
+
+        return $paginator->appends('query', $this->query);
+    }
+
+    /**
      * Paginate the given query into a paginator.
      *
      * @param  int  $perPage
@@ -323,7 +358,7 @@ class Builder
     }
 
     /**
-     * Paginate the given query into a simple paginator with raw data.
+     * Paginate the given query into a paginator with raw data.
      *
      * @param  int  $perPage
      * @param  string  $pageName


### PR DESCRIPTION
The method complements the existing `simplePaginate()` method with the option to recive the "raw" data of the search engine.

There already exists a `paginate()` and `paginateRaw()` method.