### PR TITLE
[9.x] Meilisearch Remove deleteAllIndexes

### DIFF
--- a/src/Engines/MeiliSearchEngine.php
+++ b/src/Engines/MeiliSearchEngine.php
@@ -381,16 +381,6 @@ class MeiliSearchEngine extends Engine
     }
 
     /**
-     * Delete all search indexes.
-     *
-     * @return mixed
-     */
-    public function deleteAllIndexes()
-    {
-        return $this->meilisearch->deleteAllIndexes();
-    }
-
-    /**
      * Determine if the given model uses soft deletes.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model


### PR DESCRIPTION
As of v1.0 of [Meilisearch-php](https://github.com/meilisearch/meilisearch-php/releases/tag/v1.0.0), this method was removed.