### PR TITLE
Call queryCallback in DatabaseEngine

### DIFF
--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -206,6 +206,8 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
             foreach ($builder->whereIns as $key => $values) {
                 $query->whereIn($key, $values);
             }
+        })->when(! is_null($builder->queryCallback), function ($query) use ($builder) {
+            call_user_func($builder->queryCallback, $query);
         });
     }
 


### PR DESCRIPTION
The `->query()` callback function on searches is helpful for things like eager loading relations, and is typically triggered via `getScoutModelsByIds` in engine implementations. Since the Database engine works directly with the models and does not call that method, I've added an explicit call to `queryCallback` when it's defined.

In my limited testing, this allows things like the following to work consistently on several engines including MeiliSearch and Database without requiring any engine-specific end-user code changes:

```php
Post::search('example query')
    ->query(function ($builder) {
        $builder->with('comments');
    })
    ->paginate(15);
```

It doesn't seem like that callback is documented so it may not be widely used, but since it is implemented consistently in the other official engines this seemed like a good contribution.