### PR TITLE
[9.x] Add command delete-all-indexes, update scout:index to allow FQCN and apply filterable on SoftDeletes

### DIFF
--- a/src/Console/DeleteAllIndexesCommand.php
+++ b/src/Console/DeleteAllIndexesCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Laravel\Scout\Console;
+
+use Exception;
+use Illuminate\Console\Command;
+use Laravel\Scout\EngineManager;
+
+class DeleteAllIndexesCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'scout:delete-all-indexes';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete all indexes';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Laravel\Scout\EngineManager  $manager
+     * @return void
+     */
+    public function handle(EngineManager $manager)
+    {
+        $engine = $manager->engine();
+
+        $driver = config('scout.driver');
+
+        if (! method_exists($engine, 'deleteAllIndexes')) {
+            return $this->error('The "'.$driver.'" engine does not support delete all indexes.');
+        }
+
+        try {
+            $manager->engine()->deleteAllIndexes();
+
+            $this->info('All indexes have been deleted.');
+        } catch (Exception $exception) {
+            $this->error($exception->getMessage());
+        }
+    }
+}

--- a/src/Console/DeleteAllIndexesCommand.php
+++ b/src/Console/DeleteAllIndexesCommand.php
@@ -35,13 +35,13 @@ class DeleteAllIndexesCommand extends Command
         $driver = config('scout.driver');
 
         if (! method_exists($engine, 'deleteAllIndexes')) {
-            return $this->error('The "'.$driver.'" engine does not support delete all indexes.');
+            return $this->error('The ['.$driver.'] engine does not support deleting all indexes.');
         }
 
         try {
             $manager->engine()->deleteAllIndexes();
 
-            $this->info('All indexes have been deleted.');
+            $this->info('All indexes deleted successfully.');
         } catch (Exception $exception) {
             $this->error($exception->getMessage());
         }

--- a/src/Console/IndexCommand.php
+++ b/src/Console/IndexCommand.php
@@ -51,7 +51,12 @@ class IndexCommand extends Command
             if (method_exists($engine, 'updateIndexSettings')) {
                 $driver = config('scout.driver');
 
-                if ($settings = config('scout.'.$driver.'.index-settings.'.$name, [])) {
+                $class = isset($model) ? get_class($model) : null;
+                $settings = config('scout.'.$driver.'.index-settings.'.$name)
+                    ?? config('scout.'.$driver.'.index-settings.'.$class)
+                    ?? [];
+
+                if ($settings) {
                     $engine->updateIndexSettings($name, $settings);
                 }
 

--- a/src/Console/SyncIndexSettingsCommand.php
+++ b/src/Console/SyncIndexSettingsCommand.php
@@ -46,7 +46,7 @@ class SyncIndexSettingsCommand extends Command
                 foreach ($indexes as $name => $settings) {
                     $engine->updateIndexSettings($indexName = $this->indexName($name), $settings);
 
-                    $this->info('Settings for the ["'.$indexName.'"] index synced successfully.');
+                    $this->info('Settings for the ['.$indexName.'] index synced successfully.');
                 }
             } else {
                 $this->info('No index settings found for the "'.$driver.'" engine.');

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -393,6 +393,21 @@ class MeiliSearchEngine extends Engine
     }
 
     /**
+     * Update index filterable attribute to allow filter on soft deletes statement.
+     *
+     * @param $model
+     * @return array|void
+     */
+    public function applyFilterableSoftDeletedAttribute($model)
+    {
+        if (! $this->usesSoftDelete($model)) {
+            return;
+        }
+
+        return $this->updateIndexSettings($model->searchableAs(), ['filterableAttributes' => ['__soft_deleted']]);
+    }
+
+    /**
      * Dynamically call the MeiliSearch client instance.
      *
      * @param  string  $method

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -372,7 +372,7 @@ class MeiliSearchEngine extends Engine
     }
 
     /**
-     * Delete all search indexes
+     * Delete all search indexes.
      *
      * @return mixed
      */

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -393,21 +393,6 @@ class MeiliSearchEngine extends Engine
     }
 
     /**
-     * Update index filterable attribute to allow filter on soft deletes statement.
-     *
-     * @param $model
-     * @return array|void
-     */
-    public function applyFilterableSoftDeletedAttribute($model)
-    {
-        if (! $this->usesSoftDelete($model)) {
-            return;
-        }
-
-        return $this->updateIndexSettings($model->searchableAs(), ['filterableAttributes' => ['__soft_deleted']]);
-    }
-
-    /**
      * Dynamically call the MeiliSearch client instance.
      *
      * @param  string  $method

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -372,6 +372,16 @@ class MeiliSearchEngine extends Engine
     }
 
     /**
+     * Delete all search indexes
+     *
+     * @return mixed
+     */
+    public function deleteAllIndexes()
+    {
+        return $this->meilisearch->deleteAllIndexes();
+    }
+
+    /**
      * Determine if the given model uses soft deletes.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model

--- a/src/ScoutServiceProvider.php
+++ b/src/ScoutServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Laravel\Scout;
 
 use Illuminate\Support\ServiceProvider;
+use Laravel\Scout\Console\DeleteAllIndexesCommand;
 use Laravel\Scout\Console\DeleteIndexCommand;
 use Laravel\Scout\Console\FlushCommand;
 use Laravel\Scout\Console\ImportCommand;
@@ -48,6 +49,7 @@ class ScoutServiceProvider extends ServiceProvider
                 IndexCommand::class,
                 SyncIndexSettingsCommand::class,
                 DeleteIndexCommand::class,
+                DeleteAllIndexesCommand::class,
             ]);
 
             $this->publishes([


### PR DESCRIPTION
This PR add some new features for Meilisearch:

- `scout:index` accept a FQCN as name argument.
- Apply filterable attribute on `__soft_deleted` when Model use SoftDeletes at index creation.
- Added a new command to delete all indexes _(only [Meilisearch](https://github.com/meilisearch/meilisearch-php/blob/440d061fafafa4f9e61104ff0a623f9d56816593/src/Delegates/HandlesIndex.php#L43) support it)_.

___

With this addition, your `Scout.php` config file will not look like this crazy repetition:

```php
'meilisearch' => [
    'host' => env('MEILISEARCH_HOST', 'http://localhost:7700'),
    'key' => env('MEILISEARCH_KEY', null),
    'index-settings' => [
        Model_A::class => [
            'filterableAttributes' => ['__soft_deleted'],
        ],
        Model_B::class => [
            'filterableAttributes' => ['__soft_deleted'],
        ],
        Model_C::class => [
            'filterableAttributes' => ['__soft_deleted'],
        ],
        Model_D::class => [
            'filterableAttributes' => ['__soft_deleted'],
        ],
        // ....
        Model_Y::class => [
            'filterableAttributes' => ['__soft_deleted'],
        ],
        Model_Z::class => [
            'filterableAttributes' => ['__soft_deleted'],
        ],
    ],
]
```