### PR TITLE
Advanced filters methods

### DIFF
--- a/src/Builders/CollectionBuilder.php
+++ b/src/Builders/CollectionBuilder.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Laravel\Scout\Builders;
+
+use Laravel\Scout\Builders\Traits\WhereExistsTrait;
+use Laravel\Scout\Builders\Traits\WhereNullTrait;
+
+class CollectionBuilder extends \Laravel\Scout\Builder
+{
+    use WhereNullTrait, WhereExistsTrait;
+}

--- a/src/Builders/DatabaseBuilder.php
+++ b/src/Builders/DatabaseBuilder.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Laravel\Scout\Builders;
+
+use Laravel\Scout\Builders\Traits\WhereExistsTrait;
+use Laravel\Scout\Builders\Traits\WhereNullTrait;
+
+class DatabaseBuilder extends \Laravel\Scout\Builder
+{
+    use WhereNullTrait, WhereExistsTrait;
+}

--- a/src/Builders/MeilisearchBuilder.php
+++ b/src/Builders/MeilisearchBuilder.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Laravel\Scout\Builders;
+
+use Laravel\Scout\Builders\Traits\WhereExistsTrait;
+use Laravel\Scout\Builders\Traits\WhereNullTrait;
+
+class MeilisearchBuilder extends \Laravel\Scout\Builder
+{
+    use WhereNullTrait, WhereExistsTrait;
+}

--- a/src/Builders/Traits/WhereExistsTrait.php
+++ b/src/Builders/Traits/WhereExistsTrait.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Laravel\Scout\Builders\Traits;
+
+trait WhereExistsTrait
+{
+    /**
+     * Add an exists clause to the query.
+     *
+     * @param  string  $field
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereExists($field, $boolean = 'AND', $not = false)
+    {
+        $type = "Exists";
+
+        $this->advancedWheres[] = compact('type', 'field', 'boolean', 'not');
+
+        return $this;
+    }
+
+    /**
+     * Add an or exists clause to the query.
+     *
+     * @param  string  $field
+     * @param  bool  $not
+     * @return $this
+     */
+    public function orWhereExists($field, $not = false)
+    {
+        return $this->whereExists($field, 'OR', $not);
+    }
+
+    /**
+     * Add a where not exists clause to the query.
+     *
+     * @param  string  $field
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotExists($field, $boolean = 'AND')
+    {
+        return $this->whereExists($field, $boolean, true);
+    }
+
+    /**
+     * Add a where not exists clause to the query.
+     *
+     * @param  string  $field
+     * @return $this
+     */
+    public function orWhereNotExists($field)
+    {
+        return $this->orWhereExists($field, true);
+    }
+}

--- a/src/Builders/Traits/WhereNullTrait.php
+++ b/src/Builders/Traits/WhereNullTrait.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Laravel\Scout\Builders\Traits;
+
+use Illuminate\Support\Arr;
+
+trait WhereNullTrait
+{
+    /**
+     * Add a "where null" clause to the query.
+     *
+     * @param  string|array  $fields
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereNull($fields, $boolean = 'AND', $not = false)
+    {
+        $type = 'Null';
+
+        foreach (Arr::wrap($fields) as $field) {
+            $this->advancedWheres[] = compact('type', 'field', 'boolean', 'not');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where null" clause to the query.
+     *
+     * @param  string|array  $field
+     * @return $this
+     */
+    public function orWhereNull($field)
+    {
+        return $this->whereNull($field, 'OR');
+    }
+
+    /**
+     * Add a "where not null" clause to the query.
+     *
+     * @param  string|array  $fields
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotNull($fields, $boolean = 'AND')
+    {
+        return $this->whereNull($fields, $boolean, true);
+    }
+
+    /**
+     * Add an "or where not null" clause to the query.
+     *
+     * @param  string  $field
+     * @return $this
+     */
+    public function orWhereNotNull($field)
+    {
+        return $this->whereNotNull($field, 'OR');
+    }
+
+}

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -8,6 +8,7 @@ use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Attributes\SearchUsingFullText;
 use Laravel\Scout\Attributes\SearchUsingPrefix;
 use Laravel\Scout\Builder;
+use Laravel\Scout\Builders\DatabaseBuilder;
 use Laravel\Scout\Contracts\PaginatesEloquentModelsUsingDatabase;
 use ReflectionMethod;
 
