### PR TITLE
[9.x] Add a DatabaseEngine

### DIFF
--- a/src/Attributes/FullText.php
+++ b/src/Attributes/FullText.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Laravel\Scout\Attributes;
+
+use Attribute;
+use Illuminate\Support\Arr;
+
+#[Attribute]
+class FullText
+{
+    /**
+     * The full-text columns.
+     *
+     * @var array
+     */
+    public $columns = [];
+
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  array|string  $columns
+     * @return void
+     */
+    public function __construct($columns)
+    {
+        $this->columns = Arr::wrap($columns);
+    }
+}

--- a/src/Attributes/SearchUsingFullText.php
+++ b/src/Attributes/SearchUsingFullText.php
@@ -6,7 +6,7 @@ use Attribute;
 use Illuminate\Support\Arr;
 
 #[Attribute]
-class FullText
+class SearchUsingFullText
 {
     /**
      * The full-text columns.

--- a/src/Attributes/SearchUsingPrefix.php
+++ b/src/Attributes/SearchUsingPrefix.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Laravel\Scout\Attributes;
+
+use Attribute;
+use Illuminate\Support\Arr;
+
+#[Attribute]
+class SearchUsingPrefix
+{
+    /**
+     * The prefix search columns.
+     *
+     * @var array
+     */
+    public $columns = [];
+
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  array|string  $columns
+     * @return void
+     */
+    public function __construct($columns)
+    {
+        $this->columns = Arr::wrap($columns);
+    }
+}

--- a/src/Contracts/PaginatesEloquentModels.php
+++ b/src/Contracts/PaginatesEloquentModels.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Laravel\Scout\Contracts;
+
+use Laravel\Scout\Builder;
+
+interface PaginatesEloquentModels
+{
+    /**
+     * Paginate the given search on the engine.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  int  $perPage
+     * @param  int  $page
+     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
+     */
+    public function paginate(Builder $builder, $perPage, $page);
+
+    /**
+     * Paginate the given search on the engine using simple pagination.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  int  $perPage
+     * @param  int  $page
+     * @return \Illuminate\Contracts\Pagination\Paginator
+     */
+    public function simplePaginate(Builder $builder, $perPage, $page);
+}

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -9,6 +9,7 @@ use Exception;
 use Illuminate\Support\Manager;
 use Laravel\Scout\Engines\AlgoliaEngine;
 use Laravel\Scout\Engines\CollectionEngine;
+use Laravel\Scout\Engines\DatabaseEngine;
 use Laravel\Scout\Engines\MeiliSearchEngine;
 use Laravel\Scout\Engines\NullEngine;
 use MeiliSearch\Client as MeiliSearch;
@@ -134,6 +135,16 @@ class EngineManager extends Manager
         }
 
         throw new Exception('Please install the MeiliSearch client: meilisearch/meilisearch-php.');
