### PR TITLE
[9.x] Remove default order by model key desc in database engine

### DIFF
--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -72,7 +72,6 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
     public function paginate(Builder $builder, $perPage, $page)
     {
         return $this->buildSearchQuery($builder)
-                ->orderBy($builder->model->getKeyName(), 'desc')
                 ->paginate($perPage, ['*'], 'page', $page);
     }
 
@@ -87,7 +86,6 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
     public function simplePaginate(Builder $builder, $perPage, $page)
     {
         return $this->buildSearchQuery($builder)
-                ->orderBy($builder->model->getKeyName(), 'desc')
                 ->simplePaginate($perPage, ['*'], 'page', $page);
     }
 
@@ -105,7 +103,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
             ! is_null($page) && ! is_null($perPage),
             function ($query) use ($page, $perPage) {
                 return $query->forPage($page, $perPage);
-            })->orderBy($builder->model->getKeyName(), 'desc')->get();
+            })->get();
     }
 
     /**


### PR DESCRIPTION
When trying to search a model on a column with fulltext index and naturale langage query with mysql:

```
     /**
     * Get the indexable data array for the model.
     *
     * @return array
     */
    #[SearchUsingFullText(['bio'])]
    public function toSearchableArray()
    {
        return [
            'bio' => $this->bio,
        ];
    }
```
I do:

`User::search('word1 word2')->get()`

and query executed is:

```
select *
from `users`
where (match (`users`.`bio`) against (? in natural language mode)) order by `id` desc
```

Mysql automatically order by results by relevancy based on score and we can't benefit from that. I'd like to get my users ordered something like 1, 3, 2 but always get my users ordered 3, 2, 1. 

Not sure how to solve this, but I tried removing the "sort by" completely.






