### PR TITLE
[9.x] Fix the sync index settings command not using the scout prefix

### DIFF
--- a/src/Console/SyncIndexSettingsCommand.php
+++ b/src/Console/SyncIndexSettingsCommand.php
@@ -64,6 +64,6 @@ class SyncIndexSettingsCommand extends Command
 
         $prefix = config('scout.prefix');
 
-        return ! Str::startsWith($name, $prefix) ? $prefix . $name : $name;
+        return ! Str::startsWith($name, $prefix) ? $prefix.$name : $name;
     }
 }

--- a/src/Console/SyncIndexSettingsCommand.php
+++ b/src/Console/SyncIndexSettingsCommand.php
@@ -4,6 +4,7 @@ namespace Laravel\Scout\Console;
 
 use Exception;
 use Illuminate\Console\Command;
+use Illuminate\Support\Str;
 use Laravel\Scout\EngineManager;
 
 class SyncIndexSettingsCommand extends Command
@@ -63,6 +64,6 @@ class SyncIndexSettingsCommand extends Command
 
         $prefix = config('scout.prefix');
 
-        return ! str_starts_with($name, $prefix) ? $prefix . $name : $name;
+        return ! Str::startsWith($name, $prefix) ? $prefix . $name : $name;
     }
 }

--- a/src/Console/SyncIndexSettingsCommand.php
+++ b/src/Console/SyncIndexSettingsCommand.php
@@ -43,9 +43,9 @@ class SyncIndexSettingsCommand extends Command
 
             if (count($indexes)) {
                 foreach ($indexes as $name => $settings) {
-                    $engine->updateIndexSettings($name, $settings);
+                    $engine->updateIndexSettings($indexName = $this->indexName($name), $settings);
 
-                    $this->info('Settings for the ["'.$name.'"] index synced successfully.');
+                    $this->info('Settings for the ["'.$indexName.'"] index synced successfully.');
                 }
             } else {
                 $this->info('No index settings found for the "'.$driver.'" engine.');
@@ -53,5 +53,16 @@ class SyncIndexSettingsCommand extends Command
         } catch (Exception $exception) {
             $this->error($exception->getMessage());
         }
+    }
+
+    protected function indexName($name)
+    {
+        if (class_exists($name)) {
+            return (new $name)->searchableAs();
+        }
+
+        $prefix = config('scout.prefix');
+
+        return ! str_starts_with($name, $prefix) ? $prefix . $name : $name;
     }
 }

--- a/src/Console/SyncIndexSettingsCommand.php
+++ b/src/Console/SyncIndexSettingsCommand.php
@@ -56,6 +56,12 @@ class SyncIndexSettingsCommand extends Command
         }
     }
 
+    /**
+     * Get the fully-qualified index name for the given index.
+     *
+     * @param  string  $name
+     * @return string
+     */
     protected function indexName($name)
     {
         if (class_exists($name)) {


### PR DESCRIPTION
### Changed

- Make the `scout:sync-index-settings` command aware of the scout prefix being used.

---

I was able to work around this by assigning the scout prefix to a variable inside the config file, like so:

```php
return [
    'prefix' => $scoutPrefix = env('SCOUT_PREFIX', 'local_'),

    // ...

    'meilisearch' => [
        'host' => env('MEILISEARCH_HOST', 'http://localhost:7700'),
        'key' => env('MEILISEARCH_KEY', null),
        'index-settings' => [
            $scoutPrefix . 'users' => [
                'filterableAttributes'=> [
                    '__soft_deleted',
                    'id',
                    'name',
                ],
                'sortableAttributes' => [
                    'id',
                ],
            ],
        ],
    ],
];
```

But I figured the command could be made aware of the prefix instead. This change also allows defining the key as a model, so something like:

```php
return [
    'meilisearch' => [
        'host' => env('MEILISEARCH_HOST', 'http://localhost:7700'),
        'key' => env('MEILISEARCH_KEY', null),
        'index-settings' => [
            App\Models\User::class => [
                'filterableAttributes'=> [
                    '__soft_deleted',
                    'id',
                    'name',
                ],
                'sortableAttributes' => [
                    'id',
                ],
            ],
        ],
    ],
];
```

Which uses the `searchableAs()` method inside the `Searchable` trait, which is already aware of the scout prefix.

When a string is passed instead of an FQCN, it will check if it already starts with the prefix before prepending it.