### PR TITLE
[9.x] Enable order by for `collection` & `database` engines

### DIFF
--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -101,11 +101,11 @@ class CollectionEngine extends Engine
                             }
                         })
                         ->when($builder->orders, function ($query) use ($builder) {
-                            foreach ($builder->orders as $order){
+                            foreach ($builder->orders as $order) {
                                 $query->orderBy($order['column'], $order['direction']);
                             }
                         }, function ($query) use ($builder) {
-                                $query->orderBy($builder->model->getKeyName(), 'desc');
+                            $query->orderBy($builder->model->getKeyName(), 'desc');
                         });
 
         $models = $this->ensureSoftDeletesAreHandled($builder, $query)

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -100,7 +100,13 @@ class CollectionEngine extends Engine
                                 $query->whereIn($key, $values);
                             }
                         })
-                        ->orderBy($builder->model->getKeyName(), 'desc');
+                        ->when($builder->orders, function ($query) use ($builder) {
+                            foreach ($builder->orders as $order){
+                                $query->orderBy($order['column'], $order['direction']);
+                            }
+                        }, function ($query) use ($builder) {
+                                $query->orderBy($builder->model->getKeyName(), 'desc');
+                        });
 
         $models = $this->ensureSoftDeletesAreHandled($builder, $query)
                         ->get()

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -72,6 +72,11 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
     public function paginate(Builder $builder, $perPage, $page)
     {
         return $this->buildSearchQuery($builder)
+                ->when($builder->orders, function ($query) use ($builder) {
+                    foreach ($builder->orders as $order){
+                        $query->orderBy($order['column'], $order['direction']);
+                    }
+                })
                 ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
                     $query->orderBy($builder->model->getKeyName(), 'desc');
                 })
@@ -89,6 +94,11 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
     public function simplePaginate(Builder $builder, $perPage, $page)
     {
         return $this->buildSearchQuery($builder)
+                ->when($builder->orders, function ($query) use ($builder) {
+                    foreach ($builder->orders as $order){
+                        $query->orderBy($order['column'], $order['direction']);
+                    }
+                })
                 ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
                     $query->orderBy($builder->model->getKeyName(), 'desc');
                 })
@@ -108,6 +118,11 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
         return $this->buildSearchQuery($builder)
             ->when(! is_null($page) && ! is_null($perPage), function ($query) use ($page, $perPage) {
                 $query->forPage($page, $perPage);
+            })
+            ->when($builder->orders, function ($query) use ($builder) {
+                foreach ($builder->orders as $order){
+                    $query->orderBy($order['column'], $order['direction']);
+                }
             })
             ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
                 $query->orderBy($builder->model->getKeyName(), 'desc');

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -73,7 +73,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
     {
         return $this->buildSearchQuery($builder)
                 ->when($builder->orders, function ($query) use ($builder) {
-                    foreach ($builder->orders as $order){
+                    foreach ($builder->orders as $order) {
                         $query->orderBy($order['column'], $order['direction']);
                     }
                 })
@@ -95,7 +95,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
     {
         return $this->buildSearchQuery($builder)
                 ->when($builder->orders, function ($query) use ($builder) {
-                    foreach ($builder->orders as $order){
+                    foreach ($builder->orders as $order) {
                         $query->orderBy($order['column'], $order['direction']);
                     }
                 })
@@ -120,7 +120,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
                 $query->forPage($page, $perPage);
             })
             ->when($builder->orders, function ($query) use ($builder) {
-                foreach ($builder->orders as $order){
+                foreach ($builder->orders as $order) {
                     $query->orderBy($order['column'], $order['direction']);
                 }
             })

--- a/tests/Feature/CollectionEngineTest.php
+++ b/tests/Feature/CollectionEngineTest.php
@@ -122,4 +122,15 @@ class CollectionEngineTest extends TestCase
         $models = SearchableUserModel::search('laravel')->take(1)->get();
         $this->assertCount(1, $models);
     }
+
+    public function test_it_can_order_results()
+    {
+        $models = SearchableUserModel::search('laravel')->orderBy('name', 'asc')->paginate(1, 'page', 1);
+        $this->assertCount(1, $models);
+        $this->assertEquals('Abigail Otwell', $models[0]->name);
+
+        $models = SearchableUserModel::search('laravel')->orderBy('name', 'desc')->paginate(1, 'page', 1);
+        $this->assertCount(1, $models);
+        $this->assertEquals('Taylor Otwell', $models[0]->name);
+    }
 }

--- a/tests/Feature/DatabaseEngineTest.php
+++ b/tests/Feature/DatabaseEngineTest.php
@@ -129,4 +129,31 @@ class DatabaseEngineTest extends TestCase
         })->get();
         $this->assertCount(1, $models);
     }
+
+    public function test_it_can_order_results()
+    {
+        $models = SearchableUserDatabaseModel::search('laravel')->orderBy('name', 'asc')->take(1)->get();
+        $this->assertCount(1, $models);
+        $this->assertEquals('Abigail Otwell', $models[0]->name);
+
+        $modelsPaginate = SearchableUserDatabaseModel::search('laravel')->orderBy('name', 'asc')->paginate(1, 'page', 1);
+        $this->assertCount(1, $modelsPaginate);
+        $this->assertEquals('Abigail Otwell', $modelsPaginate[0]->name);
+
+        $modelsSimplePaginate = SearchableUserDatabaseModel::search('laravel')->orderBy('name', 'asc')->simplePaginate(1, 'page', 1);
+        $this->assertCount(1, $modelsPaginate);
+        $this->assertEquals('Abigail Otwell', $modelsSimplePaginate[0]->name);
+
+        $models = SearchableUserDatabaseModel::search('laravel')->orderBy('name', 'desc')->take(1)->get();
+        $this->assertCount(1, $models);
+        $this->assertEquals('Taylor Otwell', $models[0]->name);
+
+        $modelsPaginate = SearchableUserDatabaseModel::search('laravel')->orderBy('name', 'desc')->paginate(1, 'page', 1);
+        $this->assertCount(1, $modelsPaginate);
+        $this->assertEquals('Taylor Otwell', $modelsPaginate[0]->name);
+
+        $modelsSimplePaginate = SearchableUserDatabaseModel::search('laravel')->orderBy('name', 'desc')->simplePaginate(1, 'page', 1);
+        $this->assertCount(1, $modelsSimplePaginate);
+        $this->assertEquals('Taylor Otwell', $modelsSimplePaginate[0]->name);
+    }
 }


### PR DESCRIPTION
This PR enables `->orderBy()` for the `collection` & `database` engines.

Currently, when using those engines, results are by default ordered by the model key or by any full text columns. Now you may call `->orderBy('column', 'asc');` on the Scout Builder, as you would for other engines, it will be added to the query.

Before:
```php
Users::search('otwell')->orderBy('created_at', 'desc')->get(['id', 'created_at']);
//[{
//       id: 1,
//       date: 2023-01-11 00:00:00.0,
//    },
//    {
//        id: 2,
//        date: 2023-03-11 00:00:00.0,
// }],
```
Now:
```php
Users::search('otwell')->orderBy('created_at', 'desc')->get(['id', 'created_at']);
//[{
//       id: 2,
//       date: 2023-03-11 00:00:00.0,
//    },
//    {
//       id: 1,
//       date: 2023-01-11 00:00:00.0,
// }],
```
