### PR TITLE
Add syncToSearchWithoutQueue($callback) to skip using the queue.

### DIFF
--- a/src/ModelObserver.php
+++ b/src/ModelObserver.php
@@ -37,6 +37,13 @@ class ModelObserver
     protected static $syncingDisabledFor = [];
 
     /**
+     * The class names that syncing with queue is disabled for.
+     *
+     * @var array
+     */
+    protected static $queueDisabledFor = [];
+
+    /**
      * Create a new observer instance.
      *
      * @return void
@@ -80,6 +87,41 @@ class ModelObserver
         $class = is_object($class) ? get_class($class) : $class;
 
         return isset(static::$syncingDisabledFor[$class]);
+    }
+
+    /**
+     * Enable syncing with queue for the given class.
+     *
+     * @param  string  $class
+     * @return void
+     */
+    public static function enableQueueFor($class)
+    {
+        unset(static::$queueDisabledFor[$class]);
+    }
+
+    /**
+     * Disable syncing with queue for the given class.
+     *
+     * @param  string  $class
+     * @return void
+     */
+    public static function disableQueueFor($class)
+    {
+        static::$queueDisabledFor[$class] = true;
+    }
+
+    /**
+     * Determine if syncing with queue is disabled for the given class or model.
+     *
+     * @param  object|string  $class
+     * @return bool
+     */
+    public static function queueDisabledFor($class)
+    {
+        $class = is_object($class) ? get_class($class) : $class;
+
+        return isset(static::$queueDisabledFor[$class]);
     }
 
     /**

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -58,7 +58,7 @@ trait Searchable
             return;
         }
 
-        if (! config('scout.queue')) {
+        if (! config('scout.queue') || ModelObserver::queueDisabledFor($models->first())) {
             return $models->first()->searchableUsing()->update($models);
         }
 
@@ -79,7 +79,7 @@ trait Searchable
             return;
         }
 
-        if (! config('scout.queue')) {
+        if (! config('scout.queue') || ModelObserver::queueDisabledFor($models->first())) {
             return $models->first()->searchableUsing()->delete($models);
         }
 
@@ -278,6 +278,43 @@ trait Searchable
             return $callback();
         } finally {
             static::enableSearchSyncing();
+        }
+    }
+
+    /**
+     * Enable search syncing using queue for this model.
+     *
+     * @return void
+     */
+    public static function enableSearchQueue()
+    {
+        ModelObserver::enableQueueFor(get_called_class());
+    }
+
+    /**
+     * Disable search syncing using queue for this model.
+     *
+     * @return void
+     */
+    public static function disableSearchQueue()
+    {
+        ModelObserver::disableQueueFor(get_called_class());
+    }
+
+    /**
+     * Temporarily disable search syncing using queue for the given callback.
+     *
+     * @param  callable  $callback
+     * @return mixed
+     */
+    public static function syncToSearchWithoutQueue($callback)
+    {
+        static::disableSearchQueue();
+
+        try {
+            return $callback();
+        } finally {
+            static::enableSearchQueue();
         }
     }
 

--- a/tests/Feature/SearchableTest.php
+++ b/tests/Feature/SearchableTest.php
@@ -92,6 +92,21 @@ class SearchableTest extends TestCase
         Scout::removeFromSearchUsing(RemoveFromSearch::class);
     }
 
+    public function test_job_not_pushed_to_queue_when_using_sync_to_search_without_queue()
+    {
+        Queue::fake();
+
+        config()->set('scout.queue', true);
+
+        $model = new SearchableModel;
+
+        $model->syncToSearchWithoutQueue(function() use ($model) {
+            $model->searchable();
+
+            Queue::assertNotPushed(MakeSearchable::class);
+        });
+    }
+
     public function test_was_searchable_on_model_without_soft_deletes()
     {
         $model = new SearchableModel;

--- a/tests/Feature/SearchableTest.php
+++ b/tests/Feature/SearchableTest.php
@@ -100,7 +100,7 @@ class SearchableTest extends TestCase
 
         $model = new SearchableModel;
 
-        $model->syncToSearchWithoutQueue(function() use ($model) {
+        $model->syncToSearchWithoutQueue(function () use ($model) {
             $model->searchable();
 
             Queue::assertNotPushed(MakeSearchable::class);


### PR DESCRIPTION
At times it's nice to skip using the queue. This gives you instant indexing in certain situations while still having the ability to use the queue for all other Scout syncs.