### PR TITLE
Add limit to database engine

### DIFF
--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -112,6 +112,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
             ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
                 $query->orderBy($builder->model->getKeyName(), 'desc');
             })
+            ->take($builder->limit)
             ->get();
     }
 

--- a/tests/Feature/DatabaseEngineTest.php
+++ b/tests/Feature/DatabaseEngineTest.php
@@ -109,4 +109,14 @@ class DatabaseEngineTest extends TestCase
         $models = SearchableUserDatabaseModel::search('laravel')->paginate();
         $this->assertCount(2, $models);
     }
+
+
+    public function test_limit_is_applied()
+    {
+        $models = SearchableUserDatabaseModel::search('laravel')->get();
+        $this->assertCount(2, $models);
+
+        $models = SearchableUserDatabaseModel::search('laravel')->take(1)->get();
+        $this->assertCount(1, $models);
+    }
 }

--- a/tests/Feature/DatabaseEngineTest.php
+++ b/tests/Feature/DatabaseEngineTest.php
@@ -110,7 +110,6 @@ class DatabaseEngineTest extends TestCase
         $this->assertCount(2, $models);
     }
 
-
     public function test_limit_is_applied()
     {
         $models = SearchableUserDatabaseModel::search('laravel')->get();


### PR DESCRIPTION
This PR adds support for the limit (`->take(5)`) to the DatabaseEngine (same as #569, but on the query instead of the collection).

Related issue: #594