### PR TITLE
Handle sorting (Meilisearch)

### DIFF
--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -97,7 +97,7 @@ class MeiliSearchEngine extends Engine
         return $this->performSearch($builder, array_filter([
             'filters' => $this->filters($builder),
             'limit' => $builder->limit,
-            'sort' => $this->sorters($builder),
+            'sort' => $this->buildSortFromOrderByClauses($builder),
         ]));
     }
 
@@ -188,7 +188,7 @@ class MeiliSearchEngine extends Engine
      * @param  \Laravel\Scout\Builder  $builder
      * @return array
      */
-    protected function sorters(Builder $builder): array
+    protected function buildSortFromOrderByClauses(Builder $builder): array
     {
         return collect($builder->orders)->map(function (array $order) {
             return $order['column'].':'.$order['direction'];

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -191,10 +191,10 @@ class MeiliSearchEngine extends Engine
     protected function sorters(Builder $builder): array
     {
         return collect($builder->orders)->map(function(array $order) {
-            return $order['column'] .':'. $order['direction'];
+            return $order['column'].':'.$order['direction'];
         })->toArray();
     }
-    
+
     /**
      * Pluck and return the primary keys of the given results.
      *

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -190,7 +190,7 @@ class MeiliSearchEngine extends Engine
      */
     protected function sorters(Builder $builder): array
     {
-        return collect($builder->orders)->map(function(array $order) {
+        return collect($builder->orders)->map(function (array $order) {
             return $order['column'].':'.$order['direction'];
         })->toArray();
     }

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -97,6 +97,7 @@ class MeiliSearchEngine extends Engine
         return $this->performSearch($builder, array_filter([
             'filters' => $this->filters($builder),
             'limit' => $builder->limit,
+            'sort' => $this->sorters($builder),
         ]));
     }
 
@@ -181,6 +182,19 @@ class MeiliSearchEngine extends Engine
         return $filters->values()->implode(' AND ');
     }
 
+    /**
+     * Get the sort array for the query.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return array
+     */
+    protected function sorters(Builder $builder): array
+    {
+        return collect($builder->orders)->map(function(array $order) {
+            return $order['column'] .':'. $order['direction'];
+        })->toArray();
+    }
+    
     /**
      * Pluck and return the primary keys of the given results.
      *


### PR DESCRIPTION
Sorting in the meilisearch is for a long time and works very good so there is no reason to not implement this functionality.

https://docs.meilisearch.com/reference/features/search_parameters.html#sort

```php
$query->orderBy('date', 'desc');
$query->orderBy('price', 'asc');
```

By this query, we sort results first by date (newest) and next by price (cheapest). Sorting works like in MySQL.
