### PR TITLE
[10.x] Add 'makeSearchableUsing' method (to allow eager loading when making specific models searchable)

### DIFF
--- a/src/Jobs/MakeSearchable.php
+++ b/src/Jobs/MakeSearchable.php
@@ -39,6 +39,6 @@ class MakeSearchable implements ShouldQueue
             return;
         }
 
-        $this->models->first()->searchableUsing()->update($this->models);
+        $this->models->first()->makeSearchableUsing($this->models)->first()->searchableUsing()->update($this->models);
     }
 }

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -152,7 +152,7 @@ trait Searchable
     }
 
     /**
-     * Modify the models used to make those models searchable.
+     * Modify the collection of models being made searchable.
      *
      * @param  \Illuminate\Support\Collection  models
      * @return \Illuminate\Support\Collection

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -154,8 +154,8 @@ trait Searchable
     /**
      * Modify the collection of models being made searchable.
      *
-     * @param  \Illuminate\Database\Eloquent\Collection  models
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @param  \Illuminate\Support\Collection  $models
+     * @return \Illuminate\Support\Collection
      */
     protected function makeSearchableUsing(BaseCollection $models)
     {

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -154,8 +154,8 @@ trait Searchable
     /**
      * Modify the collection of models being made searchable.
      *
-     * @param  \Illuminate\Support\Collection  models
-     * @return \Illuminate\Support\Collection
+     * @param  \Illuminate\Database\Eloquent\Collection  models
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     protected function makeSearchableUsing(BaseCollection $models)
     {

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -60,7 +60,7 @@ trait Searchable
         }
 
         if (! config('scout.queue')) {
-            return $models->first()->searchableUsing()->update($models);
+            return $models->first()->makeSearchableUsing($models)->first()->searchableUsing()->update($models);
         }
 
         dispatch((new Scout::$makeSearchableJob($models))
@@ -149,6 +149,17 @@ trait Searchable
                 $self->qualifyColumn($self->getScoutKeyName())
             )
             ->searchable($chunk);
+    }
+
+    /**
+     * Modify the models used to make those models searchable.
+     *
+     * @param  \Illuminate\Support\Collection  models
+     * @return \Illuminate\Support\Collection
+     */
+    protected function makeSearchableUsing(BaseCollection $models)
+    {
+        return $models;
     }
 
     /**

--- a/tests/Feature/SearchableTest.php
+++ b/tests/Feature/SearchableTest.php
@@ -20,6 +20,7 @@ class SearchableTest extends TestCase
     {
         $collection = m::mock();
         $collection->shouldReceive('isEmpty')->andReturn(false);
+        $collection->shouldReceive('first->makeSearchableUsing')->with($collection)->andReturn($collection);
         $collection->shouldReceive('first->searchableUsing->update')->with($collection);
 
         $model = new SearchableModel();

--- a/tests/Unit/MakeSearchableTest.php
+++ b/tests/Unit/MakeSearchableTest.php
@@ -20,6 +20,7 @@ class MakeSearchableTest extends TestCase
             $model = m::mock(),
         ]));
 
+        $model->shouldReceive('makeSearchableUsing')->with($collection)->andReturn($collection);
         $model->shouldReceive('searchableUsing->update')->with($collection);
 
         $job->handle();


### PR DESCRIPTION
In the projects at work, we use Laravel's lazy loading prevention. But when installing and using Scout, I noticed that Scout does not use `makeAllSearchableUsing` when making specific models searchable (which I thought at first). This causes lazy loading errors when the `toSearchableArray` method expects certain relations to be loaded (as is the case when importing all models because it then uses the `makeAllSearchableUsing` method).
```php
public function toSearchableArray() : array
{
    return [
        // This causes lazy loading on every model that is made searchable
        'some_relation_attribute' => $this->someRelation->attribute
    ];
}

$someModels->searchable();
$parentModel->someRelation()->searchable();
```

So to fix this, I propose introducing a new method: `makeSearchableUsing`. This method allows you to modify models before the `toSearchableArray` method is called on each of those models 

```php
protected function makeSearchableUsing($models)
{
    // load relations or add extra data that will be used in the "toSearchableArray" method
    return $models->load(...);
}
```