### PR TITLE
[10.x] Provide searchable data array with primary key and value for MeiliSearch

### DIFF
--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -62,7 +62,11 @@ class MeiliSearchEngine extends Engine
                 return;
             }
 
-            return array_merge($searchableData, $model->scoutMetadata());
+            return array_merge(
+                [$model->getScoutKeyName() => $model->getScoutKey()],
+                $searchableData,
+                $model->scoutMetadata()
+            );
         })->filter()->values()->all();
 
         if (! empty($objects)) {
@@ -203,7 +207,7 @@ class MeiliSearchEngine extends Engine
     }
 
     /**
-     * Pluck and the given results with the given primary key name.
+     * Pluck the given results with the given primary key name.
      *
      * @param  mixed  $results
      * @param  string  $key

--- a/tests/Unit/MeiliSearchEngineTest.php
+++ b/tests/Unit/MeiliSearchEngineTest.php
@@ -275,10 +275,13 @@ class MeiliSearchEngineTest extends TestCase
     {
         $client = m::mock(Client::class);
         $client->shouldReceive('index')->with('table')->andReturn($index = m::mock(Indexes::class));
-        $index->shouldReceive('addDocuments')->with([['id' => 'my-meilisearch-key.1']], 'id');
+        $index->shouldReceive('addDocuments')->once()->with([[
+            'meilisearch-key' => 'my-meilisearch-key.5',
+            'id' => 5,
+        ]], 'meilisearch-key');
 
         $engine = new MeiliSearchEngine($client);
-        $engine->update(Collection::make([new MeiliSearchCustomKeySearchableModel()]));
+        $engine->update(Collection::make([new MeiliSearchCustomKeySearchableModel(['id' => 5])]));
     }
 
     public function test_flush_a_model_with_a_custom_meilisearch_key()
@@ -425,5 +428,10 @@ class MeiliSearchCustomKeySearchableModel extends SearchableModel
     public function getScoutKey()
     {
         return 'my-meilisearch-key.'.$this->getKey();
+    }
+
+    public function getScoutKeyName()
+    {
+        return 'meilisearch-key';
     }
 }


### PR DESCRIPTION
Since `getScoutKeyName()` and `getScoutKey()` return the expected data (https://github.com/laravel/scout/pull/509) we can now build the searchable data ourselves.

This adds consistancy to the already implemented collection engine and Algolia engine that make use of a "predefined" primary key.

Furthermore, this reduces bugs on the implementation side for users that override the `toSearchableArray()` method and forget to add the primary key.