### PR TITLE
Meilisearch: support filtering with backed enums

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.0",
         "illuminate/bus": "^9.0|^10.0",
         "illuminate/contracts": "^9.0|^10.0",
         "illuminate/database": "^9.0|^10.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "illuminate/bus": "^9.0|^10.0",
         "illuminate/contracts": "^9.0|^10.0",
         "illuminate/database": "^9.0|^10.0",

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Scout\Engines;
 
+use BackedEnum;
 use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Jobs\RemoveableScoutCollection;
@@ -170,6 +171,10 @@ class MeilisearchEngine extends Engine
         $filters = collect($builder->wheres)->map(function ($value, $key) {
             if (is_bool($value)) {
                 return sprintf('%s=%s', $key, $value ? 'true' : 'false');
+            }
+
+            if ($value instanceof BackedEnum) {
+                return sprintf('%s=%s', $key, $value->value);
             }
 
             return is_numeric($value)


### PR DESCRIPTION
Meilisearch supports backed enums when inserting data, by extension I think it would make sense to also support filtering by them.