### PR TITLE
Attempt to resolve model by name

### DIFF
--- a/src/Console/FlushCommand.php
+++ b/src/Console/FlushCommand.php
@@ -27,7 +27,12 @@ class FlushCommand extends Command
      */
     public function handle()
     {
-        $class = $this->argument('model');
+        $class = $this->lookupClass();
+
+        if(!$class) {
+            $this->error('Class ['.$this->argument('model').'] could not be found.');
+            return self::FAILURE;
+        }
 
         $model = new $class;
 
@@ -35,4 +40,23 @@ class FlushCommand extends Command
 
         $this->info('All ['.$class.'] records have been flushed.');
     }
+
+    protected function lookupClass()
+    {
+        $class = $this->argument('model');
+        if(!class_exists($class)) {
+            $rootNamespace = $this->laravel->getNamespace();
+            $class = is_dir(app_path('Models'))
+                ? $rootNamespace.'Models\\'.$class
+                : $rootNamespace.$class;
+        }
+
+        if(!class_exists($class)) {
+            return false;
+        }
+
+        return $class;
+    }
+
+
 }


### PR DESCRIPTION
It would be a friendly gesture to the user if scout tried to find the model typed in the command.

Example. I tried to flush a searchable today. First writing `artisan scout:flush MyModelName`. Then i remembered it had to be qualified and wrote `artisan scout:flush App/Models/MyModelName`. Then i remembered it had to be backslashes `artisan scout:flush App\Models\MyModelName` ... etc 

Let scout be the friend that checks the Models directory to see if you meant "App\Models\MyModelName" ❤️ 