### PR TITLE
fix(meilisearch): change nbHits to estimatedTotalHits

### DIFF
--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -296,7 +296,7 @@ class MeiliSearchEngine extends Engine
      */
     public function getTotalCount($results)
     {
-        return $results['nbHits'];
+        return $results['estimatedTotalHits'];
     }
 
     /**

--- a/tests/Feature/BuilderTest.php
+++ b/tests/Feature/BuilderTest.php
@@ -107,7 +107,7 @@ class BuilderTest extends TestCase
                     'name' => $result->name,
                 ];
             }),
-            'nbHits' => $query->count(),
+            'estimatedTotalHits' => $query->count(),
         ]);
     }
 }

--- a/tests/Unit/MeiliSearchEngineTest.php
+++ b/tests/Unit/MeiliSearchEngineTest.php
@@ -441,7 +441,7 @@ class MeiliSearchEngineTest extends TestCase
     public function test_engine_returns_hits_entry_from_search_response()
     {
         $this->assertTrue(3 === (new MeiliSearchEngine(m::mock(Client::class)))->getTotalCount([
-            'nbHits' => 3,
+            'estimatedTotalHits' => 3,
         ]));
     }
 }


### PR DESCRIPTION
# Scope
Meilisearch [v0.28.0](https://github.com/meilisearch/MeiliSearch/releases) has a breaking change which renames `nbHits` to `estimatedTotalHits`. This breaks when trying to paginate the response. Functionally they have the same implementation.

I've looked to see if the engine uses the other parameters that were changed but it doesn't look like it does.