### PR TITLE
[10.x] Fixes usage with `sqlsrv` databases

### DIFF
--- a/src/SearchableScope.php
+++ b/src/SearchableScope.php
@@ -32,19 +32,23 @@ class SearchableScope implements Scope
     public function extend(EloquentBuilder $builder)
     {
         $builder->macro('searchable', function (EloquentBuilder $builder, $chunk = null) {
+            $model = $builder->getModel();
+
             $builder->chunkById($chunk ?: config('scout.chunk.searchable', 500), function ($models) {
                 $models->filter->shouldBeSearchable()->searchable();
 
                 event(new ModelsImported($models));
-            }, $builder->qualifyColumn($builder->getModel()->getScoutKeyName()), $builder->getModel()->getKeyName());
+            }, $builder->qualifyColumn($model->getScoutKeyName()), $model->getScoutKeyName());
         });
 
         $builder->macro('unsearchable', function (EloquentBuilder $builder, $chunk = null) {
+            $model = $builder->getModel();
+
             $builder->chunkById($chunk ?: config('scout.chunk.unsearchable', 500), function ($models) {
                 $models->unsearchable();
 
                 event(new ModelsFlushed($models));
-            }, $builder->qualifyColumn($builder->getModel()->getScoutKeyName()), $builder->getModel()->getKeyName());
+            }, $builder->qualifyColumn($model->getScoutKeyName()), $model->getScoutKeyName());
         });
 
         HasManyThrough::macro('searchable', function ($chunk = null) {

--- a/src/SearchableScope.php
+++ b/src/SearchableScope.php
@@ -36,7 +36,7 @@ class SearchableScope implements Scope
                 $models->filter->shouldBeSearchable()->searchable();
 
                 event(new ModelsImported($models));
-            });
+            }, $builder->qualifyColumn($builder->getModel()->getScoutKeyName()), $builder->getModel()->getKeyName());
         });
 
         $builder->macro('unsearchable', function (EloquentBuilder $builder, $chunk = null) {
@@ -44,7 +44,7 @@ class SearchableScope implements Scope
                 $models->unsearchable();
 
                 event(new ModelsFlushed($models));
-            });
+            }, $builder->qualifyColumn($builder->getModel()->getScoutKeyName()), $builder->getModel()->getKeyName());
         });
 
         HasManyThrough::macro('searchable', function ($chunk = null) {

--- a/src/SearchableScope.php
+++ b/src/SearchableScope.php
@@ -32,8 +32,7 @@ class SearchableScope implements Scope
     public function extend(EloquentBuilder $builder)
     {
         $builder->macro('searchable', function (EloquentBuilder $builder, $chunk = null) {
-            $model = $builder->getModel();
-            $scoutKeyName = $model->getScoutKeyName();
+            $scoutKeyName = $builder->getModel()->getScoutKeyName();
 
             $builder->chunkById($chunk ?: config('scout.chunk.searchable', 500), function ($models) {
                 $models->filter->shouldBeSearchable()->searchable();
@@ -43,8 +42,7 @@ class SearchableScope implements Scope
         });
 
         $builder->macro('unsearchable', function (EloquentBuilder $builder, $chunk = null) {
-            $model = $builder->getModel();
-            $scoutKeyName = $model->getScoutKeyName();
+            $scoutKeyName = $builder->getModel()->getScoutKeyName();
 
             $builder->chunkById($chunk ?: config('scout.chunk.unsearchable', 500), function ($models) {
                 $models->unsearchable();

--- a/src/SearchableScope.php
+++ b/src/SearchableScope.php
@@ -33,22 +33,24 @@ class SearchableScope implements Scope
     {
         $builder->macro('searchable', function (EloquentBuilder $builder, $chunk = null) {
             $model = $builder->getModel();
+            $scoutKeyName = $model->getScoutKeyName();
 
             $builder->chunkById($chunk ?: config('scout.chunk.searchable', 500), function ($models) {
                 $models->filter->shouldBeSearchable()->searchable();
 
                 event(new ModelsImported($models));
-            }, $builder->qualifyColumn($model->getScoutKeyName()), $model->getScoutKeyName());
+            }, $builder->qualifyColumn($scoutKeyName), $scoutKeyName);
         });
 
         $builder->macro('unsearchable', function (EloquentBuilder $builder, $chunk = null) {
             $model = $builder->getModel();
+            $scoutKeyName = $model->getScoutKeyName();
 
             $builder->chunkById($chunk ?: config('scout.chunk.unsearchable', 500), function ($models) {
                 $models->unsearchable();
 
                 event(new ModelsFlushed($models));
-            }, $builder->qualifyColumn($model->getScoutKeyName()), $model->getScoutKeyName());
+            }, $builder->qualifyColumn($scoutKeyName), $scoutKeyName);
         });
 
         HasManyThrough::macro('searchable', function ($chunk = null) {

--- a/tests/Unit/SearchableScopeTest.php
+++ b/tests/Unit/SearchableScopeTest.php
@@ -18,13 +18,26 @@ class SearchableScopeTest extends TestCase
     {
         $builder = m::mock(Builder::class);
         $builder->shouldReceive('macro')->with('searchable', m::on(function ($callback) use ($builder) {
-            $builder->shouldReceive('chunkById')->with(500, m::type(\Closure::class));
+            $model = m::mock(Model::class);
+            $model->shouldReceive('getScoutKeyName')->once()->andReturn('id');
+
+            $builder->shouldReceive('chunkById')->with(500, m::type(\Closure::class), 'users.id', 'id');
+            $builder->shouldReceive('getModel')->once()->andReturn($model);
+            $builder->shouldReceive('qualifyColumn')->once()->andReturn('users.id');
+
             $callback($builder, 500);
 
             return true;
         }));
+
         $builder->shouldReceive('macro')->with('unsearchable', m::on(function ($callback) use ($builder) {
-            $builder->shouldReceive('chunkById')->with(500, m::type(\Closure::class));
+            $model = m::mock(Model::class);
+            $model->shouldReceive('getScoutKeyName')->once()->andReturn('id');
+
+            $builder->shouldReceive('chunkById')->with(500, m::type(\Closure::class), 'users.id', 'id');
+            $builder->shouldReceive('getModel')->once()->andReturn($model);
+            $builder->shouldReceive('qualifyColumn')->once()->andReturn('users.id');
+
             $callback($builder, 500);
 
             return true;


### PR DESCRIPTION
Scout is currently experiencing compatibility issues with  Microsoft SQL Server databases, as an error is thrown when attempting to import models on Scout. The error message is as follows:

```
  SQLSTATE[HY000]: General error: 20018 A column has been specified more than once in the order by list. Columns in the order by list must be unique. [20018] (severity 15) [select top 500 * from [users] order by [users].[id] asc, [id] asc] (Connection: sqlsrv, SQL: select top 500 * from [users] order by [users].[id] asc, [id] asc)
  ```
  
The regression was introduced in the changes made during the pull request at https://github.com/laravel/scout/pull/509. It happens because two "order by" statements are used with the same column name. While this doesn't pose any problems with other database drivers, it causes issues with Microsoft SQL Server databases, as they do not allow multiple "order by" clauses with the same column name.

Fixes https://github.com/laravel/scout/issues/723.