### PR TITLE
Skip adding search constraints with empty search on `DatabaseEngine`

### DIFF
--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -139,6 +139,10 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
      */
     protected function initializeSearchQuery(Builder $builder, array $columns, array $prefixColumns = [], array $fullTextColumns = [])
     {
+        if (blank($builder->query)) {
+            return $builder->model->query();
+        }
+
         return $builder->model->query()->where(function ($query) use ($builder, $columns, $prefixColumns, $fullTextColumns) {
             $connectionType = $builder->model->getConnection()->getDriverName();
 

--- a/tests/Feature/DatabaseEngineTest.php
+++ b/tests/Feature/DatabaseEngineTest.php
@@ -45,6 +45,20 @@ class DatabaseEngineTest extends TestCase
         $this->assertCount(2, $models);
     }
 
+    public function test_it_does_not_add_search_where_clauses_with_empty_search()
+    {
+        SearchableUserDatabaseModel::search('')->query(function ($builder) {
+            $this->assertSame('select * from "users"', $builder->toSql());
+        })->get();
+    }
+
+    public function test_it_adds_search_where_clauses_with_non_empty_search()
+    {
+        SearchableUserDatabaseModel::search('Taylor')->query(function ($builder) {
+            $this->assertSame('select * from "users" where ("users"."id" like ? or "users"."name" like ? or "users"."email" like ?)', $builder->toSql());
+        })->get();
+    }
+
     public function test_it_can_retrieve_results()
     {
         $models = SearchableUserDatabaseModel::search('Taylor')->where('email', 'taylor@laravel.com')->get();


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Right now if we search for an empty string using the `DatabaseEngine`, for example in a endpoint that lists all users:

```php
Route::get('/api/users', fn () => User::search(request()->query('q'))->paginate());
```

Even when the search string is empty, the where clauses are added:

```sql
select *
from `users`
where (`users`.`name` like '%%' or `users`.`email` like '%%' or match (`users`.`notes`) against ('' in natural language mode))
order by `id` desc
limit 30 offset 0
```

This PR skips adding the search where clauses if the an empty search string.
