### PR TITLE
Return paginator for paginateRaw (fixes #573)

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -414,7 +414,7 @@ class Builder
 
         $results = $engine->paginate($this, $perPage, $page);
 
-        $paginator = Container::getInstance()->makeWith(LengthAwarePaginator::class, [
+        return Container::getInstance()->makeWith(LengthAwarePaginator::class, [
             'items' => $results,
             'total' => $this->getTotalCount($results),
             'perPage' => $perPage,


### PR DESCRIPTION
This fixes #573 as paginateRaw is currently always treated as a void method in 9.4.0.