### PR TITLE
Add limit to collection engine

### DIFF
--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -50,7 +50,7 @@ class CollectionEngine extends Engine
      */
     public function search(Builder $builder)
     {
-        $models = $this->searchModels($builder);
+        $models = $this->searchModels($builder)->take($builder->limit);
 
         return [
             'results' => $models->all(),

--- a/tests/Feature/CollectionEngineTest.php
+++ b/tests/Feature/CollectionEngineTest.php
@@ -102,4 +102,13 @@ class CollectionEngineTest extends TestCase
         $models = SearchableUserModel::search('laravel')->paginate();
         $this->assertCount(2, $models);
     }
+
+    public function test_limit_is_applied()
+    {
+        $models = SearchableUserModel::search('laravel')->get();
+        $this->assertCount(2, $models);
+
+        $models = SearchableUserModel::search('laravel')->take(1)->get();
+        $this->assertCount(1, $models);
+    }
 }


### PR DESCRIPTION
This PR adds support for the limit (`->take(5)`) to the CollectionEngine. This is useful for having your testing results more closely resemble what you would expect with other engines.