### PR TITLE
[10.x] Use scout key when mapping keys from search results #652 

### DIFF
--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -220,6 +220,19 @@ class MeiliSearchEngine extends Engine
                 : collect($results['hits'])->pluck($key)->values();
     }
 
+     /**
+     * Get the results of the query as a Collection of primary keys.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return \Illuminate\Support\Collection
+     */
+    public function keys(Builder $builder)
+    {
+        $scoutKey = $builder->model->getScoutKeyName();
+
+        return $this->mapIdsFrom($this->search($builder), $scoutKey);
+    }
+
     /**
      * Map the given results to instances of the given model.
      *

--- a/tests/Unit/MeiliSearchEngineTest.php
+++ b/tests/Unit/MeiliSearchEngineTest.php
@@ -165,6 +165,30 @@ class MeiliSearchEngineTest extends TestCase
         ]);
     }
 
+    public function test_returns_primary_keys_when_custom_array_order_present()
+    {
+        $engine = m::mock(MeiliSearchEngine::class);
+        $builder = m::mock(Builder::class);
+
+        $model = m::mock(stdClass::class);
+        $model->shouldReceive(['getScoutKeyName' => 'custom_key']);
+        $builder->model = $model;
+
+        $engine->shouldReceive('keys')->passthru();
+
+        $engine
+            ->shouldReceive('search')
+            ->once()
+            ->andReturn([]);
+
+        $engine
+            ->shouldReceive('mapIdsFrom')
+            ->once()
+            ->with([], 'custom_key');
+
+        $engine->keys($builder);
+    }
+
     public function test_map_correctly_maps_results_to_models()
     {
         $client = m::mock(Client::class);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This is the fix against https://github.com/laravel/scout/issues/651 targeted for changes for the release tree 10.x. Adapted from https://github.com/laravel/scout/pull/652

**Context**

This PR overloads the `keys()` method in the base Engine class providing `MeilisearchEngine` the exact Scout key to be used when mapping search results.

Previously the key was determined by taking the first key of the array in the search response. However as recently discovered in the aforementioned issue - Meilisearch will return random array order depending on its index configuration.

@driesvints please let me know if it's ready for review or needs improvement. :) 
