### PR TITLE
Fix Meilisearch class name case

### DIFF
--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -6,7 +6,7 @@ use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Jobs\RemoveableScoutCollection;
 use MeiliSearch\Client as MeiliSearchClient;
-use MeiliSearch\MeiliSearch;
+use MeiliSearch\Meilisearch;
 use MeiliSearch\Search\SearchResult;
 
 class MeiliSearchEngine extends Engine
@@ -139,7 +139,7 @@ class MeiliSearchEngine extends Engine
         $meilisearch = $this->meilisearch->index($builder->index ?: $builder->model->searchableAs());
 
         // meilisearch-php 0.19.0 is compatible with meilisearch server 0.21.0...
-        if (version_compare(MeiliSearch::VERSION, '0.19.0') >= 0 && isset($searchParams['filters'])) {
+        if (version_compare(Meilisearch::VERSION, '0.19.0') >= 0 && isset($searchParams['filters'])) {
             $searchParams['filter'] = $searchParams['filters'];
 
             unset($searchParams['filters']);

--- a/src/ScoutServiceProvider.php
+++ b/src/ScoutServiceProvider.php
@@ -10,7 +10,7 @@ use Laravel\Scout\Console\ImportCommand;
 use Laravel\Scout\Console\IndexCommand;
 use Laravel\Scout\Console\SyncIndexSettingsCommand;
 use MeiliSearch\Client as MeiliSearchClient;
-use MeiliSearch\MeiliSearch;
+use MeiliSearch\Meilisearch;
 
 class ScoutServiceProvider extends ServiceProvider
 {
@@ -27,7 +27,7 @@ class ScoutServiceProvider extends ServiceProvider
             $this->app->singleton(MeiliSearchClient::class, function ($app) {
                 $config = $app['config']->get('scout.meilisearch');
 
-                if (version_compare(MeiliSearch::VERSION, '0.24.2') >= 0) {
+                if (version_compare(Meilisearch::VERSION, '0.24.2') >= 0) {
                     return new MeiliSearchClient(
                         $config['host'],
                         $config['key'],


### PR DESCRIPTION
Composer is able to autoload improperly-cased namespaces if configured to do so but will not autoload an improperly-cased class name if the filesystem is case-sensitive.