### PR TITLE
[develop] Adds basic generics to `Searchable::search` API

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -7,6 +7,9 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Traits\Macroable;
 
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ */
 class Builder
 {
     use Macroable;
@@ -14,7 +17,7 @@ class Builder
     /**
      * The model instance.
      *
-     * @var \Illuminate\Database\Eloquent\Model
+     * @var \Illuminate\Database\Eloquent\Model|TModel
      */
     public $model;
 
@@ -77,7 +80,7 @@ class Builder
     /**
      * Create a new search builder instance.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|TModel  $model
      * @param  string  $query
      * @param  \Closure|null  $callback
      * @param  bool  $softDelete
@@ -255,7 +258,7 @@ class Builder
     /**
      * Get the first result from the search.
      *
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return \Illuminate\Database\Eloquent\Model|TModel
      */
     public function first()
     {
@@ -265,7 +268,7 @@ class Builder
     /**
      * Get the results of the search.
      *
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<array-key, \Illuminate\Database\Eloquent\Model|TModel>
      */
     public function get()
     {
@@ -275,7 +278,7 @@ class Builder
     /**
      * Get the results of the search as a "lazy collection" instance.
      *
-     * @return \Illuminate\Support\LazyCollection
+     * @return \Illuminate\Support\LazyCollection<array-key, \Illuminate\Database\Eloquent\Model|TModel>
      */
     public function cursor()
     {

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -113,7 +113,7 @@ trait Searchable
      *
      * @param  string  $query
      * @param  \Closure  $callback
-     * @return \Laravel\Scout\Builder
+     * @return \Laravel\Scout\Builder<static>
      */
     public static function search($query = '', $callback = null)
     {


### PR DESCRIPTION
This pull request does not fully type the `Searchable::search` API in the way that static analysis would want it, yet it adds some basic generics to `Searchable::search` API that can improve the UX on IDEs. Here is some examples that were not possible before this pull request:

<img width="525" alt="Screenshot 2021-12-13 at 06 53 18" src="https://user-images.githubusercontent.com/5457236/145842592-c6c245db-eb8a-4109-84bc-90bd6e3d09a3.png">

<img width="481" alt="Screenshot 2021-12-13 at 10 23 09" src="https://user-images.githubusercontent.com/5457236/145842605-a457309c-b225-4683-b3a2-05afa00af603.png">

<img width="412" alt="Screenshot 2021-12-13 at 10 27 56" src="https://user-images.githubusercontent.com/5457236/145842618-26a00c35-9fe8-4b03-ae5b-d52ffdb48576.png">

<img width="543" alt="Screenshot 2021-12-13 at 10 28 50" src="https://user-images.githubusercontent.com/5457236/145842629-a87fd1ce-ed0f-452b-9ac2-7b9ec81141c3.png">