### PR TITLE
[11.x] Adds support for custom page names using the database engine

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -316,7 +316,7 @@ class Builder
         $engine = $this->engine();
 
         if ($engine instanceof PaginatesEloquentModels) {
-            return $engine->simplePaginate($this, $perPage, $page)->appends('query', $this->query);
+            return $engine->simplePaginate($this, $perPage, $pageName, $page)->appends('query', $this->query);
         }
 
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
@@ -324,7 +324,7 @@ class Builder
         $perPage = $perPage ?: $this->model->getPerPage();
 
         $results = $this->model->newCollection($engine->map(
-            $this, $rawResults = $engine->paginate($this, $perPage, $page), $this->model
+            $this, $rawResults = $engine->paginate($this, $perPage, $pageName, $page), $this->model
         )->all());
 
         $paginator = Container::getInstance()->makeWith(Paginator::class, [
@@ -353,14 +353,14 @@ class Builder
         $engine = $this->engine();
 
         if ($engine instanceof PaginatesEloquentModels) {
-            return $engine->simplePaginate($this, $perPage, $page)->appends('query', $this->query);
+            return $engine->simplePaginate($this, $perPage, $pageName, $page)->appends('query', $this->query);
         }
 
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
         $perPage = $perPage ?: $this->model->getPerPage();
 
-        $results = $engine->paginate($this, $perPage, $page);
+        $results = $engine->paginate($this, $perPage, $pageName, $page);
 
         $paginator = Container::getInstance()->makeWith(Paginator::class, [
             'items' => $results,
@@ -388,7 +388,7 @@ class Builder
         $engine = $this->engine();
 
         if ($engine instanceof PaginatesEloquentModels) {
-            return $engine->paginate($this, $perPage, $page)->appends('query', $this->query);
+            return $engine->paginate($this, $perPage, $pageName, $page)->appends('query', $this->query);
         }
 
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
@@ -396,7 +396,7 @@ class Builder
         $perPage = $perPage ?: $this->model->getPerPage();
 
         $results = $this->model->newCollection($engine->map(
-            $this, $rawResults = $engine->paginate($this, $perPage, $page), $this->model
+            $this, $rawResults = $engine->paginate($this, $perPage, $pageName, $page), $this->model
         )->all());
 
         return Container::getInstance()->makeWith(LengthAwarePaginator::class, [
@@ -424,14 +424,14 @@ class Builder
         $engine = $this->engine();
 
         if ($engine instanceof PaginatesEloquentModels) {
-            return $engine->paginate($this, $perPage, $page)->appends('query', $this->query);
+            return $engine->paginate($this, $perPage, $pageName, $page)->appends('query', $this->query);
         }
 
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
         $perPage = $perPage ?: $this->model->getPerPage();
 
-        $results = $engine->paginate($this, $perPage, $page);
+        $results = $engine->paginate($this, $perPage, $pageName, $page);
 
         return Container::getInstance()->makeWith(LengthAwarePaginator::class, [
             'items' => $results,

--- a/src/Contracts/PaginatesEloquentModels.php
+++ b/src/Contracts/PaginatesEloquentModels.php
@@ -11,18 +11,20 @@ interface PaginatesEloquentModels
      *
      * @param  \Laravel\Scout\Builder  $builder
      * @param  int  $perPage
+     * @param  string  $pageName
      * @param  int  $page
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
-    public function paginate(Builder $builder, $perPage, $page);
+    public function paginate(Builder $builder, $perPage, $pageName, $page);
 
     /**
      * Paginate the given search on the engine using simple pagination.
      *
      * @param  \Laravel\Scout\Builder  $builder
      * @param  int  $perPage
+     * @param  string  $pageName
      * @param  int  $page
      * @return \Illuminate\Contracts\Pagination\Paginator
      */
-    public function simplePaginate(Builder $builder, $perPage, $page);
+    public function simplePaginate(Builder $builder, $perPage, $pageName, $page);
 }

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -230,12 +230,12 @@ class AlgoliaEngine extends Engine
         $objectIdPositions = array_flip($objectIds);
 
         return $model->queryScoutModelsByIds(
-                $builder, $objectIds
-            )->cursor()->filter(function ($model) use ($objectIds) {
-                return in_array($model->getScoutKey(), $objectIds);
-            })->sortBy(function ($model) use ($objectIdPositions) {
-                return $objectIdPositions[$model->getScoutKey()];
-            })->values();
+            $builder, $objectIds
+        )->cursor()->filter(function ($model) use ($objectIds) {
+            return in_array($model->getScoutKey(), $objectIds);
+        })->sortBy(function ($model) use ($objectIdPositions) {
+            return $objectIdPositions[$model->getScoutKey()];
+        })->values();
     }
 
     /**

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -115,10 +115,11 @@ class AlgoliaEngine extends Engine
      *
      * @param  \Laravel\Scout\Builder  $builder
      * @param  int  $perPage
+     * @param  string  $pageName
      * @param  int  $page
      * @return mixed
      */
-    public function paginate(Builder $builder, $perPage, $page)
+    public function paginate(Builder $builder, $perPage, $pageName, $page)
     {
         return $this->performSearch($builder, [
             'numericFilters' => $this->filters($builder),

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -63,10 +63,11 @@ class CollectionEngine extends Engine
      *
      * @param  \Laravel\Scout\Builder  $builder
      * @param  int  $perPage
+     * @param  string  $pageName
      * @param  int  $page
      * @return mixed
      */
-    public function paginate(Builder $builder, $perPage, $page)
+    public function paginate(Builder $builder, $perPage, $pageName, $page)
     {
         $models = $this->searchModels($builder);
 

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -233,12 +233,12 @@ class CollectionEngine extends Engine
         $objectIdPositions = array_flip($objectIds);
 
         return $model->queryScoutModelsByIds(
-                $builder, $objectIds
-            )->cursor()->filter(function ($model) use ($objectIds) {
-                return in_array($model->getScoutKey(), $objectIds);
-            })->sortBy(function ($model) use ($objectIdPositions) {
-                return $objectIdPositions[$model->getScoutKey()];
-            })->values();
+            $builder, $objectIds
+        )->cursor()->filter(function ($model) use ($objectIds) {
+            return in_array($model->getScoutKey(), $objectIds);
+        })->sortBy(function ($model) use ($objectIdPositions) {
+            return $objectIdPositions[$model->getScoutKey()];
+        })->values();
     }
 
     /**

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -66,10 +66,11 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
      *
      * @param  \Laravel\Scout\Builder  $builder
      * @param  int  $perPage
+     * @param  string  $pageName
      * @param  int  $page
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
-    public function paginate(Builder $builder, $perPage, $page)
+    public function paginate(Builder $builder, $perPage, $pageName, $page)
     {
         return $this->buildSearchQuery($builder)
                 ->when($builder->orders, function ($query) use ($builder) {
@@ -80,7 +81,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
                 ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
                     $query->orderBy($builder->model->getKeyName(), 'desc');
                 })
-                ->paginate($perPage, ['*'], 'page', $page);
+                ->paginate($perPage, ['*'], $pageName, $page);
     }
 
     /**
@@ -88,10 +89,11 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
      *
      * @param  \Laravel\Scout\Builder  $builder
      * @param  int  $perPage
+     * @param  string  $pageName
      * @param  int  $page
      * @return \Illuminate\Contracts\Pagination\Paginator
      */
-    public function simplePaginate(Builder $builder, $perPage, $page)
+    public function simplePaginate(Builder $builder, $perPage, $pageName, $page)
     {
         return $this->buildSearchQuery($builder)
                 ->when($builder->orders, function ($query) use ($builder) {
@@ -102,7 +104,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
                 ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
                     $query->orderBy($builder->model->getKeyName(), 'desc');
                 })
-                ->simplePaginate($perPage, ['*'], 'page', $page);
+                ->simplePaginate($perPage, ['*'], $pageName, $page);
     }
 
     /**

--- a/src/Engines/Engine.php
+++ b/src/Engines/Engine.php
@@ -35,10 +35,11 @@ abstract class Engine
      *
      * @param  \Laravel\Scout\Builder  $builder
      * @param  int  $perPage
+     * @param  string  $pageName
      * @param  int  $page
      * @return mixed
      */
-    abstract public function paginate(Builder $builder, $perPage, $page);
+    abstract public function paginate(Builder $builder, $perPage, $pageName, $page);
 
     /**
      * Pluck and return the primary keys of the given results.

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -117,10 +117,11 @@ class MeilisearchEngine extends Engine
      * page/hitsPerPage ensures that the search is exhaustive.
      *
      * @param  int  $perPage
+     * @param  string  $pageName
      * @param  int  $page
      * @return mixed
      */
-    public function paginate(Builder $builder, $perPage, $page)
+    public function paginate(Builder $builder, $perPage, $pageName, $page)
     {
         return $this->performSearch($builder, array_filter([
             'filter' => $this->filters($builder),

--- a/src/Engines/NullEngine.php
+++ b/src/Engines/NullEngine.php
@@ -47,10 +47,11 @@ class NullEngine extends Engine
      *
      * @param  \Laravel\Scout\Builder  $builder
      * @param  int  $perPage
+     * @param  string  $pageName
      * @param  int  $page
      * @return mixed
      */
-    public function paginate(Builder $builder, $perPage, $page)
+    public function paginate(Builder $builder, $perPage, $pageName, $page)
     {
         return [];
     }

--- a/tests/Feature/DatabaseEngineTest.php
+++ b/tests/Feature/DatabaseEngineTest.php
@@ -110,6 +110,18 @@ class DatabaseEngineTest extends TestCase
         $this->assertCount(2, $models);
     }
 
+    public function test_it_can_paginate_results_with_custom_page_name()
+    {
+        $models = SearchableUserDatabaseModel::search('Taylor')->where('email', 'taylor@laravel.com')->paginate();
+        $this->assertStringContainsString('page=1', $models->url(1));
+
+        $models = SearchableUserDatabaseModel::search('Taylor')->where('email', 'taylor@laravel.com')->paginate(pageName: 'foo');
+        $this->assertStringContainsString('foo=1', $models->url(1));
+
+        $models = SearchableUserDatabaseModel::search('Taylor')->where('email', 'taylor@laravel.com')->paginate(pageName: 'bar');
+        $this->assertStringContainsString('bar=1', $models->url(1));
+    }
+
     public function test_limit_is_applied()
     {
         $models = SearchableUserDatabaseModel::search('laravel')->get();

--- a/tests/Unit/MeilisearchEngineTest.php
+++ b/tests/Unit/MeilisearchEngineTest.php
@@ -422,7 +422,7 @@ class MeilisearchEngineTest extends TestCase
 
             return $meilisearch->search($query, $options);
         });
-        $engine->paginate($builder, $perPage, $page);
+        $engine->paginate($builder, $perPage, 'page', $page);
     }
 
     public function test_pagination_sorted_parameter()
@@ -446,7 +446,7 @@ class MeilisearchEngineTest extends TestCase
             return $meilisearch->search($query, $options);
         });
         $builder->orderBy('name', 'asc');
-        $engine->paginate($builder, $perPage, $page);
+        $engine->paginate($builder, $perPage, 'page', $page);
     }
 
     public function test_update_empty_searchable_array_from_soft_deleted_model_does_not_add_documents_to_index()


### PR DESCRIPTION
Hey there!

## Reason

This PR allows for specifying a page name when performing scout pagination using the database engine so that you can have two or more searchable indexes on a single page. 

## Rationale for approach

This only really applies to the `DatabaseEngine`, so adding the property to the `paginate` method might seem overkill, but as far as I can tell, there isn't really another way to add the page name without doing something a funky like having a `withPageName($pageName)` method on the `PaginatesEloquentModels` contract. I also think that this ends up ultimately being the cleanest solution.

If you'd rather me take the other approach btw, just say and I'll change this PR.

## Why not v10?

Obviously, either way, it's a breaking change because whilst it doesn't break any user facing code (the `Builder` remains identical), it does change the signature of `Engine` and `PaginatesEloquentModels`, which will break 3rd party drivers for Scout. As such, I've targeted v11.

Thanks for all the hard work, time and effort you put into everything.

Kind Regards,
Luke