### PR TITLE
eager load relations before handling queued update job

### DIFF
--- a/src/Jobs/MakeSearchable.php
+++ b/src/Jobs/MakeSearchable.php
@@ -39,6 +39,9 @@ class MakeSearchable implements ShouldQueue
             return;
         }
 
+        $relations = is_array($this->models->first()->searchableRelations()) ? $this->models->first()->searchableRelations() : [];
+        $this->models->loadMissing($relations);
+
         $this->models->first()->searchableUsing()->update($this->models);
     }
 }

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -157,7 +157,18 @@ trait Searchable
      */
     protected function makeAllSearchableUsing($query)
     {
-        return $query;
+        return $query->with($this->searchableRelations());
+    }
+
+
+    /**
+     * List of relations to eager load when making all models searchable.
+     *
+     * @return array
+     */
+    public function searchableRelations()
+    {
+        return [];
     }
 
     /**

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -157,7 +157,7 @@ trait Searchable
      */
     protected function makeAllSearchableUsing($query)
     {
-        return $query->with();
+        return $query;
     }
 
 

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -157,7 +157,7 @@ trait Searchable
      */
     protected function makeAllSearchableUsing($query)
     {
-        return $query->with($this->searchableRelations());
+        return $query->with();
     }
 
 

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -160,7 +160,6 @@ trait Searchable
         return $query;
     }
 
-
     /**
      * List of relations to eager load when making all models searchable.
      *

--- a/tests/Feature/SearchableTest.php
+++ b/tests/Feature/SearchableTest.php
@@ -143,7 +143,6 @@ class ModelStubForMakeAllSearchable extends SearchableModel
         $mock->shouldReceive('when')
                 ->with(true, m::type('Closure'))
                 ->andReturnUsing(function ($condition, $callback) use ($mock) {
-                    $mock->shouldReceive('with')->with('relation')->andReturn($mock);
                     $callback($mock);
 
                     return $mock;

--- a/tests/Feature/SearchableTest.php
+++ b/tests/Feature/SearchableTest.php
@@ -143,6 +143,7 @@ class ModelStubForMakeAllSearchable extends SearchableModel
         $mock->shouldReceive('when')
                 ->with(true, m::type('Closure'))
                 ->andReturnUsing(function ($condition, $callback) use ($mock) {
+                    $mock->shouldReceive('with')->with('relation')->andReturn($mock);
                     $callback($mock);
 
                     return $mock;

--- a/tests/Unit/MakeSearchableTest.php
+++ b/tests/Unit/MakeSearchableTest.php
@@ -20,6 +20,7 @@ class MakeSearchableTest extends TestCase
             $model = m::mock(),
         ]));
 
+        $model->shouldReceive('searchableRelations');
         $model->shouldReceive('searchableUsing->update')->with($collection);
 
         $job->handle();


### PR DESCRIPTION
Since the SerializesModels trait does not store model relations in the database, it is advisable to reload them before performing the update.
Some execution times before and after:
-before
[2023-01-17 12:45:57] local.INFO: MakeSearchable job took 10.680512905121 seconds
[2023-01-17 12:46:08] local.INFO: MakeSearchable job took 9.9306659698486 seconds
[2023-01-17 12:46:15] local.INFO: MakeSearchable job took 5.8786129951477 seconds
[2023-01-17 12:46:21] local.INFO: MakeSearchable job took 5.584676027298 seconds
[2023-01-17 12:46:28] local.INFO: MakeSearchable job took 6.1048059463501 seconds
[2023-01-17 12:46:37] local.INFO: MakeSearchable job took 8.2734758853912 seconds
[2023-01-17 12:46:45] local.INFO: MakeSearchable job took 6.9796011447906 seconds
[2023-01-17 12:46:54] local.INFO: MakeSearchable job took 8.1845598220825 seconds
[2023-01-17 12:46:56] local.INFO: MakeSearchable job took 0.50963115692139 seconds

-after
[2023-01-17 12:44:50] local.INFO: MakeSearchable job took 0.36999106407166 seconds
[2023-01-17 12:44:51] local.INFO: MakeSearchable job took 0.37390899658203 seconds
[2023-01-17 12:44:52] local.INFO: MakeSearchable job took 0.25979590415955 seconds
[2023-01-17 12:44:53] local.INFO: MakeSearchable job took 0.23204803466797 seconds
[2023-01-17 12:44:53] local.INFO: MakeSearchable job took 0.27224898338318 seconds
[2023-01-17 12:44:54] local.INFO: MakeSearchable job took 0.32433986663818 seconds
[2023-01-17 12:44:55] local.INFO: MakeSearchable job took 0.3041820526123 seconds
[2023-01-17 12:44:56] local.INFO: MakeSearchable job took 0.34618282318115 seconds
[2023-01-17 12:44:57] local.INFO: MakeSearchable job took 0.046711921691895 seconds


When SCOUT_QUEUE is equal to true and QUEUE_CONNECTION is equal to database, model relations are not serialised in the database. This way, when the job is executed and the toSearchableArray function refers to fields defined by the relations, the relations are loaded one at a time (N+1) and not by eager loading, drastically increasing the execution time.
The advantages are obvious, and can be seen from the times I posted earlier: shorter job execution time.