### PR TITLE
Add Configurable Scout Key Type

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -64,8 +64,8 @@ trait Searchable
         }
 
         dispatch((new Scout::$makeSearchableJob($models))
-                ->onQueue($models->first()->syncWithSearchUsingQueue())
-                ->onConnection($models->first()->syncWithSearchUsing()));
+            ->onQueue($models->first()->syncWithSearchUsingQueue())
+            ->onConnection($models->first()->syncWithSearchUsing()));
     }
 
     /**
@@ -253,7 +253,7 @@ trait Searchable
             call_user_func($builder->queryCallback, $query);
         }
 
-        $whereIn = in_array($this->getKeyType(), ['int', 'integer']) ?
+        $whereIn = in_array($this->getScoutKeyType(), ['int', 'integer']) ?
             'whereIntegerInRaw' :
             'whereIn';
 
@@ -391,6 +391,16 @@ trait Searchable
     public function getScoutKey()
     {
         return $this->getKey();
+    }
+
+    /**
+     * Get the auto-incrementing key type for querying models.
+     *
+     * @return string
+     */
+    public function getScoutKeyType()
+    {
+        return $this->getKeyType();
     }
 
     /**

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -64,8 +64,8 @@ trait Searchable
         }
 
         dispatch((new Scout::$makeSearchableJob($models))
-            ->onQueue($models->first()->syncWithSearchUsingQueue())
-            ->onConnection($models->first()->syncWithSearchUsing()));
+                ->onQueue($models->first()->syncWithSearchUsingQueue())
+                ->onConnection($models->first()->syncWithSearchUsing()));
     }
 
     /**

--- a/tests/Feature/SearchableTest.php
+++ b/tests/Feature/SearchableTest.php
@@ -102,6 +102,36 @@ class SearchableTest extends TestCase
         $this->assertTrue($model->wasSearchableBeforeDelete());
     }
 
+    public function test_it_queries_searchable_models_by_their_ids_with_integer_key_type()
+    {
+        $model = M::mock(SearchableModel::class)->makePartial();
+        $model->shouldReceive('newQuery')->andReturnSelf();
+        $model->shouldReceive('getScoutKeyType')->andReturn('int');
+        $model->shouldReceive('getScoutKeyName')->andReturn('id');
+        $model->shouldReceive('qualifyColumn')->with('id')->andReturn('qualified_id');
+        $model->shouldReceive('whereIntegerInRaw')->with('qualified_id', [1, 2, 3])->andReturnSelf();
+
+        $scoutBuilder = M::mock(\Laravel\Scout\Builder::class);
+        $scoutBuilder->queryCallback = null;
+
+        $model->queryScoutModelsByIds($scoutBuilder, [1, 2, 3]);
+    }
+
+    public function test_it_queries_searchable_models_by_their_ids_with_string_key_type()
+    {
+        $model = M::mock(SearchableModel::class)->makePartial();
+        $model->shouldReceive('newQuery')->andReturnSelf();
+        $model->shouldReceive('getScoutKeyType')->andReturn('string');
+        $model->shouldReceive('getScoutKeyName')->andReturn('id');
+        $model->shouldReceive('qualifyColumn')->with('id')->andReturn('qualified_id');
+        $model->shouldReceive('whereIn')->with('qualified_id', [1, 2, 3])->andReturnSelf();
+
+        $scoutBuilder = M::mock(\Laravel\Scout\Builder::class);
+        $scoutBuilder->queryCallback = null;
+
+        $model->queryScoutModelsByIds($scoutBuilder, [1, 2, 3]);
+    }
+
     public function test_was_searchable_before_update_works_from_true_to_false()
     {
         $model = new SearchableModelWithSoftDeletes([


### PR DESCRIPTION
Hello,

this PR improves the Scout integration when using custom keys for Searchable Models.

## Problem

This problem was already addressed in the following issue:
https://github.com/laravel/scout/issues/741

In one of our applications, we use incrementing IDs as the primary key for our models. Additionally, we are using the `HasUuids` trait to add a uuid column on top of the incrementing id. We did that because we didn't want to expose our incrementing IDs to the front end (and the search engine) due to security concerns. 

We have done that by modifying the `getScouteKey' method.
```PHP
    public function getScoutKey(): string
    {
        return $this->uuid;
    }
```

So far, so good indexing of these models works. But when we want to use the `Model::search()->get()` method within the query builder, we get a database exception because Scout thinks our primary key is an integer. 

This happens within the `queryScoutModelsByIds` method. The scout package determines the used key type (integer or string) via the Eloquent `getKeyType()` method. This behavior is not correct in this case. When you can define a custom Scout key column, you should also be able to define the column type of this custom key.

### Workaround

Before this PR, The workaround for this problem is to override the `queryScoutModelsByIds()` method within the models so the builder is doing a `whereIn()` instead of a `whereIntegerRaw()` condition.

## Solution

I have added a new `getScoutKeyType(): string` method, which, by default, returns the model key type. This new method allows you to customize the key type Scout uses for querying models.

This should not be a breaking change since it does not change the default behavior of Scout, but it adds a little more flexibility in how custom key types can be used in Scout. There is a minor risk of naming collisions, but since the new method is prefixed with the *scout* word, it should be no problem.

