### PR TITLE
re-add options for search requests

### DIFF
--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -141,6 +141,8 @@ class MeilisearchEngine extends Engine
     {
         $meilisearch = $this->meilisearch->index($builder->index ?: $builder->model->searchableAs());
 
+        $searchParams = array_merge($builder->options, $searchParams);
+
         if ($builder->callback) {
             $result = call_user_func(
                 $builder->callback,


### PR DESCRIPTION
n #683 options were added to the search request.
In https://github.com/laravel/scout/commit/ee11fd3520264cceb1e78134ae419e87b9d5e0ad the line was removed.

This PR just re-adds the line.