### PR TITLE
[9.x] use whereIntegerInRaw instead of whereIn

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -239,7 +239,7 @@ trait Searchable
             call_user_func($builder->queryCallback, $query);
         }
 
-        return $query->whereIn(
+        return $query->whereIntegerInRaw(
             $this->getScoutKeyName(), $ids
         );
     }


### PR DESCRIPTION
```whereIn``` can become slow with a lot of id's passed, ```whereIntegerInRaw``` should be used here I guess