### PR TITLE
[9.x] Define conflict with meilisearch-php 0.26.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
         "orchestra/testbench": "^6.17|^7.0",
         "phpunit/phpunit": "^9.3"
     },
+    "conflict":  {
+        "meilisearch/meilisearch-php": ">=0.26.1"
+    },
     "autoload": {
         "psr-4": {
             "Laravel\\Scout\\": "src/"


### PR DESCRIPTION
MeiliSearch\MeiliSearch class is not found when installing latest meilisearch-php (0.26.1) and latest scout (0.97)

meilisearch/meilisearch-php 0.26.1 renamed its base namespace from `MeiliSearch` to `Meilisearch` but also renamed the class `MeiliSearch\MeiliSearch` class to `Meilisearch\Meilisearch`, which breaks compatibility with Scout due to Composer class autoloading being case-sensitive.a

This PR updates the Composer configuration to define a conflict with meilisearch-php >= 0.26.1

I also have a PR on meilisearch-php (meilisearch/meilisearch-php#441) that would reverse the renaming of the class.

I can see that @mmachatschek added some conditional class_exists() calls to work around (#687), but maybe for the time being we should wait to see what is happening with meilisearch-php. I'd be less concerned if meilisearch-php's breaking change had taken place during a transition to v1.0 instead of v0.26.0 -> v0.26.1. That was just weird.

