### PR TITLE
Correct issue pagination

### DIFF
--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -167,7 +167,7 @@ class CollectionEngine extends Engine
         $results = $results['results'];
 
         return count($results) > 0
-                    ? collect($results)->pluck($results[0]->getKeyName())->values()
+                    ? collect($results)->pluck(array_pop($results)->getKeyName())->values()
                     : collect();
     }
 


### PR DESCRIPTION
When we have data with tow pages the key zero in $result[0] doesn't existe, the list $result index begin from the next page in page size

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
