### PR TITLE
[9.x] Remove default order by model key desc in database engine when full-text index is used

### DIFF
--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -109,7 +109,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
             ->when(! is_null($page) && ! is_null($perPage), function ($query) use ($page, $perPage) {
                 return $query->forPage($page, $perPage);
             })
-            ->when(!$this->getFullTextColumns($builder), function ($query) use ($builder) {
+            ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
                 $query->orderBy($builder->model->getKeyName(), 'desc');
             })
             ->get();

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -72,7 +72,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
     public function paginate(Builder $builder, $perPage, $page)
     {
         return $this->buildSearchQuery($builder)
-                ->when(!$this->getFullTextColumns($builder), function ($query) use ($builder) {
+                ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
                     $query->orderBy($builder->model->getKeyName(), 'desc');
                 })
                 ->paginate($perPage, ['*'], 'page', $page);
@@ -89,7 +89,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
     public function simplePaginate(Builder $builder, $perPage, $page)
     {
         return $this->buildSearchQuery($builder)
-                ->when(!$this->getFullTextColumns($builder), function ($query) use ($builder) {
+                ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
                     $query->orderBy($builder->model->getKeyName(), 'desc');
                 })
                 ->simplePaginate($perPage, ['*'], 'page', $page);

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -107,10 +107,10 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
     {
         return $this->buildSearchQuery($builder)
             ->when(
-            ! is_null($page) && ! is_null($perPage),
-            function ($query) use ($page, $perPage) {
-                return $query->forPage($page, $perPage);
-            })
+                ! is_null($page) && ! is_null($perPage),
+                function ($query) use ($page, $perPage) {
+                    return $query->forPage($page, $perPage);
+                })
             ->when(!$this->getFullTextColumns($builder), function ($query) use ($builder) {
                 $query->orderBy($builder->model->getKeyName(), 'desc');
             })

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -72,7 +72,6 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
     public function paginate(Builder $builder, $perPage, $page)
     {
         return $this->buildSearchQuery($builder)
-                ->orderBy($builder->model->getKeyName(), 'desc')
                 ->paginate($perPage, ['*'], 'page', $page);
     }
 
@@ -87,7 +86,6 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
     public function simplePaginate(Builder $builder, $perPage, $page)
     {
         return $this->buildSearchQuery($builder)
-                ->orderBy($builder->model->getKeyName(), 'desc')
                 ->simplePaginate($perPage, ['*'], 'page', $page);
     }
 
@@ -105,7 +103,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
             ! is_null($page) && ! is_null($perPage),
             function ($query) use ($page, $perPage) {
                 return $query->forPage($page, $perPage);
-            })->orderBy($builder->model->getKeyName(), 'desc')->get();
+            })->get();
     }
 
     /**

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -106,11 +106,9 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
     protected function searchModels(Builder $builder, $page = null, $perPage = null)
     {
         return $this->buildSearchQuery($builder)
-            ->when(
-                ! is_null($page) && ! is_null($perPage),
-                function ($query) use ($page, $perPage) {
-                    return $query->forPage($page, $perPage);
-                })
+            ->when(! is_null($page) && ! is_null($perPage), function ($query) use ($page, $perPage) {
+                return $query->forPage($page, $perPage);
+            })
             ->when(!$this->getFullTextColumns($builder), function ($query) use ($builder) {
                 $query->orderBy($builder->model->getKeyName(), 'desc');
             })


### PR DESCRIPTION
following https://github.com/laravel/scout/pull/589#issuecomment-1043061781

When trying to search a model on a column with fulltext index and naturale langage query with mysql:

```
     /**
     * Get the indexable data array for the model.
     *
     * @return array
     */
    #[SearchUsingFullText(['bio'])]
    public function toSearchableArray()
    {
        return [
            'bio' => $this->bio,
        ];
    }
```
I do:

`User::search('word1 word2')->get()`

and query executed is:

```
select *
from `users`
where (match (`users`.`bio`) against (? in natural language mode)) order by `id` desc
```

Mysql automatically order by results by relevancy based on score and we can't benefit from that. I'd like to get my users ordered something like 1, 3, 2 but always get my users ordered 3, 2, 1. So we remove default "order by" as soon as a full-text where clause is actually used.