### PR TITLE
[10.x] Adds support for custom page names using the database engine

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -318,7 +318,7 @@ class Builder
 
         if ($engine instanceof PaginatesEloquentModels) {
             return $engine->simplePaginate($this, $perPage, $page)->appends('query', $this->query);
-        } else if ($engine instanceof PaginatesEloquentModelsUsingDatabase) {
+        } elseif ($engine instanceof PaginatesEloquentModelsUsingDatabase) {
             return $engine->simplePaginateDatabase($this, $perPage, $pageName, $page)->appends('query', $this->query);
         }
 
@@ -357,7 +357,7 @@ class Builder
 
         if ($engine instanceof PaginatesEloquentModels) {
             return $engine->simplePaginate($this, $perPage, $page)->appends('query', $this->query);
-        } else if ($engine instanceof PaginatesEloquentModelsUsingDatabase) {
+        } elseif ($engine instanceof PaginatesEloquentModelsUsingDatabase) {
             return $engine->simplePaginateDatabase($this, $perPage, $pageName, $page)->appends('query', $this->query);
         }
 
@@ -394,7 +394,7 @@ class Builder
 
         if ($engine instanceof PaginatesEloquentModels) {
             return $engine->paginate($this, $perPage, $page)->appends('query', $this->query);
-        } else if ($engine instanceof PaginatesEloquentModelsUsingDatabase) {
+        } elseif ($engine instanceof PaginatesEloquentModelsUsingDatabase) {
             return $engine->paginateDatabase($this, $perPage, $pageName, $page)->appends('query', $this->query);
         }
 
@@ -432,7 +432,7 @@ class Builder
 
         if ($engine instanceof PaginatesEloquentModels) {
             return $engine->paginate($this, $perPage, $page)->appends('query', $this->query);
-        } else if ($engine instanceof PaginatesEloquentModelsUsingDatabase) {
+        } elseif ($engine instanceof PaginatesEloquentModelsUsingDatabase) {
             return $engine->paginateDatabase($this, $perPage, $pageName, $page)->appends('query', $this->query);
         }
 

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -358,7 +358,7 @@ class Builder
         if ($engine instanceof PaginatesEloquentModels) {
             return $engine->simplePaginate($this, $perPage, $page)->appends('query', $this->query);
         } else if ($engine instanceof PaginatesEloquentModelsUsingDatabase) {
-            return $engine->paginateDatabase($this, $perPage, $pageName, $page)->appends('query', $this->query);
+            return $engine->simplePaginateDatabase($this, $perPage, $pageName, $page)->appends('query', $this->query);
         }
 
         $page = $page ?: Paginator::resolveCurrentPage($pageName);

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -319,7 +319,7 @@ class Builder
         if ($engine instanceof PaginatesEloquentModels) {
             return $engine->simplePaginate($this, $perPage, $page)->appends('query', $this->query);
         } elseif ($engine instanceof PaginatesEloquentModelsUsingDatabase) {
-            return $engine->simplePaginateDatabase($this, $perPage, $pageName, $page)->appends('query', $this->query);
+            return $engine->simplePaginateUsingDatabase($this, $perPage, $pageName, $page)->appends('query', $this->query);
         }
 
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
@@ -358,7 +358,7 @@ class Builder
         if ($engine instanceof PaginatesEloquentModels) {
             return $engine->simplePaginate($this, $perPage, $page)->appends('query', $this->query);
         } elseif ($engine instanceof PaginatesEloquentModelsUsingDatabase) {
-            return $engine->simplePaginateDatabase($this, $perPage, $pageName, $page)->appends('query', $this->query);
+            return $engine->simplePaginateUsingDatabase($this, $perPage, $pageName, $page)->appends('query', $this->query);
         }
 
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
@@ -395,7 +395,7 @@ class Builder
         if ($engine instanceof PaginatesEloquentModels) {
             return $engine->paginate($this, $perPage, $page)->appends('query', $this->query);
         } elseif ($engine instanceof PaginatesEloquentModelsUsingDatabase) {
-            return $engine->paginateDatabase($this, $perPage, $pageName, $page)->appends('query', $this->query);
+            return $engine->paginateUsingDatabase($this, $perPage, $pageName, $page)->appends('query', $this->query);
         }
 
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
@@ -433,7 +433,7 @@ class Builder
         if ($engine instanceof PaginatesEloquentModels) {
             return $engine->paginate($this, $perPage, $page)->appends('query', $this->query);
         } elseif ($engine instanceof PaginatesEloquentModelsUsingDatabase) {
-            return $engine->paginateDatabase($this, $perPage, $pageName, $page)->appends('query', $this->query);
+            return $engine->paginateUsingDatabase($this, $perPage, $pageName, $page)->appends('query', $this->query);
         }
 
         $page = $page ?: Paginator::resolveCurrentPage($pageName);

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -7,6 +7,7 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Traits\Macroable;
 use Laravel\Scout\Contracts\PaginatesEloquentModels;