@@ -251,7 +252,59 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
             }
         })->when(! is_null($builder->queryCallback), function ($query) use ($builder) {
             call_user_func($builder->queryCallback, $query);
+        })->when(! $builder->callback && count($builder->advancedWheres) > 0, function ($query) use ($builder) {
+            foreach ($builder->advancedWheres as $whereData) {
+                if($whereData['type'] == "Nested" || $whereData['field'] !== '__soft_deleted') {
+                    $this->applyAdvancedWhereRulesToQuery($whereData, $query);
+                }
+            }
         });
+    }
+
+    /**
+     * Apply constrains to the query builder, recursively
+     *
+     * @param array $whereData
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     *
+     * @return void
+     */
+    protected function applyAdvancedWhereRulesToQuery(array $whereData, $query)
+    {
+        switch($whereData['type']) {
+            case "In":
+                $query->whereIn($whereData['field'], $whereData['values'], $whereData['boolean'], $whereData['not']);
+                break;
+
+            case "Null":
+                $query->whereNull($whereData['field'], $whereData['boolean'], $whereData['not']);
+                break;
+
+            case "Between":
+                $query->whereBetween($whereData['field'], $whereData['values'], $whereData['boolean'], $whereData['not']);
+                break;
+
+            case "Exists":
+                $query->whereExists($whereData['field'], $whereData['boolean'], $whereData['not']);
+                break;
+
+            case "Nested":
+                if(count($whereData['builder']->advancedWheres) > 0) {
+                    $subQuery = $whereData['builder']->model->getQuery()->forNestedWhere();
+                    foreach ($whereData['builder']->wheres as $field => $value) {
+                        $subQuery->where($field, '=', $value);
+                    }
+                    foreach ($whereData['builder']->advancedWheres as $subWhereData) {
+                        $this->applyAdvancedWhereRulesToQuery($subWhereData, $subQuery);
+                    }
+                    $query->addNestedWhereQuery($subQuery, $whereData['boolean']);
+                }
+                break;
+
+            case "Basic":
+            default:
+                $query->where($whereData['field'], $whereData['operator'], $whereData['value'], $whereData['boolean'], $whereData['not']);
+        }
     }
 
     /**
@@ -432,5 +485,14 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
     public function deleteIndex($name)
     {
         //
+    }
+
+    /**
+     * Return a custom builder class with added functionality for the engine, or null to use the default
+     * @return string|null
+     */
+    public function getCustomBuilderClass()
+    {
+        return DatabaseBuilder::class;
     }
 }

--- a/src/Engines/Engine.php
+++ b/src/Engines/Engine.php
@@ -149,4 +149,13 @@ abstract class Engine
             $builder, $this->search($builder), $builder->model
         );
     }
+
+    /**
+     * Return a custom builder class with added functionality for the engine, or null to use the default
+     * @return string|null
+     */
+    public function getCustomBuilderClass()
+    {
+        return null;
+    }
 }

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -412,4 +412,14 @@ trait Searchable
     {
         return in_array(SoftDeletes::class, class_uses_recursive(get_called_class()));
     }
+
+    /**
+     * Return a custom builder class with added functionality for the engine, or the custom builder
+     * @return string
+     */
+    protected static function getBuilderClass()
+    {
+        $self = new static;
+        return $self->searchableUsing()->getCustomBuilderClass() ?? Builder::class;
+    }
 }

