### PR TITLE
[9.x] Add import all option to import command

### DIFF
--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -4,7 +4,12 @@ namespace Laravel\Scout\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Laravel\Scout\Events\ModelsImported;
+use Laravel\Scout\Searchable;
+use Symfony\Component\Finder\Finder;
 
 class ImportCommand extends Command
 {
@@ -14,7 +19,7 @@ class ImportCommand extends Command
      * @var string
      */
     protected $signature = 'scout:import
-            {model : Class name of model to bulk import}
+            {model? : Class name of model to bulk import}
             {--c|chunk= : The number of records to import at a time (Defaults to configuration value: `scout.chunk.searchable`)}';
 
     /**
@@ -22,7 +27,7 @@ class ImportCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Import the given model into the search index';
+    protected $description = 'Import all or the given model into the search index';
 
     /**
      * Execute the console command.
@@ -32,20 +37,95 @@ class ImportCommand extends Command
      */
     public function handle(Dispatcher $events)
     {
-        $class = $this->argument('model');
+        if (is_null($this->argument('model'))) {
+            $this->importAll($events);
+
+            return;
+        }
+
+        $this->import($events);
+    }
+
+    /**
+     * Bulk import specified model.
+     *
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $events
+     * @param  string|null  $model
+     * @return void
+     */
+    protected function import($events, $model = null) {
+        $class = $model ?? $this->argument('model');
 
         $model = new $class;
 
         $events->listen(ModelsImported::class, function ($event) use ($class) {
             $key = $event->models->last()->getScoutKey();
 
-            $this->line('<comment>Imported ['.$class.'] models up to ID:</comment> '.$key);
+            $this->line('<comment>Imported [' . $class . '] models up to ID:</comment> ' . $key);
         });
 
         $model::makeAllSearchable($this->option('chunk'));
 
         $events->forget(ModelsImported::class);
 
-        $this->info('All ['.$class.'] records have been imported.');
+        $this->info('All [' . $class . '] records have been imported.');
+    }
+
+    /**
+     * Bulk import all models.
+     *
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $events
+     * @return void
+     */
+    protected function importAll($events) {
+        $models = $this->getSearchableModels();
+
+        if (empty($models)) {
+            $this->warn('There is no searchable model to import.');
+
+            return;
+        }
+
+        foreach ($models as $model) {
+            $this->import($events, $model);
+        }
+    }
+
+    /**
+     * Get all the searchable models
+     *
+     * @return array
+     */
+    protected function getSearchableModels()
+    {
+        $paths = array_unique(Arr::wrap(app_path('Models')));
+
+        $paths = array_filter($paths, function ($path) {
+            return is_dir($path);
+        });
+
+        if (empty($paths)) {
+            return [];
+        }
+
+        $namespace = app()->getNamespace();
+
+        $models = [];
+
+        foreach ((new Finder)->in($paths)->files() as $model) {
+            $model = $namespace.str_replace(
+                    ['/', '.php'],
+                    ['\\', ''],
+                    Str::after($model->getRealPath(), realpath(app_path()).DIRECTORY_SEPARATOR)
+                );
+
+            if (is_subclass_of($model, Model::class) &&
+                in_array(Searchable::class, class_uses($model)) &&
+                ! (new \ReflectionClass($model))->isAbstract()) {
+                $models[] = $model;
+            }
+        }
+
+        return $models;
     }
 }


### PR DESCRIPTION
Before this PR, you had to run `php artisan scout:import "App\Models\{Model}"` for every model manually which could be exhausting for existing projects with a lot of models, especially when you had to make some changes and then import them again.

This PR makes it possible to just run `php artisan scout:import` without any argument and it finds all the models that use the Searchable trait and imports them but it also accepts an optional model argument that acts like the original command.