+use Laravel\Scout\Contracts\PaginatesEloquentModelsUsingDatabase;
 
 class Builder
 {
@@ -317,6 +318,8 @@ class Builder
 
         if ($engine instanceof PaginatesEloquentModels) {
             return $engine->simplePaginate($this, $perPage, $page)->appends('query', $this->query);
+        } else if ($engine instanceof PaginatesEloquentModelsUsingDatabase) {
+            return $engine->simplePaginateDatabase($this, $perPage, $pageName, $page)->appends('query', $this->query);
         }
 
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
@@ -354,6 +357,8 @@ class Builder
 
         if ($engine instanceof PaginatesEloquentModels) {
             return $engine->simplePaginate($this, $perPage, $page)->appends('query', $this->query);
+        } else if ($engine instanceof PaginatesEloquentModelsUsingDatabase) {
+            return $engine->paginateDatabase($this, $perPage, $pageName, $page)->appends('query', $this->query);
         }
 
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
@@ -389,6 +394,8 @@ class Builder
 
         if ($engine instanceof PaginatesEloquentModels) {
             return $engine->paginate($this, $perPage, $page)->appends('query', $this->query);
+        } else if ($engine instanceof PaginatesEloquentModelsUsingDatabase) {
+            return $engine->paginateDatabase($this, $perPage, $pageName, $page)->appends('query', $this->query);
         }
 
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
@@ -425,6 +432,8 @@ class Builder
 
         if ($engine instanceof PaginatesEloquentModels) {
             return $engine->paginate($this, $perPage, $page)->appends('query', $this->query);
+        } else if ($engine instanceof PaginatesEloquentModelsUsingDatabase) {
+            return $engine->paginateDatabase($this, $perPage, $pageName, $page)->appends('query', $this->query);
         }
 
         $page = $page ?: Paginator::resolveCurrentPage($pageName);

--- a/src/Contracts/PaginatesEloquentModelsUsingDatabase.php
+++ b/src/Contracts/PaginatesEloquentModelsUsingDatabase.php
@@ -15,7 +15,7 @@ interface PaginatesEloquentModelsUsingDatabase
      * @param  int  $page
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
-    public function paginateDatabase(Builder $builder, $perPage, $pageName, $page);
+    public function paginateUsingDatabase(Builder $builder, $perPage, $pageName, $page);
 
     /**
      * Paginate the given search on the engine using simple pagination.
@@ -26,5 +26,5 @@ interface PaginatesEloquentModelsUsingDatabase
      * @param  int  $page
      * @return \Illuminate\Contracts\Pagination\Paginator
      */
-    public function simplePaginateDatabase(Builder $builder, $perPage, $pageName, $page);
+    public function simplePaginateUsingDatabase(Builder $builder, $perPage, $pageName, $page);
 }

