### PR TITLE
[9.x] Add flag to mark query callback as non filtering

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -41,6 +41,13 @@ class Builder
     public $queryCallback;
 
     /**
+     * Allows to manually confirm that the query callback will not filter.
+     *
+     * @var bool
+     */
+    public $queryCallbackIsFiltering = true;
+
+    /**
      * The custom index specified for the search.
      *
      * @var string
@@ -246,9 +253,10 @@ class Builder
      * @param  callable  $callback
      * @return $this
      */
-    public function query($callback)
+    public function query($callback, $isFiltering = true)
     {
         $this->queryCallback = $callback;
+        $this->queryCallbackIsFiltering = $isFiltering;
 
         return $this;
     }
@@ -457,7 +465,7 @@ class Builder
 
         $totalCount = $engine->getTotalCount($results);
 
-        if (is_null($this->queryCallback)) {
+        if (is_null($this->queryCallback) || ! $this->queryCallbackIsFiltering) {
             return $totalCount;
         }
 


### PR DESCRIPTION
This PR adds a `$queryCallbackIsFiltering` flag to mark the `$queryCallback` as non filtering (i.e. no where clauses or limits).

In 99% of my use cases, I use the `$queryCallback` to load additional resources. But when doing this, I'm running into the issue that's described https://github.com/laravel/scout/issues/481#issuecomment-1418261000 . 

There are 2 distinct issues:

A) An extra query to the search engine + an extra query to the DB are made which seems wasteful. And in cases where you want to implement [numbered pagination](https://docs.meilisearch.com/learn/advanced/pagination.html#numbered-page-selectors)  this is quite a big issue.

B) Secondly, when `$limit` is null on `Builder` there usually is a default limit (20 for Meilisearch). So https://github.com/laravel/scout/blob/9.x/src/Builder.php#L470 will still only take 20 results and not the total count. I can expand on this if necessary but I'm hoping issue A) will be enough.

The Scout docs already suggest not actually filtering in the query callback - https://laravel.com/docs/10.x/scout#customizing-the-eloquent-results-query

I've used the default to be `true` to avoid any breaking changes, but personally, I feel like it might make sense to reverse - enforce/assume that the query will not filter because filtering is a less common use case. 
