### PR TITLE
Meilisearch Count

### DIFF
--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -314,7 +314,7 @@ class MeilisearchEngine extends Engine
      */
     public function getTotalCount($results)
     {
-        return $results['totalHits'];
+        return $results['nbHits'];
     }
 
     /**

--- a/tests/Feature/BuilderTest.php
+++ b/tests/Feature/BuilderTest.php
@@ -116,7 +116,7 @@ class BuilderTest extends TestCase
                 })->toArray(),
                 'hitsPerPage' => $hitsPerPage,
                 'page' => $page,
-                'totalHits' => $query->count(),
+                'nbHits' => $query->count(),
                 'totalPages' => $totalPages > 0 ? $totalPages : 0,
                 'processingTimeMs' => 1,
             ]);

--- a/tests/Unit/MeilisearchEngineTest.php
+++ b/tests/Unit/MeilisearchEngineTest.php
@@ -541,7 +541,7 @@ class MeilisearchEngineTest extends TestCase
     public function test_engine_returns_hits_entry_from_search_response()
     {
         $this->assertTrue(3 === (new MeilisearchEngine(m::mock(Client::class)))->getTotalCount([
-            'totalHits' => 3,
+            'nbHits' => 3,
         ]));
     }
 


### PR DESCRIPTION
<!-- DO NOT THROW THIS AWAY -->
<!-- Fill out the FULL versions with patch versions -->

PR to Issue: [ISSUE](https://github.com/laravel/scout/issues/717)

- Scout Version: 10.0.2
- Scout Driver: Meilisearch
- Laravel Version: 10.4.1
- PHP Version: 8.2.4
- SDK Version (If using a third-party service): 1.0
- Meilisearch CLI Version (If using Meilisearch): 1.0.2

### Description:

Create Builder Macro in Provider, according to documetation:

https://laravel.com/docs/10.x/scout#builder-macros

![Screenshot from 2023-03-25 11-50-49](https://user-images.githubusercontent.com/45684782/227725439-39501af1-a03c-498a-a7ef-c158ea2ead53.png)

This error happens, image here:

![Screenshot from 2023-03-25 12-08-38](https://user-images.githubusercontent.com/45684782/227725602-a1c679d8-f603-41ce-a482-ded239b2b5f1.png)

### Steps To Reproduce:

Install Laravel Scout in project.

Run Meilisearch in v1.0.2.

Create Macro and run in some model, example:

`Integration::search($this->search)->count();`