### PR TITLE
Use scout key when mapping keys from search results

### DIFF
--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -232,7 +232,22 @@ class MeiliSearchEngine extends Engine
     {
         return count($results['hits']) === 0
                 ? collect()
-                : collect($results['hits'])->pluck($key)->values();
+
+    /**
+     * Get the results of the query as a Collection of primary keys.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return \Illuminate\Support\Collection
+     */
+    public function keys(Builder $builder)
+    {
+        $scoutKey = $builder->model->getScoutKeyName();
+
+        if (str_contains($scoutKey, '.')) {
+            $scoutKey = explode('.', $scoutKey)[1];
+        }
+
+        return $this->mapIdsFrom($this->search($builder), $scoutKey);
     }
 
     /**

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -232,6 +232,8 @@ class MeiliSearchEngine extends Engine
     {
         return count($results['hits']) === 0
                 ? collect()
+                : collect($results['hits'])->pluck($key)->values();
+    }
 
     /**
      * Get the results of the query as a Collection of primary keys.

--- a/tests/Unit/MeiliSearchEngineTest.php
+++ b/tests/Unit/MeiliSearchEngineTest.php
@@ -157,12 +157,30 @@ class MeiliSearchEngineTest extends TestCase
             ],
         ], 'id');
 
-        $this->assertEquals($results->all(), [
-            1,
-            2,
-            3,
-            4,
-        ]);
+    }
+
+    public function test_returns_primary_keys_when_custom_array_order_present()
+    {
+        $engine = m::mock(MeiliSearchEngine::class);
+        $builder = m::mock(Builder::class);
+
+        $model = m::mock(stdClass::class);
+        $model->shouldReceive(['getScoutKeyName' => 'table.custom_key']);
+        $builder->model = $model;
+
+        $engine->shouldReceive('keys')->passthru();
+
+        $engine
+            ->shouldReceive('search')
+            ->once()
+            ->andReturn([]);
+
+        $engine
+            ->shouldReceive('mapIdsFrom')
+            ->once()
+            ->with([], 'custom_key');
+
+        $engine->keys($builder);
     }
 
     public function test_map_correctly_maps_results_to_models()

--- a/tests/Unit/MeiliSearchEngineTest.php
+++ b/tests/Unit/MeiliSearchEngineTest.php
@@ -156,6 +156,13 @@ class MeiliSearchEngineTest extends TestCase
                 ],
             ],
         ], 'id');
+        
+        $this->assertEquals($results->all(), [
+            1,
+            2,
+            3,
+            4,
+        ]);
 
     }
 

--- a/tests/Unit/MeiliSearchEngineTest.php
+++ b/tests/Unit/MeiliSearchEngineTest.php
@@ -156,14 +156,13 @@ class MeiliSearchEngineTest extends TestCase
                 ],
             ],
         ], 'id');
-        
+
         $this->assertEquals($results->all(), [
             1,
             2,
             3,
             4,
         ]);
-
     }
 
     public function test_returns_primary_keys_when_custom_array_order_present()


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Trying a fix against https://github.com/laravel/scout/issues/651

This PR overloads the `keys()` method in the base Engine class providing `MeilisearchEngine` the exact Scout key to be used when mapping search results. 

Previously the key was determined by taking the first key of the array in the search response. However as recently discovered in the aforementioned issue - Meilisearch will return random array order depending on its index configuration. 