### PR TITLE
Add config for appends() parameter name

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -102,6 +102,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Query Parameter Name
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to control what name string will be used to 
+    | append the url query string name i.e. ?query=search-term. Useful
+    | when using pagination links keeping it consistant with the app.
+    |
+    */
+
+    'parameter_name' => env('SCOUT_PARAMETER_NAME', 'query'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Algolia Configuration
     |--------------------------------------------------------------------------
     |

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -98,7 +98,7 @@ class Builder
         $this->model = $model;
         $this->query = $query;
         $this->callback = $callback;
-        $this->parameterName = Config::get('scout.parameter_name', 'query'); 
+        $this->parameterName = 'query';
 
         if ($softDelete) {
             $this->wheres['__soft_deleted'] = 0;

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -7,6 +7,7 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Facades\Config;
 use Laravel\Scout\Contracts\PaginatesEloquentModels;
 
 class Builder
@@ -47,6 +48,13 @@ class Builder
      * @var string
      */
     public $index;
+
+     /**
+     * The custom parameter name for the query string.
+     *
+     * @var string
+     */
+    public $parameterName;
 
     /**
      * The "where" constraints added to the query.
@@ -90,6 +98,7 @@ class Builder
         $this->model = $model;
         $this->query = $query;
         $this->callback = $callback;
+        $this->parameterName = Config::get('scout.parameter_name', 'query');
 
         if ($softDelete) {
             $this->wheres['__soft_deleted'] = 0;
@@ -297,7 +306,7 @@ class Builder
         $engine = $this->engine();
 
         if ($engine instanceof PaginatesEloquentModels) {
-            return $engine->simplePaginate($this, $perPage, $page)->appends('query', $this->query);
+            return $engine->simplePaginate($this, $perPage, $page)->appends($this->parameterName, $this->query);
         }
 
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
@@ -318,7 +327,7 @@ class Builder
             ],
         ])->hasMorePagesWhen(($perPage * $page) < $engine->getTotalCount($rawResults));
 
-        return $paginator->appends('query', $this->query);
+        return $paginator->appends($this->parameterName, $this->query);
     }
 
     /**
@@ -334,7 +343,7 @@ class Builder
         $engine = $this->engine();
 
         if ($engine instanceof PaginatesEloquentModels) {
-            return $engine->simplePaginate($this, $perPage, $page)->appends('query', $this->query);
+            return $engine->simplePaginate($this, $perPage, $page)->appends($this->parameterName, $this->query);
         }
 
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
@@ -353,7 +362,7 @@ class Builder
             ],
         ])->hasMorePagesWhen(($perPage * $page) < $engine->getTotalCount($results));
 
-        return $paginator->appends('query', $this->query);
+        return $paginator->appends($this->parameterName, $this->query);
     }
 
     /**
@@ -369,7 +378,7 @@ class Builder
         $engine = $this->engine();
 
         if ($engine instanceof PaginatesEloquentModels) {
-            return $engine->paginate($this, $perPage, $page)->appends('query', $this->query);
+            return $engine->paginate($this, $perPage, $page)->appends($this->parameterName, $this->query);
         }
 
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
@@ -389,7 +398,7 @@ class Builder
                 'path' => Paginator::resolveCurrentPath(),
                 'pageName' => $pageName,
             ],
-        ])->appends('query', $this->query);
+        ])->appends($this->parameterName, $this->query);
     }
 
     /**
@@ -405,7 +414,7 @@ class Builder
         $engine = $this->engine();
 
         if ($engine instanceof PaginatesEloquentModels) {
-            return $engine->paginate($this, $perPage, $page)->appends('query', $this->query);
+            return $engine->paginate($this, $perPage, $page)->appends($this->parameterName, $this->query);
         }
 
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
@@ -423,7 +432,7 @@ class Builder
                 'path' => Paginator::resolveCurrentPath(),
                 'pageName' => $pageName,
             ],
-        ])->appends('query', $this->query);
+        ])->appends($this->parameterName, $this->query);
     }
 
     /**


### PR DESCRIPTION
### Small change to add the ability to customize the query string parameter

**Example**  https://domain.com?search=term INSTEAD OF https://domain.com?query=term 
I've seen a few requests for this and didn't find a solution out there.  This may not be the best solution but it works for me without breaking anything else.

**Added**
I have added a config setting with a default of 'query' so it shouldn't break anything and updated the Builder class methods.

`'parameter_name' => env('SCOUT_PARAMETER_NAME', 'query')`

**Why?**
Pagination links were overriding my original parameter. Using Laravel / Inertia / React

