### PR TITLE
[9.x] Make scout compatible with new meilisearch casing

### DIFF
--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -117,8 +117,8 @@ class EngineManager extends Manager
 
         return new MeiliSearchEngine(
             $this->container->make(
-                class_exists(MeiliSearch::class) 
-                    ? MeiliSearch::class 
+                class_exists(MeiliSearch::class)
+                    ? MeiliSearch::class
                     : \Meilisearch\Client::class
             ),
             config('scout.soft_delete', false)

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -116,7 +116,11 @@ class EngineManager extends Manager
         $this->ensureMeiliSearchClientIsInstalled();
 
         return new MeiliSearchEngine(
-            $this->container->make(MeiliSearch::class),
+            $this->container->make(
+                class_exists(MeiliSearch::class) 
+                    ? MeiliSearch::class 
+                    : \Meilisearch\Client::class
+            ),
             config('scout.soft_delete', false)
         );
     }
@@ -130,7 +134,7 @@ class EngineManager extends Manager
      */
     protected function ensureMeiliSearchClientIsInstalled()
     {
-        if (class_exists(MeiliSearch::class)) {
+        if (class_exists(MeiliSearch::class) || class_exists(\Meilisearch\Client::class)) {
             return;
         }
 

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -5,7 +5,6 @@ namespace Laravel\Scout\Engines;
 use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Jobs\RemoveableScoutCollection;
-use MeiliSearch\Client as MeiliSearchClient;
 use MeiliSearch\MeiliSearch;
 use MeiliSearch\Search\SearchResult;
 
@@ -14,7 +13,7 @@ class MeiliSearchEngine extends Engine
     /**
      * The MeiliSearch client.
      *
-     * @var \MeiliSearch\Client|\Meilisearch\Client 
+     * @var \MeiliSearch\Client|\Meilisearch\Client
      */
     protected $meilisearch;
 
@@ -138,8 +137,8 @@ class MeiliSearchEngine extends Engine
     {
         $meilisearch = $this->meilisearch->index($builder->index ?: $builder->model->searchableAs());
 
-        $meilisearchVersionClassName = class_exists(MeiliSearch::class) 
-            ? MeiliSearch::class 
+        $meilisearchVersionClassName = class_exists(MeiliSearch::class)
+            ? MeiliSearch::class
             : \Meilisearch\Meilisearch::class;
 
         // meilisearch-php 0.19.0 is compatible with meilisearch server 0.21.0...

--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -14,7 +14,7 @@ class MeiliSearchEngine extends Engine
     /**
      * The MeiliSearch client.
      *
-     * @var \MeiliSearch\Client
+     * @var \MeiliSearch\Client|\Meilisearch\Client 
      */
     protected $meilisearch;
 
@@ -28,11 +28,11 @@ class MeiliSearchEngine extends Engine
     /**
      * Create a new MeiliSearchEngine instance.
      *
-     * @param  \MeiliSearch\Client  $meilisearch
+     * @param  \MeiliSearch\Client|\Meilisearch\Client  $meilisearch
      * @param  bool  $softDelete
      * @return void
      */
-    public function __construct(MeiliSearchClient $meilisearch, $softDelete = false)
+    public function __construct($meilisearch, $softDelete = false)
     {
         $this->meilisearch = $meilisearch;
         $this->softDelete = $softDelete;
@@ -44,7 +44,7 @@ class MeiliSearchEngine extends Engine
      * @param  \Illuminate\Database\Eloquent\Collection  $models
      * @return void
      *
-     * @throws \MeiliSearch\Exceptions\ApiException
+     * @throws \MeiliSearch\Exceptions\ApiException|\Meilisearch\Exceptions\ApiException
      */
     public function update($models)
     {
@@ -138,8 +138,12 @@ class MeiliSearchEngine extends Engine
     {
         $meilisearch = $this->meilisearch->index($builder->index ?: $builder->model->searchableAs());
 
+        $meilisearchVersionClassName = class_exists(MeiliSearch::class) 
+            ? MeiliSearch::class 
+            : \Meilisearch\Meilisearch::class;
+
         // meilisearch-php 0.19.0 is compatible with meilisearch server 0.21.0...
-        if (version_compare(MeiliSearch::VERSION, '0.19.0') >= 0 && isset($searchParams['filters'])) {
+        if (version_compare($meilisearchVersionClassName::VERSION, '0.19.0') >= 0 && isset($searchParams['filters'])) {
             $searchParams['filter'] = $searchParams['filters'];
 
             unset($searchParams['filters']);
@@ -155,7 +159,11 @@ class MeiliSearchEngine extends Engine
                 $searchParams
             );
 
-            return $result instanceof SearchResult ? $result->getRaw() : $result;
+            $searchResultClass = class_exists(SearchResult::class)
+                ? SearchResult::class
+                : \Meilisearch\Search\SearchResult;
+
+            return $result instanceof $searchResultClass ? $result->getRaw() : $result;
         }
 
         return $meilisearch->rawSearch($builder->query, $searchParams);
@@ -339,7 +347,7 @@ class MeiliSearchEngine extends Engine
      * @param  array  $options
      * @return mixed
      *
-     * @throws \MeiliSearch\Exceptions\ApiException
+     * @throws \MeiliSearch\Exceptions\ApiException|\Meilisearch\Exceptions\ApiException
      */
     public function createIndex($name, array $options = [])
     {
@@ -353,7 +361,7 @@ class MeiliSearchEngine extends Engine
      * @param  array  $options
      * @return array
      *
-     * @throws \MeiliSearch\Exceptions\ApiException
+     * @throws \MeiliSearch\Exceptions\ApiException|\Meilisearch\Exceptions\ApiException
      */
     public function updateIndexSettings($name, array $options = [])
     {
@@ -366,7 +374,7 @@ class MeiliSearchEngine extends Engine
      * @param  string  $name
      * @return mixed
      *
-     * @throws \MeiliSearch\Exceptions\ApiException
+     * @throws \MeiliSearch\Exceptions\ApiException|\Meilisearch\Exceptions\ApiException
      */
     public function deleteIndex($name)
     {

--- a/src/ScoutServiceProvider.php
+++ b/src/ScoutServiceProvider.php
@@ -24,14 +24,14 @@ class ScoutServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../config/scout.php', 'scout');
 
         if (class_exists(MeiliSearchClient::class) || class_exists(\Meilisearch\Client::class)) {
-            $meilisearchClientClassName = class_exists(MeiliSearchClient::class) 
-                ? MeiliSearchClient::class 
+            $meilisearchClientClassName = class_exists(MeiliSearchClient::class)
+                ? MeiliSearchClient::class
                 : \Meilisearch\Client::class;
             $this->app->singleton($meilisearchClientClassName, function ($app) {
                 $config = $app['config']->get('scout.meilisearch');
 
-                $meilisearchVersionClassName = class_exists(MeiliSearch::class) 
-                    ? MeiliSearch::class 
+                $meilisearchVersionClassName = class_exists(MeiliSearch::class)
+                    ? MeiliSearch::class
                     : \Meilisearch\Meilisearch::class;
                 if (version_compare($meilisearchVersionClassName::VERSION, '0.24.2') >= 0) {
                     return new MeiliSearchClient(

--- a/src/ScoutServiceProvider.php
+++ b/src/ScoutServiceProvider.php
@@ -23,11 +23,17 @@ class ScoutServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/scout.php', 'scout');
 
-        if (class_exists(MeiliSearchClient::class)) {
-            $this->app->singleton(MeiliSearchClient::class, function ($app) {
+        if (class_exists(MeiliSearchClient::class) || class_exists(\Meilisearch\Client::class)) {
+            $meilisearchClientClassName = class_exists(MeiliSearchClient::class) 
+                ? MeiliSearchClient::class 
+                : \Meilisearch\Client::class;
+            $this->app->singleton($meilisearchClientClassName, function ($app) {
                 $config = $app['config']->get('scout.meilisearch');
 
-                if (version_compare(MeiliSearch::VERSION, '0.24.2') >= 0) {
+                $meilisearchVersionClassName = class_exists(MeiliSearch::class) 
+                    ? MeiliSearch::class 
+                    : \Meilisearch\Meilisearch::class;
+                if (version_compare($meilisearchVersionClassName::VERSION, '0.24.2') >= 0) {
                     return new MeiliSearchClient(
                         $config['host'],
                         $config['key'],
@@ -37,7 +43,7 @@ class ScoutServiceProvider extends ServiceProvider
                     );
                 }
 
-                return new MeiliSearchClient($config['host'], $config['key']);
+                return new $meilisearchClientClassName($config['host'], $config['key']);
             });
         }
 


### PR DESCRIPTION
This adds workarounds for the new casing of class names that we introduced on `meilisearch/meilisearch-php` which had more implications than we thought. This should also solve issues like https://github.com/laravel/scout/pull/685

Unfortunately PHP handles case sensitivity on some platforms differently

These changes are not necessary for the 10.x branch which (when released) will already handle these case changes

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
