### PR TITLE
Add withRaw() method for including raw query data to converted Eloquent model

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -77,7 +77,7 @@ class Builder
     public $orders = [];
 
     /**
-     * The attributes to include from the raw query
+     * The attributes to include from the raw query.
      *
      * @var array
      */
@@ -104,7 +104,7 @@ class Builder
     }
 
     /**
-     * Specify the fields from the raw query to include in the final result
+     * Specify the fields from the raw query to include in the final result.
      *
      * @param  array fields
      * @return $this

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -77,6 +77,13 @@ class Builder
     public $orders = [];
 
     /**
+     * The attributes to include from the raw query
+     *
+     * @var array
+     */
+    public $withRaw = [];
+
+    /**
      * Create a new search builder instance.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
@@ -94,6 +101,19 @@ class Builder
         if ($softDelete) {
             $this->wheres['__soft_deleted'] = 0;
         }
+    }
+
+    /**
+     * Specify the fields from the raw query to include in the final result
+     *
+     * @param  array fields
+     * @return $this
+     */
+    public function withRaw($fields)
+    {
+        $this->withRaw = $fields;
+
+        return $this;
     }
 
     /**

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -259,6 +259,21 @@ class MeiliSearchEngine extends Engine
             return in_array($model->getScoutKey(), $objectIds);
         })->sortBy(function ($model) use ($objectIdPositions) {
             return $objectIdPositions[$model->getScoutKey()];
+        })->when(!empty($builder->withRaw), function ($collection) use ($builder, $objectIdPositions, $results) {
+            return $collection->map(function ($model) use ($builder, $objectIdPositions, $results) {
+
+                $data = [];
+                $raw_result = $results['hits'][$objectIdPositions[$model->getScoutKey()]];
+
+                collect($builder->withRaw)
+                ->each(function($append) use (&$data, $raw_result) {
+                    data_set($data, $append, data_get($raw_result, $append));
+                });
+
+                $model->scout = $data;
+
+                return $model;
+            });
         })->values();
     }
 

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -259,14 +259,14 @@ class MeiliSearchEngine extends Engine
             return in_array($model->getScoutKey(), $objectIds);
         })->sortBy(function ($model) use ($objectIdPositions) {
             return $objectIdPositions[$model->getScoutKey()];
-        })->when(!empty($builder->withRaw), function ($collection) use ($builder, $objectIdPositions, $results) {
+        })->when(! empty($builder->withRaw), function ($collection) use ($builder, $objectIdPositions, $results) {
             return $collection->map(function ($model) use ($builder, $objectIdPositions, $results) {
 
                 $data = [];
                 $raw_result = $results['hits'][$objectIdPositions[$model->getScoutKey()]];
 
                 collect($builder->withRaw)
-                ->each(function($append) use (&$data, $raw_result) {
+                ->each(function ($append) use (&$data, $raw_result) {
                     data_set($data, $append, data_get($raw_result, $append));
                 });
 

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -261,7 +261,6 @@ class MeiliSearchEngine extends Engine
             return $objectIdPositions[$model->getScoutKey()];
         })->when(! empty($builder->withRaw), function ($collection) use ($builder, $objectIdPositions, $results) {
             return $collection->map(function ($model) use ($builder, $objectIdPositions, $results) {
-
                 $data = [];
                 $raw_result = $results['hits'][$objectIdPositions[$model->getScoutKey()]];
 


### PR DESCRIPTION
This pull request suggests the addition of a withRaw() method to the Scout Builder object together with an exemplary Meilisearch implementation as a base for discussion of the benefits and usecases. 

The withRaw() method allows the user to append data from the raw query to the result of the ORM mapped Eloquent result. 
An example usecase would be for Meilisearch. Meilisearch allows the user to specify a [attributesToHighlight](https://docs.meilisearch.com/reference/api/search.html#attributes-to-highlight) option for a given query, which includes a `_formatted` field in the result that has the matching query string highlighted with `<em>` tags. 
But currently there is no way of retrieving that field with the `->get()` method, only with `->raw()`. But with `->raw()` you can't take advantage of automatic relation loading etc. with the `->query()` method. Introducing the `->withRaw()` method would solve this issue.

Here is an example usecase:

```
$result = Customer::search(
  $query_string,
  function(Indexes $meiliSearch, string $query, array $options) {
      $options['attributesToHighlight'] = ["*"];

      return $meiliSearch->search($query, $options);
  })
  ->withRaw(['_formatted'])
  ->query(function($query) {
    $query->with('relationship');
  })->get();
```
The exemplary implementation for Meilisearch adds the raw appended data to a `scout[]` attribute on the model. I am not sure though, how and where we usally append(nested and temporary) additional data to a model in Laravel correctly?

I am aware, that the current implementation is propably not up to the required standards, imcomplete regarding all supported search engines and might be solved more elegantly, but that is currently beyonde my skill level and experience.
But maybe there is still something useful in this pull request we can iterate and refine upon on together. 

Cheers,
Michael 