### PR TITLE
[9.x] Allow options for search requests

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -76,6 +76,13 @@ class Builder
     public $orders = [];
 
     /**
+     * Extra options that should be applied to the search.
+     *
+     * @var int
+     */
+    public $options = [];
+
+    /**
      * Create a new search builder instance.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
@@ -186,6 +193,19 @@ class Builder
             'column' => $column,
             'direction' => strtolower($direction) == 'asc' ? 'asc' : 'desc',
         ];
+
+        return $this;
+    }
+
+    /**
+     * Set extra options for the search query.
+     *
+     * @param  array  $options
+     * @return $this
+     */
+    public function options(array $options)
+    {
+        $this->options = $options;
 
         return $this;
     }

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -140,6 +140,8 @@ class AlgoliaEngine extends Engine
             $builder->index ?: $builder->model->searchableAs()
         );
 
+        $options = array_merge($builder->options, $options);
+
         if ($builder->callback) {
             return call_user_func(
                 $builder->callback,

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -125,7 +125,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
     {
         $query = $this->initializeSearchQuery(
             $builder,
-            $columns = array_keys($builder->model->toSearchableArray()),
+            array_keys($builder->model->toSearchableArray()),
             $this->getPrefixColumns($builder),
             $this->getFullTextColumns($builder)
         );
@@ -216,8 +216,8 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
      * Ensure that soft delete constraints are properly applied to the query.
      *
      * @param  \Laravel\Scout\Builder  $builder
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @return \Illuminate\Database\Query\Builder
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     protected function constrainForSoftDeletes($builder, $query)
     {

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -145,6 +145,8 @@ class MeiliSearchEngine extends Engine
             unset($searchParams['filters']);
         }
 
+        $searchParams = array_merge($builder->options, $searchParams);
+
         if ($builder->callback) {
             $result = call_user_func(
                 $builder->callback,


### PR DESCRIPTION
Closes https://github.com/laravel/scout/issues/682

This PR allows users to set extra options for their search request. Right now, Algolia and Meilisearch are supported.

```php
$results = User::search('hello world')->options([
    'matchingStrategy' => 'all',
])->get();
```