### PR TITLE
[9.x] Pass builder instance to custom search callback

### DIFF
--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -140,7 +140,8 @@ class AlgoliaEngine extends Engine
                 $builder->callback,
                 $algolia,
                 $builder->query,
-                $options
+                $options,
+                $builder,
             );
         }
 

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -143,7 +143,8 @@ class MeiliSearchEngine extends Engine
                 $builder->callback,
                 $meilisearch,
                 $builder->query,
-                $searchParams
+                $searchParams,
+                $builder,
             );
 
             return $result instanceof SearchResult ? $result->getRaw() : $result;


### PR DESCRIPTION
This adds the possibility to access data configured on the builder instance in a custom search query. As pointed out here https://github.com/laravel/scout/pull/537#issue-1017081540 there is already a "orderBy" method on the builder instance that is currently only useful to the collection engine but not to the MeiliSearch engine or algolia.

This PR makes the following example possible and leaves the implementation of the orderBy query on the user side if needed and doesn't add additional methods to the builder or engine:

```php
Product::search('query', function($meilisearch, $query, $options, $builder) {
    $options['sort'] = collect($builder->orders)->map(function ($order) {
        return $order['column'] . ':' . $order['direction'];
    })->toArray();
    return $meilisearch->rawSearch($query, $options);
})->where('price', '>', 50)->orderBy('price', 'asc')->paginate(10);
```
