### PR TITLE
[9.x] Fix missing variable in closure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "require-dev": {
         "meilisearch/meilisearch-php": "^0.19",
         "mockery/mockery": "^1.0",
+        "php-http/guzzle7-adapter": "^1.0",
         "orchestra/testbench": "^6.17|^7.0",
         "phpunit/phpunit": "^9.3"
     },

--- a/src/ScoutServiceProvider.php
+++ b/src/ScoutServiceProvider.php
@@ -27,7 +27,7 @@ class ScoutServiceProvider extends ServiceProvider
             $meilisearchClientClassName = class_exists(MeiliSearchClient::class)
                 ? MeiliSearchClient::class
                 : \Meilisearch\Client::class;
-            $this->app->singleton($meilisearchClientClassName, function ($app) {
+            $this->app->singleton($meilisearchClientClassName, function ($app) use ($meilisearchClientClassName) {
                 $config = $app['config']->get('scout.meilisearch');
 
                 $meilisearchVersionClassName = class_exists(MeiliSearch::class)

--- a/tests/Feature/MeilisearchEngineTest.php
+++ b/tests/Feature/MeilisearchEngineTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Laravel\Scout\Tests\Feature;
+
+use Laravel\Scout\ScoutServiceProvider;
+use MeiliSearch\Client;
+use Orchestra\Testbench\TestCase;
+
+class MeilisearchEngineTest extends TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [ScoutServiceProvider::class];
+    }
+
+    protected function defineEnvironment($app)
+    {
+        $app->make('config')->set('scout.driver', 'meilisearch');
+    }
+
+    public function test_the_meilisearch_client_can_be_initialized()
+    {
+        $this->assertInstanceOf(Client::class, app(Client::class));
+    }
+}


### PR DESCRIPTION
This PR fixes a missing variable import for the Meilisearch client in its service provider.

Fixes https://github.com/laravel/scout/issues/693