### PR TITLE
[10.x] Fixes `makeSearchableUsing` not being able to be called

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -157,7 +157,7 @@ trait Searchable
      * @param  \Illuminate\Support\Collection  $models
      * @return \Illuminate\Support\Collection
      */
-    protected function makeSearchableUsing(BaseCollection $models)
+    public function makeSearchableUsing(BaseCollection $models)
     {
         return $models;
     }

--- a/tests/Unit/MakeSearchableTest.php
+++ b/tests/Unit/MakeSearchableTest.php
@@ -4,6 +4,7 @@ namespace Laravel\Scout\Tests\Unit;
 
 use Illuminate\Database\Eloquent\Collection;
 use Laravel\Scout\Jobs\MakeSearchable;
+use Laravel\Scout\Tests\Fixtures\SearchableModel;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -17,10 +18,9 @@ class MakeSearchableTest extends TestCase
     public function test_handle_passes_the_collection_to_engine()
     {
         $job = new MakeSearchable($collection = Collection::make([
-            $model = m::mock(),
+            $model = m::mock(new SearchableModel)->makePartial(),
         ]));
 
-        $model->shouldReceive('makeSearchableUsing')->with($collection)->andReturn($collection);
         $model->shouldReceive('searchableUsing->update')->with($collection);
 
         $job->handle();


### PR DESCRIPTION
This pull request fixes `makeSearchableUsing` not being able to be called, and add tests on it.