### PR TITLE
[9.x] Added soft deleted to Meilisearch (OOTB included)

### DIFF
--- a/src/Console/IndexCommand.php
+++ b/src/Console/IndexCommand.php
@@ -59,6 +59,10 @@ class IndexCommand extends Command
                                 ?? config('scout.'.$driver.'.index-settings.'.$class)
                                 ?? [];
 
+                if (method_exists($engine, 'withSoftDeletedFilterable')) {
+                    $settings = $engine->withSoftDeletedFilterable($class, $settings);
+                }
+
                 if ($settings) {
                     $engine->updateIndexSettings($name, $settings);
                 }

--- a/src/Console/SyncIndexSettingsCommand.php
+++ b/src/Console/SyncIndexSettingsCommand.php
@@ -44,6 +44,15 @@ class SyncIndexSettingsCommand extends Command
 
             if (count($indexes)) {
                 foreach ($indexes as $name => $settings) {
+                    if (! is_array($settings)) {
+                        $name = $settings;
+                        $settings = [];
+                    }
+
+                    if (method_exists($engine, 'withSoftDeletedFilterable')) {
+                        $settings = $engine->withSoftDeletedFilterable($name, $settings);
+                    }
+
                     $engine->updateIndexSettings($indexName = $this->indexName($name), $settings);
 
                     $this->info('Settings for the ['.$indexName.'] index synced successfully.');

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -393,6 +393,39 @@ class MeiliSearchEngine extends Engine
     }
 
     /**
+     * Determine if the given model is soft deletable.
+     *
+     * @param  $name
+     * @return bool
+     */
+    protected function isSoftDeletable($name)
+    {
+        if (! class_exists($name)) {
+            return false;
+        }
+
+        return config('scout.soft_delete', false) && $this->usesSoftDelete(new $name);
+    }
+
+    /**
+     * Set soft deleted filterable attributes to scout index settings.
+     *
+     * @param  $name
+     * @param  $settings
+     * @return array
+     */
+    public function withSoftDeletedFilterable($name, $settings)
+    {
+        if (! $this->isSoftDeletable($name)) {
+            return $settings;
+        }
+
+        $settings['filterableAttributes'][] = '__soft_deleted';
+
+        return $settings;
+    }
+
+    /**
      * Dynamically call the MeiliSearch client instance.
      *
      * @param  string  $method


### PR DESCRIPTION
This PR add soft deleted for Meilisearch indexes.

1. Out of the box: `artisan scout:index 'App\Models\Users'` will add filterable attributes `__soft_deleted` **when model already use SoftDeletes trait** and **without any configuration** 🤩 
2. Sync index: when you add SoftDeletes after index creation, **you need** to declare class in your scout config file. Instead of writing some repetition of:
```php
\App\Models\User::class => [
    'filterableAttributes' => ['__soft_deleted']
],
```
You can simply write: `\App\Models\User::class => [],` or, more compact: `\App\Models\User::class,`

Your `scout` config file should look like:

```php
'meilisearch' => [
    'host' => env('MEILISEARCH_HOST', 'http://localhost:7700'),
    'key' => env('MEILISEARCH_KEY', null),
    'index-settings' => [
        // full declaration
        \App\Models\User::class => [
            'filterableAttributes' => ['__soft_deleted']
        ],
        // compact declaration
        \App\Models\User::class => [],
        // more compact
        \App\Models\User::class,
    ],
],
```

_Don't worry about multiple attributes definition, I tested a lot of times by querying Meilisearch index settings, and only one definition will be set._