--- a/src/Contracts/PaginatesEloquentModelsUsingDatabase.php
+++ b/src/Contracts/PaginatesEloquentModelsUsingDatabase.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Laravel\Scout\Contracts;
+
+use Laravel\Scout\Builder;
+
+interface PaginatesEloquentModelsUsingDatabase
+{
+    /**
+     * Paginate the given search on the engine.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  int  $perPage
+     * @param  string  $pageName
+     * @param  int  $page
+     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
+     */
+    public function paginateDatabase(Builder $builder, $perPage, $pageName, $page);
+
+    /**
+     * Paginate the given search on the engine using simple pagination.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  int  $perPage
+     * @param  string  $pageName
+     * @param  int  $page
+     * @return \Illuminate\Contracts\Pagination\Paginator
+     */
+    public function simplePaginateDatabase(Builder $builder, $perPage, $pageName, $page);
+}

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -71,7 +71,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
      */
     public function paginate(Builder $builder, $perPage, $page)
     {
-        return $this->paginateDatabase($builder, $perPage, 'page', $page);
+        return $this->paginateUsingDatabase($builder, $perPage, 'page', $page);
     }
 
     /**
@@ -83,7 +83,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
      * @param  int  $page
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
-    public function paginateDatabase(Builder $builder, $perPage, $pageName, $page)
+    public function paginateUsingDatabase(Builder $builder, $perPage, $pageName, $page)
     {
         return $this->buildSearchQuery($builder)
             ->when($builder->orders, function ($query) use ($builder) {
@@ -107,7 +107,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
      */
     public function simplePaginate(Builder $builder, $perPage, $page)
     {
-        return $this->simplePaginateDatabase($builder, $perPage, 'page', $page);
+        return $this->simplePaginateUsingDatabase($builder, $perPage, 'page', $page);
     }
 
     /**
@@ -118,7 +118,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
      * @param  int|null  $page
      * @return \Illuminate\Contracts\Pagination\Paginator
      */
