### PR TITLE
[9.x] Ensure proper garbage collection when running `scout:import`

### DIFF
--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -38,6 +38,7 @@ class ImportCommand extends Command
 
         $events->listen(ModelsImported::class, function ($event) use ($class) {
             $key = $event->models->last()->getScoutKey();
+            $event->models = collect();
 
             $this->line('<comment>Imported ['.$class.'] models up to ID:</comment> '.$key);
         });

--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -38,9 +38,10 @@ class ImportCommand extends Command
 
         $events->listen(ModelsImported::class, function ($event) use ($class) {
             $key = $event->models->last()->getScoutKey();
-            $event->models = collect();
 
             $this->line('<comment>Imported ['.$class.'] models up to ID:</comment> '.$key);
+
+            unset($event->models);
         });
 
         $model::makeAllSearchable($this->option('chunk'));


### PR DESCRIPTION
Apologies for making the PR to to the `9.x` branch, `10.x` is still very fresh, and as far as I can tell this file is exactly the same on the `10.x` branch.

We have rather large Eloquent models that we are using in combination with Scout, and we started encountering memory issues on our production server when importing large amounts of large models. Now, we are using chunking when importing (in combination with redis) so at first I was unsure as to why memory usage kept going up.

I forked Scout and did some tinkering and used the code below to identify and fix the issue we were seeing.

(I was able to identify the issue by logging the memory usage like I did here: https://github.com/dive-be/scout/commit/69ce819bdd964ddd204d0c685f328ec89f906ce3). I could not do the PR via the organisation, so I made a new one here, with the one line that fixes the issue on our end.

Without this change, in our case (on PHP 8.1, if that matters) the models do not appear to be garbage collected after the closure is finished running. 

As a result, the memory usage of this command keeps growing, even though the actual models in `$event->models` inside the closure are only 250 items (which our chunk size). In our use case, the first 250 items would take up about ~100 MB but grow to beyond 4 GB after plenty of chunks.

Once we use the fix which replaces `$event->models` with an empty collection (or use `unset()` on the actual Collection instance which contain the models) the memory usage significantly drops, and memory usage remains below 200 MB, even after reindexing ~15k records.

I also described the issue here: https://twitter.com/nicoverbruggen/status/1625533566925914119

Now, I'm a bit stumped as to what exactly might be causing this. Perhaps the nature of our own implementation of `toSearchableArray()` is causing this, or some cyclical Eloquent relationships?

Regardless, since the event that is being listened to in this context is only used to log how many models were (re-)indexed when running the command, this might be a fix that can help lower memory usage for others as well, without any negative side effects, as far as I can tell. 

I also noticed a significant speedup in record indexing as a result of this modification as well.

Any initial feedback or thoughts are very welcome!