--- a/tests/Unit/CollectionEngineTest.php
+++ b/tests/Unit/CollectionEngineTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Laravel\Scout\Tests\Unit;
+
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Config;
+use Laravel\Scout\Builder;
+use Laravel\Scout\Builders\CollectionBuilder;
+use Laravel\Scout\Engines\CollectionEngine;
+use Laravel\Scout\Tests\Fixtures\SearchableModel;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class CollectionEngineTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Config::shouldReceive('get')->with('scout.after_commit', m::any())->andReturn(false);
+        Config::shouldReceive('get')->with('scout.soft_delete', m::any())->andReturn(false);
+    }
+
+    protected function tearDown(): void
+    {
+        Container::getInstance()->flush();
+        m::close();
+    }
+
+    public function test_advanced_where_query_are_constructed_correctly()
+    {
+        [$model, $dbQuery] = $this->prepareQueryBuilderMock();
+
+        $dbQuery->shouldReceive('where')->with('field1', '>', 1, 'AND', false)->andReturn($dbQuery);
+        $dbQuery->shouldReceive('where')->with('field2', '<', 2, 'OR', false)->andReturn($dbQuery);
+        $dbQuery->shouldReceive('where')->with('field3', '=', 'test word', 'OR', true)->andReturn($dbQuery);
+        $dbQuery->shouldReceive('where')->with('field4', '=', true, 'AND', true)->andReturn($dbQuery);
+
+
+        $engine = new CollectionEngine();
+        $builder = new CollectionBuilder($model, '');
+        $builder->where('field1', '>', 1)
+            ->orWhere('field2', '<', 2)
+            ->orWhereNot('field3', '=', 'test word')
+            ->whereNot('field4', '=', true);
+
+        $engine->search($builder);
+    }
+
+    public function test_advanced_where_between_query_are_constructed_correctly()
+    {
+        [$model, $dbQuery] = $this->prepareQueryBuilderMock();
+
+        $dbQuery->shouldReceive('whereBetween')->with('field1', [1,2], 'AND', false)->andReturn($dbQuery);
+        $dbQuery->shouldReceive('whereBetween')->with('field2', [3,4], 'OR', false)->andReturn($dbQuery);
+        $dbQuery->shouldReceive('whereBetween')->with('field3', [5,6], 'OR', true)->andReturn($dbQuery);
+        $dbQuery->shouldReceive('whereBetween')->with('field4', [7,8], 'AND', true)->andReturn($dbQuery);
+
+        $engine = new CollectionEngine();
+        $builder = new CollectionBuilder($model, '');
+        $builder->whereBetween('field1', [1,2])
+            ->orWhereBetween('field2', [3,4])
+            ->orWhereNotBetween('field3', [5,6])
+            ->whereNotBetween('field4', [7,8]);
+
+        $engine->search($builder);
+    }
+
+    public function test_advanced_where_in_query_are_constructed_correctly()
+    {
+        [$model, $dbQuery] = $this->prepareQueryBuilderMock();
+
+        $dbQuery->shouldReceive('whereIn')->with('field1', [1,2,3], 'AND', false)->andReturn($dbQuery);
+        $dbQuery->shouldReceive('whereIn')->with('field2', [4,5,6], 'OR', false)->andReturn($dbQuery);
+        $dbQuery->shouldReceive('whereIn')->with('field3', [7,8,9], 'OR', true)->andReturn($dbQuery);
+        $dbQuery->shouldReceive('whereIn')->with('field4', ['string1', 'string2', 'string3'], 'AND', true)->andReturn($dbQuery);
+
+        $engine = new CollectionEngine();
+        $builder = new CollectionBuilder($model, '');
+        $builder->whereInAdvanced('field1', [1,2,3])
+            ->orWhereIn('field2', [4,5,6])
+            ->orWhereNotIn('field3', [7,8,9])
+            ->whereNotIn('field4', ['string1', 'string2', 'string3']);
+
+        $engine->search($builder);
+    }
+
+    public function test_advanced_nested_where_query_are_constructed_correctly()
+    {
+        [$model, $dbQuery] = $this->prepareQueryBuilderMock();
+
+        $dbSubQuery = m::mock( \Illuminate\Database\Query\Builder::class);
+        $dbSubQuery->grammar = m::mock( \Illuminate\Database\Query\Grammars\Grammar::class)->makePartial();
+        $dbQuery->shouldReceive('forNestedWhere')->andReturn($dbSubQuery);
+        $dbQuery->shouldReceive('addNestedWhereQuery');
+        $dbQuery->shouldReceive('where')->with('field1', '=', 1, 'AND', false)->andReturn($dbQuery);
+        $dbSubQuery->shouldReceive('where')->with('subField1', '=', 'string1')->andReturn($dbSubQuery);
+        $dbSubQuery->shouldReceive('where')->with('subField2', '>', 2, 'AND', false)->andReturn($dbSubQuery);
+        $dbSubQuery->shouldReceive('where')->with('subField3', '=', 'string3', 'OR', false)->andReturn($dbSubQuery);
+
+        $engine = new CollectionEngine();
+        $builder = new CollectionBuilder($model, '');
+        $builder->where('field1', '=', 1)
+                ->orWhere(fn(Builder $subBuilder) =>
+                                $subBuilder->where('subField1', 'string1')
+                                            ->where('subField2', '>', 2)
+                                            ->orWhere('subField3', '=', 'string3'));
+        $engine->search($builder);
+    }
+
+    protected function prepareQueryBuilderMock()
+    {
+        $dbQuery = m::mock( \Illuminate\Database\Query\Builder::class);
+        $dbQuery->grammar = m::mock( \Illuminate\Database\Query\Grammars\Grammar::class)->makePartial();
+        $eloquentBuilder = m::mock( \Illuminate\Database\Eloquent\Builder::class)->makePartial();
+        $eloquentBuilder->setQuery($dbQuery);
+        $eloquentBuilder->shouldReceive('get')->andReturn(collect([]));
+        $model = m::mock(SearchableModel::class)->makePartial();
+        $model->shouldReceive('toSearchableArray')->andReturns([]);
+        $model->shouldReceive('qualifyColumn')->with('id')->andReturns("id");
+        $model->shouldReceive('query')->andReturns($eloquentBuilder);
+        $model->shouldReceive('newQuery')->andReturns($eloquentBuilder);
+        $dbQuery->shouldReceive('where')->with( \Mockery::type(\Closure::class))->andReturn($dbQuery);
+        $dbQuery->shouldReceive('take')->with(null)->andReturn($dbQuery);
+        $dbQuery->shouldReceive('orderBy')->with('id', 'desc')->andReturn($dbQuery);
+
+        return [$model, $dbQuery];
+    }
+
+}

