### PR TITLE
Use `newQuery()` instead of `query()` in `DatabaseEngine`

### DIFF
--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -162,10 +162,10 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
     protected function initializeSearchQuery(Builder $builder, array $columns, array $prefixColumns = [], array $fullTextColumns = [])
     {
         if (blank($builder->query)) {
-            return $builder->model->query();
+            return $builder->model->newQuery();
         }
 
-        return $builder->model->query()->where(function ($query) use ($builder, $columns, $prefixColumns, $fullTextColumns) {
+        return $builder->model->newQuery()->where(function ($query) use ($builder, $columns, $prefixColumns, $fullTextColumns) {
             $connectionType = $builder->model->getConnection()->getDriverName();
 
             $canSearchPrimaryKey = ctype_digit($builder->query) &&


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The issue with `$builder->model->query()` is the fact that it creates a new query from a "new" **static** model; `$builder->model->newQuery()` will create a query from the current object (see [`Illuminate\Database\Eloquent\Model` abstract class](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Eloquent/Model.php#L1469-L1487)).

If you set the schema (or table name) of your model dynamically, `$builder->model->query()` will not work.
See #712 for more details.

Close #712
