### PR TITLE
Added ability to pass primary key into mapping methods

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -448,7 +448,7 @@ class Builder
         )->all();
 
         if (count($ids) < $totalCount) {
-            $ids = $engine->keys(tap(clone $this, function ($builder) use ($totalCount) {
+            $ids = $engine->keys($this->model->getKeyName(), tap(clone $this, function ($builder) use ($totalCount) {
                 $builder->take(
                     is_null($this->limit) ? $totalCount : min($this->limit, $totalCount)
                 );

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -169,10 +169,11 @@ class AlgoliaEngine extends Engine
     /**
      * Pluck and return the primary keys of the given results.
      *
+     * @param  mixed  $key
      * @param  mixed  $results
      * @return \Illuminate\Support\Collection
      */
-    public function mapIds($results)
+    public function mapIds($key, $results)
     {
         return collect($results['hits'])->pluck('objectID')->values();
     }

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -162,7 +162,7 @@ class CollectionEngine extends Engine
      * @param  mixed  $results
      * @return \Illuminate\Support\Collection
      */
-    public function mapIds($results)
+    public function mapIds($key, $results)
     {
         $results = array_values($results['results']);
 

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -307,10 +307,11 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
     /**
      * Pluck and return the primary keys of the given results.
      *
+     * @param  mixed  $key
      * @param  mixed  $results
      * @return \Illuminate\Support\Collection
      */
-    public function mapIds($results)
+    public function mapIds($key, $results)
     {
         $results = $results['results'];
 

--- a/src/Engines/Engine.php
+++ b/src/Engines/Engine.php
@@ -117,8 +117,8 @@ abstract class Engine
     /**
      * Get the results of the query as a Collection of primary keys.
      *
-     * @param mixed $key
-     * @param \Laravel\Scout\Builder $builder
+     * @param  mixed  $key
+     * @param  \Laravel\Scout\Builder  $builder
      * @return \Illuminate\Support\Collection
      */
     public function keys($key, Builder $builder)

--- a/src/Engines/Engine.php
+++ b/src/Engines/Engine.php
@@ -43,10 +43,11 @@ abstract class Engine
     /**
      * Pluck and return the primary keys of the given results.
      *
+     * @param  mixed  $key
      * @param  mixed  $results
      * @return \Illuminate\Support\Collection
      */
-    abstract public function mapIds($results);
+    abstract public function mapIds($key, $results);
 
     /**
      * Map the given results to instances of the given model.
@@ -110,18 +111,19 @@ abstract class Engine
      */
     public function mapIdsFrom($results, $key)
     {
-        return $this->mapIds($results);
+        return $this->mapIds($key, $results);
     }
 
     /**
      * Get the results of the query as a Collection of primary keys.
      *
-     * @param  \Laravel\Scout\Builder  $builder
+     * @param mixed $key
+     * @param \Laravel\Scout\Builder $builder
      * @return \Illuminate\Support\Collection
      */
-    public function keys(Builder $builder)
+    public function keys($key, Builder $builder)
     {
-        return $this->mapIds($this->search($builder));
+        return $this->mapIds($key, $this->search($builder));
     }
 
     /**

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -205,18 +205,17 @@ class MeiliSearchEngine extends Engine
      *
      * This expects the first item of each search item array to be the primary key.
      *
+     * @param  mixed  $key
      * @param  mixed  $results
      * @return \Illuminate\Support\Collection
      */
-    public function mapIds($results)
+    public function mapIds($key, $results)
     {
         if (0 === count($results['hits'])) {
             return collect();
         }
 
         $hits = collect($results['hits']);
-
-        $key = key($hits->first());
 
         return $hits->pluck($key)->values();
     }

--- a/src/Engines/NullEngine.php
+++ b/src/Engines/NullEngine.php
@@ -58,10 +58,11 @@ class NullEngine extends Engine
     /**
      * Pluck and return the primary keys of the given results.
      *
+     * @param  mixed  $key
      * @param  mixed  $results
      * @return \Illuminate\Support\Collection
      */
-    public function mapIds($results)
+    public function mapIds($key, $results)
     {
         return BaseCollection::make();
     }


### PR DESCRIPTION
As mentioned here https://github.com/laravel/scout/issues/615#issuecomment-1191016297, there is a bug that causes pagination with Meilisearch to not work at all.

Whole problem is that, sometimes meilisearch (found out that it may be due to changing searchable fields) does not return primary key as first key hits result causing pagination to not work at all.

In my case, meilisearch `hits` array looks something like this

```
[
  [
    'name' => 'FooBar',
    'uuid' => '...'
  ]
]
```

so Scout thinks `name` is the primary key for model.