--- a/tests/Unit/DatabaseEngineTest.php
+++ b/tests/Unit/DatabaseEngineTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Laravel\Scout\Tests\Unit;
+
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Config;
+use Laravel\Scout\Builder;
+use Laravel\Scout\Builders\DatabaseBuilder;
+use Laravel\Scout\Engines\DatabaseEngine;
+use Laravel\Scout\Tests\Fixtures\SearchableModel;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEngineTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Config::shouldReceive('get')->with('scout.after_commit', m::any())->andReturn(false);
+        Config::shouldReceive('get')->with('scout.soft_delete', m::any())->andReturn(false);
+    }
+
+    protected function tearDown(): void
+    {
+        Container::getInstance()->flush();
+        m::close();
+    }
+
+    public function test_advanced_where_query_are_constructed_correctly()
+    {
+        [$model, $dbQuery] = $this->prepareQueryBuilderMock();
+
+        $dbQuery->shouldReceive('where')->with('field1', '>', 1, 'AND', false)->andReturn($dbQuery);
+        $dbQuery->shouldReceive('where')->with('field2', '<', 2, 'OR', false)->andReturn($dbQuery);
+        $dbQuery->shouldReceive('where')->with('field3', '=', 'test word', 'OR', true)->andReturn($dbQuery);
+        $dbQuery->shouldReceive('where')->with('field4', '=', true, 'AND', true)->andReturn($dbQuery);
+
+
+        $engine = new DatabaseEngine();
+        $builder = new DatabaseBuilder($model, '');
+        $builder->where('field1', '>', 1)
+            ->orWhere('field2', '<', 2)
+            ->orWhereNot('field3', '=', 'test word')
+            ->whereNot('field4', '=', true);
+
+        $engine->search($builder);
+    }
+
+    public function test_advanced_where_between_query_are_constructed_correctly()
+    {
+        [$model, $dbQuery] = $this->prepareQueryBuilderMock();
+
+        $dbQuery->shouldReceive('whereBetween')->with('field1', [1,2], 'AND', false)->andReturn($dbQuery);
+        $dbQuery->shouldReceive('whereBetween')->with('field2', [3,4], 'OR', false)->andReturn($dbQuery);
+        $dbQuery->shouldReceive('whereBetween')->with('field3', [5,6], 'OR', true)->andReturn($dbQuery);
+        $dbQuery->shouldReceive('whereBetween')->with('field4', [7,8], 'AND', true)->andReturn($dbQuery);
+
+        $engine = new DatabaseEngine();
+        $builder = new DatabaseBuilder($model, '');
+        $builder->whereBetween('field1', [1,2])
+            ->orWhereBetween('field2', [3,4])
+            ->orWhereNotBetween('field3', [5,6])
+            ->whereNotBetween('field4', [7,8]);
+
+        $engine->search($builder);
+    }
+
+    public function test_advanced_where_in_query_are_constructed_correctly()
+    {
+        [$model, $dbQuery] = $this->prepareQueryBuilderMock();
+
+        $dbQuery->shouldReceive('whereIn')->with('field1', [1,2,3], 'AND', false)->andReturn($dbQuery);
+        $dbQuery->shouldReceive('whereIn')->with('field2', [4,5,6], 'OR', false)->andReturn($dbQuery);
+        $dbQuery->shouldReceive('whereIn')->with('field3', [7,8,9], 'OR', true)->andReturn($dbQuery);
+        $dbQuery->shouldReceive('whereIn')->with('field4', ['string1', 'string2', 'string3'], 'AND', true)->andReturn($dbQuery);
+
+        $engine = new DatabaseEngine();
+        $builder = new DatabaseBuilder($model, '');
+        $builder->whereInAdvanced('field1', [1,2,3])
+            ->orWhereIn('field2', [4,5,6])
+            ->orWhereNotIn('field3', [7,8,9])
+            ->whereNotIn('field4', ['string1', 'string2', 'string3']);
+
+        $engine->search($builder);
+    }
+
+    public function test_advanced_nested_where_query_are_constructed_correctly()
+    {
+        [$model, $dbQuery] = $this->prepareQueryBuilderMock();
+
+        $dbSubQuery = m::mock( \Illuminate\Database\Query\Builder::class);
+        $dbSubQuery->grammar = m::mock( \Illuminate\Database\Query\Grammars\Grammar::class)->makePartial();
+        $dbQuery->shouldReceive('forNestedWhere')->andReturn($dbSubQuery);
+        $dbQuery->shouldReceive('addNestedWhereQuery');
+        $dbQuery->shouldReceive('where')->with('field1', '=', 1, 'AND', false)->andReturn($dbQuery);
+        $dbSubQuery->shouldReceive('where')->with('subField1', '=', 'string1')->andReturn($dbSubQuery);
+        $dbSubQuery->shouldReceive('where')->with('subField2', '>', 2, 'AND', false)->andReturn($dbSubQuery);
+        $dbSubQuery->shouldReceive('where')->with('subField3', '=', 'string3', 'OR', false)->andReturn($dbSubQuery);
+
+        $engine = new DatabaseEngine();
+        $builder = new DatabaseBuilder($model, '');
+        $builder->where('field1', '=', 1)
+                ->orWhere(fn(Builder $subBuilder) =>
+                                $subBuilder->where('subField1', 'string1')
+                                            ->where('subField2', '>', 2)
+                                            ->orWhere('subField3', '=', 'string3'));
+        $engine->search($builder);
+    }
+
+    protected function prepareQueryBuilderMock()
+    {
+        $dbQuery = m::mock( \Illuminate\Database\Query\Builder::class);
+        $dbQuery->grammar = m::mock( \Illuminate\Database\Query\Grammars\Grammar::class)->makePartial();
+        $eloquentBuilder = m::mock( \Illuminate\Database\Eloquent\Builder::class)->makePartial();
+        $eloquentBuilder->setQuery($dbQuery);
+        $eloquentBuilder->shouldReceive('get')->andReturn(collect([]));
+        $model = m::mock(SearchableModel::class)->makePartial();
+        $model->shouldReceive('toSearchableArray')->andReturns([]);
+        $model->shouldReceive('newQuery')->andReturns($eloquentBuilder);
+        $dbQuery->shouldReceive('where')->with( \Mockery::type(\Closure::class))->andReturn($dbQuery);
+        $dbQuery->shouldReceive('take')->with(null)->andReturn($dbQuery);
+        $dbQuery->shouldReceive('orderBy')->with('id', 'desc')->andReturn($dbQuery);
+
+        return [$model, $dbQuery];
+    }
+
+}


### PR DESCRIPTION
As suggested on issue #744 I'm submitting a pull request to extend the filtering functionality of scout.

I've done the following modification:
- Introduced advancedWheres array in Builder to store advanced where operations with additional data (following the style of the Query/Eloquent Builder in laravel)
- Created specialized where methods in Builder object that are common to all the search engines
- Created specialized Builder for the single search engine that add operations supported by the engine
- Added a getter function that permit to specify a custom Builder for an Engine, that it's used to return the correct Builder
- Modified all the included Engines to implement the logic to convert the advancedWheres rules in query for the specific engine
- Switched Algolia from numericFilters to the more powerful (and suggested from the documentation) filters
- Created unit tests for all the included engines that test the correct execution of the advancedWheres transformation in the Engines

There's only one change that I've left in the code as comment as it would be a breaking change for all the custom extensions:
I've used the advancedWheres array in Builder to not interfere with the basic wheres array structure that have the field name as key and value as value. In future would be optimal to merge all of this changes in the main wheres array and remove the whereIn array.

