### PR TITLE
[9.x] Optimize whereIn to use whereIntegerInRaw when primaryKey is integer

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -239,7 +239,11 @@ trait Searchable
             call_user_func($builder->queryCallback, $query);
         }
 
-        return $query->whereIn(
+        $whereIn = in_array($this->getKeyType(), ['int', 'integer']) ?
+            'whereIntegerInRaw' :
+            'whereIn';
+
+        return $query->{$whereIn}(
             $this->getScoutKeyName(), $ids
         );
     }


### PR DESCRIPTION
This PR is an updated version of #566, this will now check if the key is ```int``` or ```integer```