### PR TITLE
[10.x] Add `getColumn` method to `Builder`

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -3,6 +3,7 @@
 namespace Laravel\Scout;
 
 use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Traits\Macroable;
@@ -291,6 +292,17 @@ class Builder
     public function get()
     {
         return $this->engine()->get($this);
+    }
+
+   /**
+    * Get the results of the search with specific columns.
+    *
+    * @param mixed $column
+    * @return \Illuminate\Database\Eloquent\Collection
+    */
+    public function getColumn(...$column)
+    {
+        return $this->query(fn (EloquentBuilder $builder) => $builder->select($column))->get();
     }
 
     /**

--- a/tests/Feature/DatabaseEngineTest.php
+++ b/tests/Feature/DatabaseEngineTest.php
@@ -95,6 +95,22 @@ class DatabaseEngineTest extends TestCase
         $this->assertCount(0, $models);
     }
 
+    public function test_it_can_retrieve_results_with_specific_columns()
+    {
+        $models = SearchableUserDatabaseModel::search('laravel')->getColumn('name');
+
+        $this->assertCount(2, $models);
+        $this->assertEquals('Abigail Otwell', $models[0]->name);
+        $this->assertNull($models[0]->email);
+        
+
+        $models = SearchableUserDatabaseModel::search('laravel')->getColumn('name', 'email');
+
+        $this->assertCount(2, $models);
+        $this->assertEquals('Taylor Otwell', $models[1]->name);
+        $this->assertEquals('taylor@laravel.com', $models[1]->email);
+    }
+
     public function test_it_can_paginate_results()
     {
         $models = SearchableUserDatabaseModel::search('Taylor')->where('email', 'taylor@laravel.com')->paginate();


### PR DESCRIPTION
In this PR, added `getColumn` method to Builder class. (Database driver)

By default in each search request we recived all columns in our query like this:
```php
Post::search('php')->get();
```

![img1](https://user-images.githubusercontent.com/66994089/227618768-5c83af22-b7be-4c5c-af24-36f7b70101cc.png)

This is not good and for better performance it is better to use the required columns for each search.
The `getColumn` method help us to get all needed columns in query like this:
```php
Post::search('php')->getColumn('title');
```
![img2](https://user-images.githubusercontent.com/66994089/227619856-538f3682-9b4e-4600-884f-357566837166.png)

