### PR TITLE
[10.x] Override attributesToRetrieve config to ensure search result is complete

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -79,7 +79,7 @@ class Builder
     /**
      * Extra options that should be applied to the search.
      *
-     * @var int
+     * @var array
      */
     public $options = [];
 

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -143,6 +143,13 @@ class MeilisearchEngine extends Engine
 
         $searchParams = array_merge($builder->options, $searchParams);
 
+        if (array_key_exists('attributesToRetrieve', $searchParams)) {
+            $searchParams['attributesToRetrieve'] = array_merge(
+                [$builder->model->getScoutKeyName()],
+                $searchParams['attributesToRetrieve'],
+            );
+        }
+
         if ($builder->callback) {
             $result = call_user_func(
                 $builder->callback,

--- a/tests/Unit/MeilisearchEngineTest.php
+++ b/tests/Unit/MeilisearchEngineTest.php
@@ -130,6 +130,25 @@ class MeilisearchEngineTest extends TestCase
         $engine->search($builder);
     }
 
+    public function test_search_includes_at_least_scoutKeyName_in_attributesToRetrieve_on_builder_options()
+    {
+        $client = m::mock(Client::class);
+        $client->shouldReceive('index')->with('table')->andReturn($index = m::mock(Indexes::class));
+        $index->shouldReceive('search')->with('mustang', [
+            'filter' => 'foo=1 AND bar=2',
+            'attributesToRetrieve' => ['id', 'foo'],
+        ]);
+
+        $engine = new MeilisearchEngine($client);
+        $builder = new Builder(new SearchableModel(), 'mustang', function ($meilisearch, $query, $options) {
+            $options['filter'] = 'foo=1 AND bar=2';
+
+            return $meilisearch->search($query, $options);
+        });
+        $builder->options = ['attributesToRetrieve' => ['foo']];
+        $engine->search($builder);
+    }
+
     public function test_submitting_a_callable_search_with_search_method_returns_array()
     {
         $builder = new Builder(


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Closes #750

Fixes occasions with meilisearch where users can set options on the `Builder` class like `attributesToRetrieve` which would restrict the search engine to include the unique identifiers on the search result.

Unfortunately if users [customize their search engine calls](https://laravel.com/docs/10.x/scout#customizing-engine-searches) this issue would still be possible as we have no control over the search result provided by the user.
