### PR TITLE
[10.x]  Meilisearch v1 returns estimatedTotalHits or totalHits, but not both

### DIFF
--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -316,6 +316,10 @@ class MeilisearchEngine extends Engine
      */
     public function getTotalCount($results)
     {
+        if (isset($result['estimatedTotalHits'])) {
+            return $result['estimatedTotalHits'];
+        }
+
         return $results['totalHits'];
     }
 

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -316,8 +316,8 @@ class MeilisearchEngine extends Engine
      */
     public function getTotalCount($results)
     {
-        if (isset($result['estimatedTotalHits'])) {
-            return $result['estimatedTotalHits'];
+        if (isset($results['estimatedTotalHits'])) {
+            return $results['estimatedTotalHits'];
         }
 
         return $results['totalHits'];


### PR DESCRIPTION
## Issue
When using pagination we get a `Undefined array key "totalHits"`

The Meilisearch engine provides `estimatedTotalHits` or `totalHits` but not both.

The logic is currently provided upstream in `meilisearch-php`, but is currently providing the old key name `nbHits`, instead of what is now expected as `totalHits`.

https://github.com/meilisearch/meilisearch-php/blob/78cec653dcd1a796596e947f9e02d889ec0a606b/src/Endpoints/Indexes.php#L206

I created a pull request to add this, but it would better to maintain this at the Scout side to provide BC.
https://github.com/meilisearch/meilisearch-php/pull/502