### PR TITLE
Handle empty whereIn clause

### DIFF
--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -167,6 +167,10 @@ class AlgoliaEngine extends Engine
         })->values();
 
         return $wheres->merge(collect($builder->whereIns)->map(function ($values, $key) {
+            if (empty($values)) {
+                return '0=1';
+            }
+
             return collect($values)->map(function ($value) use ($key) {
                 return $key.'='.$value;
             })->all();

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -173,20 +173,20 @@ class MeilisearchEngine extends Engine
             }
 
             return is_numeric($value)
-                            ? sprintf('%s=%s', $key, $value)
-                            : sprintf('%s="%s"', $key, $value);
+                ? sprintf('%s=%s', $key, $value)
+                : sprintf('%s="%s"', $key, $value);
         });
 
         foreach ($builder->whereIns as $key => $values) {
-            $filters->push(sprintf('(%s)', collect($values)->map(function ($value) use ($key) {
+            $filters->push(sprintf('%s IN [%s]', $key, collect($values)->map(function ($value) {
                 if (is_bool($value)) {
-                    return sprintf('%s=%s', $key, $value ? 'true' : 'false');
+                    return sprintf('%s', $value ? 'true' : 'false');
                 }
 
                 return filter_var($value, FILTER_VALIDATE_INT) !== false
-                                ? sprintf('%s=%s', $key, $value)
-                                : sprintf('%s="%s"', $key, $value);
-            })->values()->implode(' OR ')));
+                    ? sprintf('%s', $value)
+                    : sprintf('"%s"', $value);
+            })->values()->implode(', ')));
         }
 
         return $filters->values()->implode(' AND ');

--- a/tests/Unit/AlgoliaEngineTest.php
+++ b/tests/Unit/AlgoliaEngineTest.php
@@ -136,6 +136,20 @@ class AlgoliaEngineTest extends TestCase
         $engine->search($builder);
     }
 
+    public function test_search_sends_correct_parameters_to_algolia_for_empty_where_in_search()
+    {
+        $client = m::mock(SearchClient::class);
+        $client->shouldReceive('initIndex')->with('table')->andReturn($index = m::mock(stdClass::class));
+        $index->shouldReceive('search')->with('zonda', [
+            'numericFilters' => ['foo=1', '0=1'],
+        ]);
+
+        $engine = new AlgoliaEngine($client);
+        $builder = new Builder(new SearchableModel, 'zonda');
+        $builder->where('foo', 1)->whereIn('bar', []);
+        $engine->search($builder);
+    }
+
     public function test_map_correctly_maps_results_to_models()
     {
         $client = m::mock(SearchClient::class);


### PR DESCRIPTION
The Algolia and Meilisearch engines currently do not handle empty `whereIn` clauses correctly. Algolia seems to ignore it whereas Meilisearch gives an error. This pull request aims to resolve this.

### Algolia

I've copied the fix that was included in algolia/scout-extended where they just send `0=1`.
https://github.com/algolia/scout-extended/pull/265/files

### Meilisearch

I've used the `IN` operator that was introduced in Meilisearch v0.29:
https://github.com/meilisearch/product/discussions/407#discussioncomment-3084053

This automatically handles the empty case and is a more elegant way of doing it instead of the `OR` operator.