### PR TITLE
Added support for complex where clauses in scout builder, as original…

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -161,7 +161,7 @@ class Builder
         // If no operator is passed as a parameter, it will be assumed that the desired operator is '='
         // where('id', 5) <=> where('id', '=', 5)
         $this->wheres[$column] = $operator;
-        
+
         return $this;
     }
 

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -145,6 +145,7 @@ class Builder
             //    ['id', '<', 10]
             // ]);
             $this->complexWheres = $column;
+
             return $this;
         } elseif ($value != null) {
             // This was added in order to support the following syntax used in the Eloquent Builder.
@@ -153,12 +154,14 @@ class Builder
             // where('id', '<', 3)
             // '=', '<', '>', '<=', '>=', '!=', etc.
             $this->complexWheres[] = [$column, $operator, $value];
+
             return $this;
         }
         // The old scout builder syntax is still supported, all changes are fully backward compatible.
         // If no operator is passed as a parameter, it will be assumed that the desired operator is '='
         // where('id', 5) <=> where('id', '=', 5)
         $this->wheres[$column] = $operator;
+        
         return $this;
     }
 

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -125,7 +125,7 @@ class Builder
     /**
      * Add a constraint to the search query.
      *
-     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression $column
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -137,7 +137,7 @@ class Builder
         // to the complexWheres array instead of the wheres array.
         // Any operator supported by the Eloquent Builder is now supported aswell, in addition to passing
         // an array of arrays as a parameter.
-        if(is_array($column)){
+        if (is_array($column)) {
             // This was added in order to support the following syntax used in the Eloquent Builder.
             // An array of arrays can be passed as a parameter :
             // where([
@@ -146,7 +146,7 @@ class Builder
             // ]);
             $this->complexWheres = $column;
             return $this;
-        } else if($value != null){
+        } elseif ($value != null) {
             // This was added in order to support the following syntax used in the Eloquent Builder.
             // Any operator supported by the Eloquent Builder is now supported aswell :
             // where('id', '>', 5)

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -218,6 +218,16 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
                     $query->where($key, '=', $value);
                 }
             }
+        }) // If wheres is empty, and complexWheres isn't, it means the user sent a complex where clause.
+           // complexWheres is an array of arrays, we traverse it and call $query->where on each of its child arrays,
+           // passed as parameters.
+        ->when(! $builder->callback && count($builder->complexWheres) > 0, function ($query) use ($builder) {
+            foreach ($builder->complexWheres as $complexWhere) {
+                $key = $complexWhere[0];
+                $operator = $complexWhere[1];
+                $value = $complexWhere[2];
+                $query->where($key, $operator, $value);
+            }
         })->when(! $builder->callback && count($builder->whereIns) > 0, function ($query) use ($builder) {
             foreach ($builder->whereIns as $key => $values) {
                 $query->whereIn($key, $values);


### PR DESCRIPTION
As can be seen in the scout documentation[1], when using the database driver, scout only supports simple where clauses that work only for basic numeric equality checks.
I edited the addAdditionalConstraints method found in the DatabaseEngine and the where method found in scout/src/Builder.php in order to add the following functionalities :

- An array of arrays can be passed as a parameter : where([['id', '>', 5],['id', '<', 10]]).
- Any operator supported by the Eloquent Builder is now supported as well : '=', '<', '>', '<=', '>=', '!=', etc.
- Clauses containing the operator like so : where('id', '>', 5). 
- All changes are fully backward compatible, If no operator is passed as a parameter, it will be assumed that the desired operator is '=' (where('id', 5) <=> where('id', '=', 5)).

[1]: https://laravel.com/docs/10.x/scout#where-clauses