### PR TITLE
[10.x] Meilisearch v1 support 

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.md
@@ -7,7 +7,7 @@ about: "Report something that's broken. Please ensure your Laravel version is st
 <!-- Fill out the FULL versions with patch versions -->
 
 - Scout Version: #.#.#
-- Scout Driver: Algolia / MeiliSearch / Database / Collection
+- Scout Driver: Algolia / Meilisearch / Database / Collection
 - Laravel Version: #.#.#
 - PHP Version: #.#.#
 - Database Driver & Version:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 Laravel Scout provides a simple, driver-based solution for adding full-text search to your Eloquent models. Once Scout is installed and configured, it will automatically sync your model changes to your search indexes. Currently, Scout supports:
 
 - [Algolia](https://www.algolia.com/)
-- [MeiliSearch](https://github.com/meilisearch/meilisearch)
+- [Meilisearch](https://github.com/meilisearch/meilisearch)
 
 ## Official Documentation
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -29,17 +29,17 @@ PR: https://github.com/laravel/scout/pull/657
 
 Due to the `getScoutKeyName` change discussed above, the `getUnqualifiedScoutKeyName` method was removed as it is no longer necessary.
 
-### Meilisearch v1.0 Changes
+### Meilisearch 1.0 Changes
 
-Scout v10 now supports Meilisearch PHP v1.0 as its new minimum version. You should upgrade your dependency:
+Scout 10.x requires Meilisearch PHP 1.0 as its minimum supported SDK version; therefore, you should upgrade your dependency via your application's `composer.json` file:
 
 ```json
 "meilisearch/meilisearch-php": "^1.0",
 ```
 
-Further more, all casing has been changed from the old `MeiliSearch` to the new `Meilisearch`. This means that all references to Meilisearch code you have in your codebase should adopt this new casing.
+In this SDK update, all namespace and class references to "MeiliSearch" have been updated to "Meilisearch". Please review your code for any reference to the old capitalization and update those references accordingly.
 
-Please see [the full Meilisearch PHP v1.0 changelog](https://github.com/meilisearch/meilisearch-php/releases/tag/v1.0.0) for all changes.
+In addition, please consult the full [Meilisearch PHP v1.0 changelog](https://github.com/meilisearch/meilisearch-php/releases/tag/v1.0.0) for further details.
 
 ## Upgrading To 9.0 From 8.x
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -29,6 +29,18 @@ PR: https://github.com/laravel/scout/pull/657
 
 Due to the `getScoutKeyName` change discussed above, the `getUnqualifiedScoutKeyName` method was removed as it is no longer necessary.
 
+### Meilisearch v1.0 Changes
+
+Scout v10 now supports Meilisearch PHP v1.0 as its new minimum version. You should upgrade your dependency:
+
+```json
+"meilisearch/meilisearch-php": "^1.0",
+```
+
+Further more, all casing has been changed from the old `MeiliSearch` to the new `Meilisearch`. This means that all references to Meilisearch code you have in your codebase should adopt this new casing.
+
+Please see [the full Meilisearch PHP v1.0 changelog](https://github.com/meilisearch/meilisearch/releases/tag/v1.0.0) for all changes.
+
 ## Upgrading To 9.0 From 8.x
 
 ### Minimum Laravel Version

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -39,7 +39,7 @@ Scout v10 now supports Meilisearch PHP v1.0 as its new minimum version. You shou
 
 Further more, all casing has been changed from the old `MeiliSearch` to the new `Meilisearch`. This means that all references to Meilisearch code you have in your codebase should adopt this new casing.
 
-Please see [the full Meilisearch PHP v1.0 changelog](https://github.com/meilisearch/meilisearch/releases/tag/v1.0.0) for all changes.
+Please see [the full Meilisearch PHP v1.0 changelog](https://github.com/meilisearch/meilisearch-php/releases/tag/v1.0.0) for all changes.
 
 ## Upgrading To 9.0 From 8.x
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -29,7 +29,7 @@ PR: https://github.com/laravel/scout/pull/657
 
 Due to the `getScoutKeyName` change discussed above, the `getUnqualifiedScoutKeyName` method was removed as it is no longer necessary.
 
-### Meilisearch 1.0 Changes
+### Meilisearch 1.0
 
 Scout 10.x requires Meilisearch PHP 1.0 as its minimum supported SDK version; therefore, you should upgrade your dependency via your application's `composer.json` file:
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "illuminate/support": "^9.0|^10.0"
     },
     "require-dev": {
-        "meilisearch/meilisearch-php": "^0.23",
+        "meilisearch/meilisearch-php": "^1.0",
         "mockery/mockery": "^1.0",
         "php-http/guzzle7-adapter": "^1.0",
         "orchestra/testbench": "^7.0|^8.0",
@@ -52,7 +52,7 @@
     },
     "suggest": {
         "algolia/algoliasearch-client-php": "Required to use the Algolia engine (^3.2).",
-        "meilisearch/meilisearch-php": "Required to use the MeiliSearch engine (^0.23)."
+        "meilisearch/meilisearch-php": "Required to use the Meilisearch engine (^1.0)."
     },
     "config": {
         "sort-packages": true,

--- a/config/scout.php
+++ b/config/scout.php
@@ -118,12 +118,12 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | MeiliSearch Configuration
+    | Meilisearch Configuration
     |--------------------------------------------------------------------------
     |
-    | Here you may configure your MeiliSearch settings. MeiliSearch is an open
+    | Here you may configure your Meilisearch settings. Meilisearch is an open
     | source search engine with minimal configuration. Below, you can state
-    | the host and key information for your own MeiliSearch installation.
+    | the host and key information for your own Meilisearch installation.
     |
     | See: https://docs.meilisearch.com/guides/advanced_guides/configuration.html
     |

--- a/src/Console/SyncIndexSettingsCommand.php
+++ b/src/Console/SyncIndexSettingsCommand.php
@@ -22,7 +22,7 @@ class SyncIndexSettingsCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Sync your configured index settings with your search engine (MeiliSearch)';
+    protected $description = 'Sync your configured index settings with your search engine (Meilisearch)';
 
     /**
      * Execute the console command.

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -10,9 +10,10 @@ use Illuminate\Support\Manager;
 use Laravel\Scout\Engines\AlgoliaEngine;
 use Laravel\Scout\Engines\CollectionEngine;
 use Laravel\Scout\Engines\DatabaseEngine;
-use Laravel\Scout\Engines\MeiliSearchEngine;
+use Laravel\Scout\Engines\MeilisearchEngine;
 use Laravel\Scout\Engines\NullEngine;
-use MeiliSearch\Client as MeiliSearch;
+use Meilisearch\Client as MeilisearchClient;
+use Meilisearch\Meilisearch;
 
 class EngineManager extends Manager
 {
@@ -74,10 +75,10 @@ class EngineManager extends Manager
         }
 
         if (class_exists('AlgoliaSearch\Client')) {
-            throw new Exception('Please upgrade your Algolia client to version: ^2.2.');
+            throw new Exception('Please upgrade your Algolia client to version: ^3.2.');
         }
 
-        throw new Exception('Please install the Algolia client: algolia/algoliasearch-client-php.');
+        throw new Exception('Please install the suggested Algolia client: algolia/algoliasearch-client-php.');
     }
 
     /**
@@ -107,38 +108,34 @@ class EngineManager extends Manager
     }
 
     /**
-     * Create an MeiliSearch engine instance.
+     * Create a Meilisearch engine instance.
      *
-     * @return \Laravel\Scout\Engines\MeiliSearchEngine
+     * @return \Laravel\Scout\Engines\MeilisearchEngine
      */
     public function createMeilisearchDriver()
     {
-        $this->ensureMeiliSearchClientIsInstalled();
+        $this->ensureMeilisearchClientIsInstalled();
 
-        return new MeiliSearchEngine(
-            $this->container->make(
-                class_exists(MeiliSearch::class)
-                    ? MeiliSearch::class
-                    : \Meilisearch\Client::class
-            ),
+        return new MeilisearchEngine(
+            $this->container->make(MeilisearchClient::class),
             config('scout.soft_delete', false)
         );
     }
 
     /**
-     * Ensure the MeiliSearch client is installed.
+     * Ensure the Meilisearch client is installed.
      *
      * @return void
      *
      * @throws \Exception
      */
-    protected function ensureMeiliSearchClientIsInstalled()
+    protected function ensureMeilisearchClientIsInstalled()
     {
-        if (class_exists(MeiliSearch::class) || class_exists(\Meilisearch\Client::class)) {
+        if (class_exists(Meilisearch::class) && version_compare(Meilisearch::VERSION, '1.0.0') >= 0) {
             return;
         }
 
-        throw new Exception('Please install the MeiliSearch client: meilisearch/meilisearch-php.');
+        throw new Exception('Please install the suggested Meilisearch client: meilisearch/meilisearch-php.');
     }
 
     /**

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -113,6 +113,7 @@ class MeilisearchEngine extends Engine
 
     /**
      * Perform the given search on the engine.
+     *
      * page/hitsPerPage ensures that the search is exhaustive.
      *
      * @param  int  $perPage

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -5,15 +5,17 @@ namespace Laravel\Scout\Engines;
 use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Jobs\RemoveableScoutCollection;
-use MeiliSearch\MeiliSearch;
-use MeiliSearch\Search\SearchResult;
+use Meilisearch\Client as MeilisearchClient;
+use Meilisearch\Contracts\IndexesQuery;
+use Meilisearch\Meilisearch;
+use Meilisearch\Search\SearchResult;
 
-class MeiliSearchEngine extends Engine
+class MeilisearchEngine extends Engine
 {
     /**
-     * The MeiliSearch client.
+     * The Meilisearch client.
      *
-     * @var \MeiliSearch\Client|\Meilisearch\Client
+     * @var \Meilisearch\Client
      */
     protected $meilisearch;
 
@@ -25,13 +27,13 @@ class MeiliSearchEngine extends Engine
     protected $softDelete;
 
     /**
-     * Create a new MeiliSearchEngine instance.
+     * Create a new MeilisearchEngine instance.
      *
-     * @param  \MeiliSearch\Client|\Meilisearch\Client  $meilisearch
+     * @param  \Meilisearch\Client  $meilisearch
      * @param  bool  $softDelete
      * @return void
      */
-    public function __construct($meilisearch, $softDelete = false)
+    public function __construct(MeilisearchClient $meilisearch, $softDelete = false)
     {
         $this->meilisearch = $meilisearch;
         $this->softDelete = $softDelete;
@@ -43,7 +45,7 @@ class MeiliSearchEngine extends Engine
      * @param  \Illuminate\Database\Eloquent\Collection  $models
      * @return void
      *
-     * @throws \MeiliSearch\Exceptions\ApiException|\Meilisearch\Exceptions\ApiException
+     * @throws \Meilisearch\Exceptions\ApiException
      */
     public function update($models)
     {
@@ -103,14 +105,15 @@ class MeiliSearchEngine extends Engine
     public function search(Builder $builder)
     {
         return $this->performSearch($builder, array_filter([
-            'filters' => $this->filters($builder),
-            'limit' => $builder->limit,
+            'filter' => $this->filters($builder),
+            'hitsPerPage' => $builder->limit,
             'sort' => $this->buildSortFromOrderByClauses($builder),
         ]));
     }
 
     /**
      * Perform the given search on the engine.
+     * page/hitsPerPage ensures that the search is exhaustive.
      *
      * @param  int  $perPage
      * @param  int  $page
@@ -119,9 +122,9 @@ class MeiliSearchEngine extends Engine
     public function paginate(Builder $builder, $perPage, $page)
     {
         return $this->performSearch($builder, array_filter([
-            'filters' => $this->filters($builder),
-            'limit' => (int) $perPage,
-            'offset' => ($page - 1) * $perPage,
+            'filter' => $this->filters($builder),
+            'hitsPerPage' => (int) $perPage,
+            'page' => $page,
             'sort' => $this->buildSortFromOrderByClauses($builder),
         ]));
     }
@@ -136,19 +139,6 @@ class MeiliSearchEngine extends Engine
     protected function performSearch(Builder $builder, array $searchParams = [])
     {
         $meilisearch = $this->meilisearch->index($builder->index ?: $builder->model->searchableAs());
-
-        $meilisearchVersionClassName = class_exists(MeiliSearch::class)
-            ? MeiliSearch::class
-            : \Meilisearch\Meilisearch::class;
-
-        // meilisearch-php 0.19.0 is compatible with meilisearch server 0.21.0...
-        if (version_compare($meilisearchVersionClassName::VERSION, '0.19.0') >= 0 && isset($searchParams['filters'])) {
-            $searchParams['filter'] = $searchParams['filters'];
-
-            unset($searchParams['filters']);
-        }
-
-        $searchParams = array_merge($builder->options, $searchParams);
 
         if ($builder->callback) {
             $result = call_user_func(
@@ -323,7 +313,7 @@ class MeiliSearchEngine extends Engine
      */
     public function getTotalCount($results)
     {
-        return $results['nbHits'];
+        return $results['totalHits'];
     }
 
     /**
@@ -346,7 +336,7 @@ class MeiliSearchEngine extends Engine
      * @param  array  $options
      * @return mixed
      *
-     * @throws \MeiliSearch\Exceptions\ApiException|\Meilisearch\Exceptions\ApiException
+     * @throws \Meilisearch\Exceptions\ApiException
      */
     public function createIndex($name, array $options = [])
     {
@@ -360,7 +350,7 @@ class MeiliSearchEngine extends Engine
      * @param  array  $options
      * @return array
      *
-     * @throws \MeiliSearch\Exceptions\ApiException|\Meilisearch\Exceptions\ApiException
+     * @throws \Meilisearch\Exceptions\ApiException
      */
     public function updateIndexSettings($name, array $options = [])
     {
@@ -373,7 +363,7 @@ class MeiliSearchEngine extends Engine
      * @param  string  $name
      * @return mixed
      *
-     * @throws \MeiliSearch\Exceptions\ApiException|\Meilisearch\Exceptions\ApiException
+     * @throws \Meilisearch\Exceptions\ApiException
      */
     public function deleteIndex($name)
     {
@@ -387,7 +377,19 @@ class MeiliSearchEngine extends Engine
      */
     public function deleteAllIndexes()
     {
-        return $this->meilisearch->deleteAllIndexes();
+        $tasks = [];
+        $limit = 1000000;
+
+        $query = new IndexesQuery();
+        $query->setLimit($limit);
+
+        $indexes = $this->meilisearch->getIndexes($query);
+
+        foreach ($indexes->getResults() as $index) {
+            $tasks[] = $index->delete();
+        }
+
+        return $tasks;
     }
 
     /**
@@ -402,7 +404,7 @@ class MeiliSearchEngine extends Engine
     }
 
     /**
-     * Dynamically call the MeiliSearch client instance.
+     * Dynamically call the Meilisearch client instance.
      *
      * @param  string  $method
      * @param  array  $parameters

--- a/src/ScoutServiceProvider.php
+++ b/src/ScoutServiceProvider.php
@@ -9,8 +9,7 @@ use Laravel\Scout\Console\FlushCommand;
 use Laravel\Scout\Console\ImportCommand;
 use Laravel\Scout\Console\IndexCommand;
 use Laravel\Scout\Console\SyncIndexSettingsCommand;
-use MeiliSearch\Client as MeiliSearchClient;
-use MeiliSearch\MeiliSearch;
+use Meilisearch\Client as Meilisearch;
 
 class ScoutServiceProvider extends ServiceProvider
 {
@@ -23,27 +22,15 @@ class ScoutServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/scout.php', 'scout');
 
-        if (class_exists(MeiliSearchClient::class) || class_exists(\Meilisearch\Client::class)) {
-            $meilisearchClientClassName = class_exists(MeiliSearchClient::class)
-                ? MeiliSearchClient::class
-                : \Meilisearch\Client::class;
-            $this->app->singleton($meilisearchClientClassName, function ($app) use ($meilisearchClientClassName) {
+        if (class_exists(Meilisearch::class)) {
+            $this->app->singleton(Meilisearch::class, function ($app) {
                 $config = $app['config']->get('scout.meilisearch');
 
-                $meilisearchVersionClassName = class_exists(MeiliSearch::class)
-                    ? MeiliSearch::class
-                    : \Meilisearch\Meilisearch::class;
-                if (version_compare($meilisearchVersionClassName::VERSION, '0.24.2') >= 0) {
-                    return new MeiliSearchClient(
-                        $config['host'],
-                        $config['key'],
-                        null,
-                        null,
-                        [sprintf('Meilisearch Laravel Scout (v%s)', Scout::VERSION)],
-                    );
-                }
-
-                return new $meilisearchClientClassName($config['host'], $config['key']);
+                return new Meilisearch(
+                    $config['host'],
+                    $config['key'],
+                    clientAgents: [sprintf('Meilisearch Laravel Scout (v%s)', Scout::VERSION)],
+                );
             });
         }
 

--- a/tests/Feature/MeilisearchEngineTest.php
+++ b/tests/Feature/MeilisearchEngineTest.php
@@ -3,7 +3,7 @@
 namespace Laravel\Scout\Tests\Feature;
 
 use Laravel\Scout\ScoutServiceProvider;
-use MeiliSearch\Client;
+use Meilisearch\Client;
 use Orchestra\Testbench\TestCase;
 
 class MeilisearchEngineTest extends TestCase


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

- [x] Notable changes for the migration guide
  - [x] casing of the the client in the service container has been renamed (use the correct `\Meilisearch\Client`)
    - Reference: https://github.com/meilisearch/meilisearch-php/releases/tag/v0.27.0
  - [x] minimum required meilisearch-php library version v1
  - [x] Usage of the new pagination implementation of meilisearch (page/hitsPerPage) which makes the search results exhausitve instead of estimated
    - Reference: https://docs.meilisearch.com/learn/advanced/pagination.html#numbered-page-selectors 
    - Reference: https://github.com/meilisearch/meilisearch/releases/tag/v0.30.0
  - [x] No workarounds for earlier meilisearch-php library versions (`filters => filter`)
    - Reference: https://github.com/meilisearch/meilisearch/releases/tag/v0.21.0
  - [x] Also consult the changelog on https://github.com/meilisearch/meilisearch-php for any breaking changes if you are customizing engine searches like so https://laravel.com/docs/9.x/scout#customizing-engine-searches
    - Reference: https://github.com/meilisearch/meilisearch-php/releases