### PR TITLE
[10.x] Drop old PHP and Laravel versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2]
+        php: ['8.0', 8.1, 8.2]
         laravel: [9]
+        exclude:
+          - php: '8.0'
+            laravel: 9
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,15 +16,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, '8.0', 8.1, 8.2]
-        laravel: [8, 9]
-        exclude:
-          - php: 7.3
-            laravel: 9
-          - php: 7.4
-            laravel: 9
-          - php: 8.2
-            laravel: 8
+        php: [8.1, 8.2]
+        laravel: [9]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -14,19 +14,19 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
-        "illuminate/bus": "^8.0|^9.0",
-        "illuminate/contracts": "^8.0|^9.0",
-        "illuminate/database": "^8.0|^9.0",
-        "illuminate/http": "^8.0|^9.0",
-        "illuminate/pagination": "^8.0|^9.0",
-        "illuminate/queue": "^8.0|^9.0",
-        "illuminate/support": "^8.0|^9.0"
+        "php": "^8.1",
+        "illuminate/bus": "^9.0",
+        "illuminate/contracts": "^9.0",
+        "illuminate/database": "^9.0",
+        "illuminate/http": "^9.0",
+        "illuminate/pagination": "^9.0",
+        "illuminate/queue": "^9.0",
+        "illuminate/support": "^9.0"
     },
     "require-dev": {
-        "meilisearch/meilisearch-php": "^0.19",
+        "meilisearch/meilisearch-php": "^0.23",
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "^6.17|^7.0",
+        "orchestra/testbench": "^7.0",
         "phpunit/phpunit": "^9.3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.0",
         "illuminate/bus": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/database": "^9.0",


### PR DESCRIPTION
Drops support for PHP 7.3 & 7.4 and Laravel 8.x