+    }
+
+    /**
+     * Create a database engine instance.
+     *
+     * @return \Laravel\Scout\Engines\DatabaseEngine
+     */
+    public function createDatabaseDriver()
+    {
+        return new DatabaseEngine;
     }
 
     /**

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace Laravel\Scout\Engines;
+
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Arr;
+use Illuminate\Support\LazyCollection;
+use Illuminate\Support\Str;
+use Laravel\Scout\Builder;
+
+class DatabaseEngine extends Engine
+{
+    /**
+     * Create a new engine instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Update the given model in the index.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @return void
+     */
+    public function update($models)
+    {
+        //
+    }
+
+    /**
+     * Remove the given model from the index.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @return void
+     */
+    public function delete($models)
+    {
+        //
+    }
+
+    /**
+     * Perform the given search on the engine.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return mixed
+     */
+    public function search(Builder $builder)
+    {
+        $models = $this->searchModels($builder);
+
+        return [
+            'results' => $models->all(),
+            'total' => count($models),
+        ];
+    }
+
+    /**
+     * Perform the given search on the engine.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  int  $perPage
+     * @param  int  $page
+     * @return mixed
+     */
+    public function paginate(Builder $builder, $perPage, $page)
+    {
+        $models = $this->searchModels($builder);
+
+        return [
+            'results' => $models->forPage($page, $perPage)->all(),
+            'total' => count($models),
+        ];
+    }
+
+    /**
+     * Get the Eloquent models for the given builder.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    protected function searchModels(Builder $builder)
+    {
+        $columns = array_keys($builder->model->toSearchableArray());
+
+        $query = $builder->model->query()
+                        ->whereFulltext($columns, $builder->query)
+                        ->when(! is_null($builder->callback), function ($query) use ($builder) {
+                            call_user_func($builder->callback, $query, $builder, $builder->query);
+                        })
+                        ->when(! $builder->callback && count($builder->wheres) > 0, function ($query) use ($builder) {
+                            foreach ($builder->wheres as $key => $value) {
+                                if ($key !== '__soft_deleted') {
+                                    $query->where($key, $value);
+                                }
+                            }
+                        })
+                        ->when(! $builder->callback && count($builder->whereIns) > 0, function ($query) use ($builder) {
+                            foreach ($builder->whereIns as $key => $values) {
+                                $query->whereIn($key, $values);
+                            }
+                        })
+                        ->orderBy($builder->model->getKeyName(), 'desc');
+
+        $models = $this->ensureSoftDeletesAreHandled($builder, $query)
+                        ->get()
+                        ->values();
+
+        if (count($models) === 0) {
+            return $models;
+        }
+
+        return $models->filter(function ($model) use ($builder) {
+            if (! $model->shouldBeSearchable()) {
+                return false;
+            }
+
+            if (! $builder->query) {
+                return true;
+            }
+
+            return false;
+        })->values();
+    }
+
+    /**
+     * Ensure that soft delete handling is properly applied to the query.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return \Illuminate\Database\Query\Builder
+     */
+    protected function ensureSoftDeletesAreHandled($builder, $query)
+    {
+        if (Arr::get($builder->wheres, '__soft_deleted') === 0) {
+            return $query->withoutTrashed();
+        } elseif (Arr::get($builder->wheres, '__soft_deleted') === 1) {
+            return $query->onlyTrashed();
+        } elseif (in_array(SoftDeletes::class, class_uses_recursive(get_class($builder->model))) &&
+                  config('scout.soft_delete', false)) {
+            return $query->withTrashed();
+        }
+
+        return $query;
+    }
+
+    /**
+     * Pluck and return the primary keys of the given results.
+     *
+     * @param  mixed  $results
+     * @return \Illuminate\Support\Collection
+     */
+    public function mapIds($results)
+    {
+        $results = $results['results'];
+
+        return count($results) > 0
+                    ? collect($results)->pluck($results[0]->getKeyName())->values()
+                    : collect();
+    }
+
+    /**
+     * Map the given results to instances of the given model.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  mixed  $results
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function map(Builder $builder, $results, $model)
+    {
+        $results = $results['results'];
+
+        if (count($results) === 0) {
+            return $model->newCollection();
+        }
+
+        $objectIds = collect($results)
+                ->pluck($model->getKeyName())
+                ->values()
+                ->all();
+
+        $objectIdPositions = array_flip($objectIds);
+
+        return $model->getScoutModelsByIds(
+            $builder, $objectIds
+        )->filter(function ($model) use ($objectIds) {
+            return in_array($model->getScoutKey(), $objectIds);
+        })->sortBy(function ($model) use ($objectIdPositions) {
+            return $objectIdPositions[$model->getScoutKey()];
+        })->values();
+    }
+
+    /**
+     * Map the given results to instances of the given model via a lazy collection.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  mixed  $results
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Support\LazyCollection
+     */
+    public function lazyMap(Builder $builder, $results, $model)
+    {
+        $results = $results['results'];
+
+        if (count($results) === 0) {
+            return LazyCollection::empty();
+        }
+
+        $objectIds = collect($results)
+                ->pluck($model->getKeyName())
+                ->values()->all();
+
+        $objectIdPositions = array_flip($objectIds);
+
+        return $model->queryScoutModelsByIds(
+            $builder, $objectIds
+        )->cursor()->filter(function ($model) use ($objectIds) {
+            return in_array($model->getScoutKey(), $objectIds);
+        })->sortBy(function ($model) use ($objectIdPositions) {
+            return $objectIdPositions[$model->getScoutKey()];
+        })->values();
+    }
+
+    /**
+     * Get the total count from a raw result returned by the engine.
+     *
+     * @param  mixed  $results
+     * @return int
+     */
+    public function getTotalCount($results)
+    {
+        return $results['total'];
+    }
+
+    /**
+     * Flush all of the model's records from the engine.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    public function flush($model)
+    {
+        //
+    }
+
+    /**
+     * Create a search index.
+     *
+     * @param  string  $name
+     * @param  array  $options
+     * @return mixed
+     *
+     * @throws \Exception
+     */
+    public function createIndex($name, array $options = [])
+    {
+        //
+    }
+
+    /**
+     * Delete a search index.
+     *
+     * @param  string  $name
+     * @return mixed
+     */
+    public function deleteIndex($name)
+    {
+        //
+    }
+}

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -88,9 +88,7 @@ class DatabaseEngine extends Engine
      */
     protected function searchModels(Builder $builder, $page = null, $perPage = null)
     {
-        $query = $this->buildSearchQuery($builder);
-
-        $models = $query->when(! is_null($page) && ! is_null($perPage), function ($query) use ($page, $perPage) {
+        $models = $this->buildSearchQuery($builder)->when(! is_null($page) && ! is_null($perPage), function ($query) use ($page, $perPage) {
             return $query->forPage($page, $perPage);
         })->get();
 

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -70,10 +70,8 @@ class DatabaseEngine extends Engine
      */
     public function paginate(Builder $builder, $perPage, $page)
     {
-        $models = $this->searchModels($builder, $page, $perPage);
-
         return [
-            'results' => $models,
+            'results' => $this->searchModels($builder, $page, $perPage),
             'total' => $this->buildSearchQuery($builder)->toBase()->getCountForPagination(),
         ];
     }

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -252,6 +252,10 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
     {
         $columns = [];
 
+        if (PHP_MAJOR_VERSION < 8) {
+            return [];
+        }
+
         foreach ((new ReflectionMethod($builder->model, 'toSearchableArray'))->getAttributes() as $attribute) {
             if ($attribute->getName() !== $attributeClass) {
                 continue;

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -90,7 +90,7 @@ class DatabaseEngine extends Engine
             ! is_null($page) && ! is_null($perPage),
             function ($query) use ($page, $perPage) {
                 return $query->forPage($page, $perPage);
-            })->get();
+        })->orderBy($builder->model->getKeyName(), 'desc')->get();
 
         return count($models) > 0
                 ? $models->filter->shouldBeSearchable()->values()

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -86,9 +86,11 @@ class DatabaseEngine extends Engine
      */
     protected function searchModels(Builder $builder, $page = null, $perPage = null)
     {
-        $models = $this->buildSearchQuery($builder)->when(! is_null($page) && ! is_null($perPage), function ($query) use ($page, $perPage) {
-            return $query->forPage($page, $perPage);
-        })->get();
+        $models = $this->buildSearchQuery($builder)->when(
+            ! is_null($page) && ! is_null($perPage),
+            function ($query) use ($page, $perPage) {
+                return $query->forPage($page, $perPage);
+            })->get();
 
         return count($models) > 0
                 ? $models->filter->shouldBeSearchable()->values()
@@ -147,6 +149,10 @@ class DatabaseEngine extends Engine
                         $builder->query
                     );
                 } else {
+                    if ($canSearchPrimaryKey && $column === $builder->model->getKeyName()) {
+                        continue;
+                    }
+
                     $query->orWhere(
                         $builder->model->qualifyColumn($column),
                         $likeOperator,

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -90,7 +90,7 @@ class DatabaseEngine extends Engine
             ! is_null($page) && ! is_null($perPage),
             function ($query) use ($page, $perPage) {
                 return $query->forPage($page, $perPage);
-        })->orderBy($builder->model->getKeyName(), 'desc')->get();
+            })->orderBy($builder->model->getKeyName(), 'desc')->get();
 
         return count($models) > 0
                 ? $models->filter->shouldBeSearchable()->values()

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -5,7 +5,6 @@ namespace Laravel\Scout\Engines;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Arr;
 use Illuminate\Support\LazyCollection;
-use Illuminate\Support\Str;
 use Laravel\Scout\Builder;
 
 class DatabaseEngine extends Engine

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -112,17 +112,7 @@ class DatabaseEngine extends Engine
             return $models;
         }
 
