### PR TITLE
[9.x] Add `scout:create` command

### DIFF
--- a/src/Console/CreateCommand.php
+++ b/src/Console/CreateCommand.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Laravel\Scout\Console;
+
+use Illuminate\Console\GeneratorCommand;
+
+class CreateCommand extends GeneratorCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'scout:create {name : The name of the custom engine}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new scout custom engine class';
+
+    protected function getStub()
+    {
+        return __DIR__ . '/stubs/create.stub';
+    }
+
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace . '\Scout';
+    }
+}

--- a/src/Console/stubs/create.stub
+++ b/src/Console/stubs/create.stub
@@ -1,0 +1,127 @@
+<?php
+
+namespace {{ namespace }};
+
+use Laravel\Scout\Builder;
+use laravel\Scout\Engines\Engine;
+
+class {{ class }} extends Engine
+{
+
+    /**
+     * Update the given model in the index.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @return void
+     */
+    public function update($models){
+        //
+    }
+
+    /**
+     * Remove the given model from the index.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @return void
+     */
+    public function delete($models){
+        //
+    }
+
+    /**
+     * Perform the given search on the engine.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return mixed
+     */
+    public function search(Builder $builder){
+        //
+    }
+
+    /**
+     * Perform the given search on the engine.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  int  $perPage
+     * @param  int  $page
+     * @return mixed
+     */
+    public function paginate(Builder $builder, $perPage, $page){
+        //
+    }
+
+    /**
+     * Pluck and return the primary keys of the given results.
+     *
+     * @param  mixed  $results
+     * @return \Illuminate\Support\Collection
+     */
+    public function mapIds($results){
+        //
+    }
+
+    /**
+     * Map the given results to instances of the given model.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  mixed  $results
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function map(Builder $builder, $results, $model){
+        //
+    }
+
+    /**
+     * Map the given results to instances of the given model via a lazy collection.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  mixed  $results
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Support\LazyCollection
+     */
+    public function lazyMap(Builder $builder, $results, $model){
+        //
+    }
+
+    /**
+     * Get the total count from a raw result returned by the engine.
+     *
+     * @param  mixed  $results
+     * @return int
+     */
+    public function getTotalCount($results){
+        //
+    }
+
+    /**
+     * Flush all of the model's records from the engine.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    public function flush($model){
+        //
+    }
+
+    /**
+     * Create a search index.
+     *
+     * @param  string  $name
+     * @param  array  $options
+     * @return mixed
+     */
+    public function createIndex($name, array $options = []){
+        //
+    }
+
+    /**
+     * Delete a search index.
+     *
+     * @param  string  $name
+     * @return mixed
+     */
+    public function deleteIndex($name){
+        //
+    }
+}

--- a/src/ScoutServiceProvider.php
+++ b/src/ScoutServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Laravel\Scout;
 
 use Illuminate\Support\ServiceProvider;
+use Laravel\Scout\Console\CreateCommand;
 use Laravel\Scout\Console\DeleteAllIndexesCommand;
 use Laravel\Scout\Console\DeleteIndexCommand;
 use Laravel\Scout\Console\FlushCommand;
@@ -67,6 +68,7 @@ class ScoutServiceProvider extends ServiceProvider
                 SyncIndexSettingsCommand::class,
                 DeleteIndexCommand::class,
                 DeleteAllIndexesCommand::class,
+                CreateCommand::class,
             ]);
 
             $this->publishes([


### PR DESCRIPTION
In this PR, add the `scout:create` command for create the custom search engine class.

This command gives the `name` argument for the name of the search engine.

exp:
```` 
php artisan scout:create SqliteEngine 
````