### PR TITLE
[9.x] Fix issues for users providing searchable array without primary key

### DIFF
--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -62,7 +62,11 @@ class MeiliSearchEngine extends Engine
                 return;
             }
 
-            return array_merge($searchableData, $model->scoutMetadata());
+            return array_merge(
+                [$model->getKeyName() => $model->getScoutKey()],
+                $searchableData,
+                $model->scoutMetadata()
+            );
         })->filter()->values()->all();
 
         if (! empty($objects)) {

--- a/tests/Unit/MeiliSearchEngineTest.php
+++ b/tests/Unit/MeiliSearchEngineTest.php
@@ -275,10 +275,12 @@ class MeiliSearchEngineTest extends TestCase
     {
         $client = m::mock(Client::class);
         $client->shouldReceive('index')->with('table')->andReturn($index = m::mock(Indexes::class));
-        $index->shouldReceive('addDocuments')->with([['id' => 'my-meilisearch-key.1']], 'id');
+        $index->shouldReceive('addDocuments')->once()->with([[
+            'id' => 5,
+        ]], 'id');
 
         $engine = new MeiliSearchEngine($client);
-        $engine->update(Collection::make([new MeiliSearchCustomKeySearchableModel()]));
+        $engine->update(Collection::make([new MeiliSearchCustomKeySearchableModel(['id' => 5])]));
     }
 
     public function test_flush_a_model_with_a_custom_meilisearch_key()


### PR DESCRIPTION
This is a backport to the changes in #546 for the 9.x branch
