### PR TITLE
Add a method to convert a search result into an Eloquent query builder

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -255,6 +255,21 @@ class Builder
     }
 
     /**
+     * Convert a search result into an Eloquent builder.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function toEloquent()
+    {
+        return $this->model
+            ->query()
+            ->whereIn(
+                $this->model->getQualifiedKeyName(),
+                $this->keys()
+            );
+    }
+
+    /**
      * Get the first result from the search.
      *
      * @return \Illuminate\Database\Eloquent\Model

--- a/tests/Feature/BuilderTest.php
+++ b/tests/Feature/BuilderTest.php
@@ -5,6 +5,7 @@ namespace Laravel\Scout\Tests\Feature;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Collection;
 use Laravel\Scout\EngineManager;
 use Laravel\Scout\Engines\MeiliSearchEngine;
 use Laravel\Scout\ScoutServiceProvider;
@@ -85,6 +86,15 @@ class BuilderTest extends TestCase
         $this->assertSame(10, $paginator->total());
         $this->assertSame(1, $paginator->lastPage());
         $this->assertSame(15, $paginator->perPage());
+    }
+
+    public function test_it_can_get_keys_from_search_result()
+    {
+        $this->prepareScoutSearchMockUsing('Laravel');
+
+        $keys = SearchableUserModel::search('Laravel')->keys();
+
+        $this->assertInstanceOf(Collection::class, $keys);
     }
 
     protected function prepareScoutSearchMockUsing($searchQuery)

--- a/tests/Feature/BuilderTest.php
+++ b/tests/Feature/BuilderTest.php
@@ -97,6 +97,16 @@ class BuilderTest extends TestCase
         $this->assertInstanceOf(Collection::class, $keys);
     }
 
+    public function test_it_can_convert_search_result_to_eloquent()
+    {
+        $this->prepareScoutSearchMockUsing('Laravel');
+
+        $result = SearchableUserModel::search('Laravel')
+            ->toEloquent();
+
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Builder::class, $result);
+    }
+
     protected function prepareScoutSearchMockUsing($searchQuery)
     {
         $engine = m::mock('MeiliSearch\Client');


### PR DESCRIPTION
I'm using scout with Algolia, and I'm implementing post-search filters. Scout only has very rudimentary abilities for that, but eloquent has lots. Once scout has done its thing and given you a response, it would be useful to be able to convert that into an eloquent builder and carry on adding filtering operations from there.

This PR adds a simple method to convert a scout search result into an eloquent builder. It works by extracting the keys from the scout result and using them in a `whereIn` method. It uses the `keys` method to get the model IDs directly from the search result and doesn't look them up again unnecessarily. It's obviously somewhat inefficient because you're doing two searches, but it does make it very easy to work with.

Example:

    $result = SearchableUserModel::search('Laravel')
        ->toEloquent()
        ->where('created_at', '>', Carbon::yesterday());

The test I initially wrote failed, but I discovered that this was not my doing, so I've included a failing test for that (with no other code changes) as a separate commit. It seems that calling `search()->keys()` triggers an error in Meilisearch that I don't understand. My method calls the same function, and so suffers the same failure – if you fix it, both will work!