### PR TITLE
[9.x] Handle non-consecutive key collection on MeiliSearch document deletion

### DIFF
--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -92,7 +92,7 @@ class MeiliSearchEngine extends Engine
             ? $models->pluck($models->first()->getUnqualifiedScoutKeyName())
             : $models->map->getScoutKey();
 
-        $index->deleteDocuments($keys->all());
+        $index->deleteDocuments($keys->values()->all());
     }
 
     /**


### PR DESCRIPTION
Methods `MeiliSearchEngine::update()` and `MeiliSearchEngine::delete()` both expect a Illuminate\Database\Eloquent\Collection of models. 

For my use case I used to fine-tune this collection using `->filter()` on it. Using ->filter() on collection might result in a collection that doesn't wrap a [list](https://www.php.net/manual/en/function.array-is-list.php) anymore, but an array with non-consecutive keys. While `MeiliSearchEngine::update()` implementation handle this well, calling the `MeiliSearchEngine::delete()` method results in following error from Meilisearch:

> Meilisearch ApiException: Http Status: 400 - Message: Json deserialize error: invalid type: map, expected a sequence at line 1 column 0 - Code: bad_request - Type: invalid_request - Link: https://docs.meilisearch.com/errors#bad_request

This is because delete() method uses `->all()` directly on the provided Collection.

You might argue I should use `->values()` in my user-land code, and this is what I did for the moment as a workaround. But IMHO, update() and delete() should behave the same with array that are not list.

This PR propose to change `->all()` to `->values()->all()`.