### PR TITLE
[9.x] Apply `limit` on `DatabaseEngine` before applying additional constraints

### DIFF
--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -112,7 +112,6 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
             ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
                 $query->orderBy($builder->model->getKeyName(), 'desc');
             })
-            ->take($builder->limit)
             ->get();
     }
 
@@ -132,7 +131,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
         );
 
         return $this->constrainForSoftDeletes(
-            $builder, $this->addAdditionalConstraints($builder, $query)
+            $builder, $this->addAdditionalConstraints($builder, $query->take($builder->limit))
         );
     }
 


### PR DESCRIPTION
The previous PR broke Laravel Nova implementation on Global Search where we use the following:

```php
App\Models\User::search('Laravel')->tap(fn ($query) => $query->limit(5))->get();
``` 

### Before

Callback using `tap()` take priority over default.

#### After

`limit()` take priority over `tap()` and I would consider this a breaking change.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
