### PR TITLE
Proof of issues with calculated custom key values

### DIFF
--- a/tests/Fixtures/SearchableModelWithCustomKey.php
+++ b/tests/Fixtures/SearchableModelWithCustomKey.php
@@ -18,7 +18,7 @@ class SearchableModelWithCustomKey extends Model
 
     public function getScoutKey()
     {
-        return $this->other_id;
+        return md5($this->other_id);
     }
 
     public function getScoutKeyName()

--- a/tests/Unit/RemoveFromSearchTest.php
+++ b/tests/Unit/RemoveFromSearchTest.php
@@ -66,7 +66,7 @@ class RemoveFromSearchTest extends TestCase
         $this->assertCount(1, $job->models);
         $this->assertInstanceOf(SearchableModelWithCustomKey::class, $job->models->first());
         $this->assertTrue($model->is($job->models->first()));
-        $this->assertEquals(1234, $job->models->first()->getScoutKey());
+        $this->assertEquals(md5(1234), $job->models->first()->getScoutKey());
         $this->assertEquals('searchable_model_with_custom_keys.other_id', $job->models->first()->getScoutKeyName());
     }
 
@@ -80,8 +80,8 @@ class RemoveFromSearchTest extends TestCase
         ]);
 
         $this->assertEquals([
-            1234,
-            2345,
+            md5(1234),
+            md5(2345),
             3456,
             7891,
         ], $collection->getQueueableIds());


### PR DESCRIPTION
Currently this PR only serves to prove issues with calculated custom key values provided through `getScoutKey()` for a Searchable model through minimal alternation of test "Fixtures" and expected changes in the tests.

The unit tests in this branch now fail with the following output. Note that the actual value received is an md5 hash of the expected value which is an md5 hash of the models `other_id` attribute.

```
There was 1 failure:

1) Laravel\Scout\Tests\Unit\RemoveFromSearchTest::test_models_are_deserialized_without_the_database_using_custom_scout_key
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'81dc9bdb52d04dc20036dbd8313ed055'
+'ec6a6536ca304edf844d1d248a4f08dc'

~/scout/tests/Unit/RemoveFromSearchTest.php:69
```