-    public function simplePaginateDatabase(Builder $builder, $perPage, $pageName, $page)
+    public function simplePaginateUsingDatabase(Builder $builder, $perPage, $pageName, $page)
     {
         return $this->buildSearchQuery($builder)
             ->when($builder->orders, function ($query) use ($builder) {

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -8,10 +8,10 @@ use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Attributes\SearchUsingFullText;
 use Laravel\Scout\Attributes\SearchUsingPrefix;
 use Laravel\Scout\Builder;
-use Laravel\Scout\Contracts\PaginatesEloquentModels;
+use Laravel\Scout\Contracts\PaginatesEloquentModelsUsingDatabase;
 use ReflectionMethod;
 
-class DatabaseEngine extends Engine implements PaginatesEloquentModels
+class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
 {
     /**
      * Create a new engine instance.
@@ -71,16 +71,30 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
      */
     public function paginate(Builder $builder, $perPage, $page)
     {
+        return $this->paginateDatabase($builder, $perPage, 'page', $page);
+    }
+
+    /**
+     * Paginate the given search on the engine.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  int  $perPage
+     * @param  string  $pageName
+     * @param  int  $page
+     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
+     */
+    public function paginateDatabase(Builder $builder, $perPage, $pageName, $page)
+    {
         return $this->buildSearchQuery($builder)
-                ->when($builder->orders, function ($query) use ($builder) {
-                    foreach ($builder->orders as $order) {
-                        $query->orderBy($order['column'], $order['direction']);
-                    }
-                })
-                ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
-                    $query->orderBy($builder->model->getKeyName(), 'desc');
-                })
-                ->paginate($perPage, ['*'], 'page', $page);
+            ->when($builder->orders, function ($query) use ($builder) {
+                foreach ($builder->orders as $order) {
+                    $query->orderBy($order['column'], $order['direction']);
+                }
+            })
+            ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
+                $query->orderBy($builder->model->getKeyName(), 'desc');
+            })
+            ->paginate($perPage, ['*'], $pageName, $page);
     }
 
     /**
@@ -93,16 +107,29 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModels
      */
     public function simplePaginate(Builder $builder, $perPage, $page)
     {
+        return $this->simplePaginateDatabase($builder, $perPage, 'page', $page);
+    }
+
+    /**
+     * Paginate the given query into a simple paginator.
+     *
+     * @param  int  $perPage
+     * @param  string  $pageName
+     * @param  int|null  $page
+     * @return \Illuminate\Contracts\Pagination\Paginator
+     */
+    public function simplePaginateDatabase(Builder $builder, $perPage, $pageName, $page)
+    {
         return $this->buildSearchQuery($builder)
-                ->when($builder->orders, function ($query) use ($builder) {
-                    foreach ($builder->orders as $order) {
-                        $query->orderBy($order['column'], $order['direction']);
-                    }
-                })
-                ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
-                    $query->orderBy($builder->model->getKeyName(), 'desc');
-                })
-                ->simplePaginate($perPage, ['*'], 'page', $page);
+            ->when($builder->orders, function ($query) use ($builder) {
+                foreach ($builder->orders as $order) {
+                    $query->orderBy($order['column'], $order['direction']);
+                }
+            })
+            ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
+                $query->orderBy($builder->model->getKeyName(), 'desc');
+            })
+            ->simplePaginate($perPage, ['*'], $pageName, $page);
     }
 
     /**

--- a/tests/Feature/DatabaseEngineTest.php
+++ b/tests/Feature/DatabaseEngineTest.php
@@ -110,6 +110,30 @@ class DatabaseEngineTest extends TestCase
         $this->assertCount(2, $models);
     }
 
+    public function test_it_can_paginate_using_a_custom_page_name()
+    {
+        $models = SearchableUserDatabaseModel::search('Taylor')->where('email', 'taylor@laravel.com')->paginate();
+        $this->assertStringContainsString('page=1', $models->url(1));
+
+        $models = SearchableUserDatabaseModel::search('Taylor')->where('email', 'taylor@laravel.com')->paginate(pageName: 'foo');
+        $this->assertStringContainsString('foo=1', $models->url(1));
+
+        $models = SearchableUserDatabaseModel::search('Taylor')->where('email', 'taylor@laravel.com')->paginate(pageName: 'bar');
+        $this->assertStringContainsString('bar=1', $models->url(1));
+    }
+
+    public function test_it_can_simple_paginate_using_a_custom_page_name()
+    {
+        $models = SearchableUserDatabaseModel::search('Taylor')->where('email', 'taylor@laravel.com')->simplePaginate();
+        $this->assertStringContainsString('page=1', $models->url(1));
+
+        $models = SearchableUserDatabaseModel::search('Taylor')->where('email', 'taylor@laravel.com')->simplePaginate(pageName: 'foo');
+        $this->assertStringContainsString('foo=1', $models->url(1));
+
+        $models = SearchableUserDatabaseModel::search('Taylor')->where('email', 'taylor@laravel.com')->simplePaginate(pageName: 'bar');
+        $this->assertStringContainsString('bar=1', $models->url(1));
+    }
+
     public function test_limit_is_applied()
     {
         $models = SearchableUserDatabaseModel::search('laravel')->get();


### PR DESCRIPTION
Hey there!

This is a follow up PR to https://github.com/laravel/scout/pull/726 which uses the suggested approach to introduce this ability in a non-breaking fashion.

It does this by introducing a new contract: `PaginatesEloquentModelsUsingDatabase`, which includes support for specifying a `$pageName` for both the `paginate` and `simplePaginate` methods. Technically, this replaces `PaginatesEloquentModels`, which is no longer used in the codebase at all. However, I have left the logic in place in case a 3rd party driver uses that contract. Perhaps we could remove it in a future version of Scout?

I have left the old `simplePaginate` method on the `DatabaseEngine` so that should anybody be doing something strange like injecting it directly, the signature remains identical. The old method simply defers to the new method, passing manual `$pageName` of 'page', which replicates previous behaviour. 