-        return $models->filter(function ($model) use ($builder) {
-            if (! $model->shouldBeSearchable()) {
-                return false;
-            }
-
-            if (! $builder->query) {
-                return true;
-            }
-
-            return false;
-        })->values();
+        return $models->filter->shouldBeSearchable()->values();
     }
 
     /**

--- a/tests/Feature/DatabaseEngineTest.php
+++ b/tests/Feature/DatabaseEngineTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Laravel\Scout\Tests\Feature;
+
+use Illuminate\Foundation\Testing\WithFaker;
+use Laravel\Scout\ScoutServiceProvider;
+use Laravel\Scout\Tests\Fixtures\SearchableUserDatabaseModel;
+use Orchestra\Testbench\Factories\UserFactory;
+use Orchestra\Testbench\TestCase;
+
+class DatabaseEngineTest extends TestCase
+{
+    use WithFaker;
+
+    protected function getPackageProviders($app)
+    {
+        return [ScoutServiceProvider::class];
+    }
+
+    protected function defineEnvironment($app)
+    {
+        $app->make('config')->set('scout.driver', 'database');
+    }
+
+    protected function defineDatabaseMigrations()
+    {
+        $this->setUpFaker();
+        $this->loadLaravelMigrations();
+
+        UserFactory::new()->create([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        UserFactory::new()->create([
+            'name' => 'Abigail Otwell',
+            'email' => 'abigail@laravel.com',
+        ]);
+    }
+
+    public function test_it_can_retrieve_results_with_empty_search()
+    {
+        $models = SearchableUserDatabaseModel::search()->get();
+
+        $this->assertCount(2, $models);
+    }
+
+    public function test_it_can_retrieve_results()
+    {
+        $models = SearchableUserDatabaseModel::search('Taylor')->where('email', 'taylor@laravel.com')->get();
+        $this->assertCount(1, $models);
+        $this->assertEquals(1, $models[0]->id);
+
+        $models = SearchableUserDatabaseModel::search('Taylor')->query(function ($query) {
+            $query->where('email', 'like', 'taylor@laravel.com');
+        })->get();
+
+        $this->assertCount(1, $models);
+        $this->assertEquals(1, $models[0]->id);
+
+        $models = SearchableUserDatabaseModel::search('Abigail')->where('email', 'abigail@laravel.com')->get();
+        $this->assertCount(1, $models);
+        $this->assertEquals(2, $models[0]->id);
+
+        $models = SearchableUserDatabaseModel::search('Taylor')->where('email', 'abigail@laravel.com')->get();
+        $this->assertCount(0, $models);
+
+        $models = SearchableUserDatabaseModel::search('Taylor')->where('email', 'taylor@laravel.com')->get();
+        $this->assertCount(1, $models);
+
+        $models = SearchableUserDatabaseModel::search('otwell')->get();
+        $this->assertCount(2, $models);
+
+        $models = SearchableUserDatabaseModel::search('laravel')->get();
+        $this->assertCount(2, $models);
+
+        $models = SearchableUserDatabaseModel::search('foo')->get();
+        $this->assertCount(0, $models);
+
+        $models = SearchableUserDatabaseModel::search('Abigail')->where('email', 'taylor@laravel.com')->get();
+        $this->assertCount(0, $models);
+    }
+
+    public function test_it_can_paginate_results()
+    {
+        $models = SearchableUserDatabaseModel::search('Taylor')->where('email', 'taylor@laravel.com')->paginate();
+        $this->assertCount(1, $models);
+
+        $models = SearchableUserDatabaseModel::search('Taylor')->where('email', 'abigail@laravel.com')->paginate();
+        $this->assertCount(0, $models);
+
+        $models = SearchableUserDatabaseModel::search('Taylor')->where('email', 'taylor@laravel.com')->paginate();
+        $this->assertCount(1, $models);
+
+        $models = SearchableUserDatabaseModel::search('laravel')->paginate();
+        $this->assertCount(2, $models);
+    }
+}

--- a/tests/Fixtures/SearchableUserDatabaseModel.php
+++ b/tests/Fixtures/SearchableUserDatabaseModel.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Laravel\Scout\Tests\Fixtures;
+
+use Illuminate\Foundation\Auth\User as Model;
+use Laravel\Scout\Searchable;
+
+class SearchableUserDatabaseModel extends Model
+{
+    use Searchable;
+
+    protected $table = 'users';
+
+    /**
+     * Get the indexable data array for the model.
+     *
+     * @return array
+     */
+    public function toSearchableArray()
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'email' => $this->email,
+        ];
+    }
+}


### PR DESCRIPTION
> This PR depends on https://github.com/laravel/framework/pull/40129

This PR adds a new database engine to Scout that's powered by the upcoming `whereFulltext` addition to Laravel's query builder. Using this, we'll be able to offer natural language search in Scout on `fulltext` indexes for Scout.

I managed to quickly set this up thanks to the existing Collection engine. We'll probably need to abstract those so functionality is shared.

The way this works is that you define the columns of your index through the `toSearchableArray` method:

```php
/**
 * Get the indexable data array for the model.
 *
 * @return array
 */
public function toSearchableArray()
{
    return [
        'name' => $this->name,
        'bio' => $this->bio,
    ];
}
```

Then use it as usual:

```php
$users = User::search('Hello world!')->get();
```

`where` statements to limit results are also supported:

```
$invoices = Invoice::search('Forge')->where('status', 'open')->get();
```

Later on when `whereFulltext` gets supported by more database engines in Laravel, the upgrade will be seamless.

### Todo
- [ ] Figure out a better way to configure columns when models have multiple `fulltext` indexes.
- [ ] Figure out a way to pass options to the `whereFulltext` method. Maybe through the `scoutMetadata` method?
- [ ] Abstract similar functionality from the collection driver.
- [ ] Add tests