### PR TITLE
Fix missing function issue

### DIFF
--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -248,7 +248,7 @@ class MeilisearchEngine extends Engine
      */
     public function keys(Builder $builder)
     {
-        $scoutKey = $builder->model->getUnqualifiedScoutKeyName();
+        $scoutKey = $builder->model->getScoutKeyName();
 
         return $this->mapIdsFrom($this->search($builder), $scoutKey);
     }

--- a/tests/Unit/MeilisearchEngineTest.php
+++ b/tests/Unit/MeilisearchEngineTest.php
@@ -242,7 +242,7 @@ class MeilisearchEngineTest extends TestCase
         $builder = m::mock(Builder::class);
 
         $model = m::mock(stdClass::class);
-        $model->shouldReceive(['getUnqualifiedScoutKeyName' => 'custom_key']);
+        $model->shouldReceive(['getScoutKeyName' => 'custom_key']);
         $builder->model = $model;
 
         $engine->shouldReceive('keys')->passthru();


### PR DESCRIPTION
`getUnqualifiedScoutKeyName` doesn't exist anymore. Since `getScoutKeyName` sends back to `\Illuminate\Database\Eloquent\Model::getKeyName` which is unqualified, the fix is straightforward.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
