### PR TITLE
[9.x] Fix wrong doc blocks

### DIFF
--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -231,7 +231,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
     }
 
     /**
-     * Get the full-text columns for the query.
+     * Get the prefix search columns for the query.
      *
      * @param  \Laravel\Scout\Builder  $builder
      * @return array

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -175,7 +175,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
     }
 
     /**
-     * Add additional, developer defined constraints to the serach query.
+     * Add additional, developer defined constraints to the search query.
      *
      * @param  \Laravel\Scout\Builder  $builder
      * @param  \Illuminate\Database\Eloquent\Builder  $query


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Doc Block for the `getPrefixColumns` method was using the same description as the `getFullTextColumns` method.

I based the description on the attribute `SearchUsingPrefix`'s `$columns` property description.

https://github.com/laravel/scout/blob/bb6bea547d7f9231dab2bb378fed12a64a000687/src/Attributes/SearchUsingPrefix.php#L12
