### PR TITLE
Fix invalid (but working) constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/database": "^8.0|^9.0",
         "illuminate/http": "^8.0|^9.0",
         "illuminate/pagination": "^8.0|^9.0",
-        "illuminate/queue": "^8.|^9.0",
+        "illuminate/queue": "^8.0|^9.0",
         "illuminate/support": "^8.0|^9.0"
     },
     "require-dev": {


### PR DESCRIPTION
This doesn't appear to actually be breaking anything but, nonetheless, this fixes the constraint on `illuminate/queue` to be valid.