### PR TITLE
Add "whereNotIn" native support to Meilisearch, Database and Collection engines

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -63,6 +63,13 @@ class Builder
     public $whereIns = [];
 
     /**
+     * The "where not in" constraints added to the query.
+     *
+     * @var array
+     */
+    public $whereNotIns = [];
+
+    /**
      * The "limit" that should be applied to the search.
      *
      * @var int
@@ -140,6 +147,20 @@ class Builder
     public function whereIn($field, array $values)
     {
         $this->whereIns[$field] = $values;
+
+        return $this;
+    }
+
+    /**
+     * Add a "where not in" constraint to the search query.
+     *
+     * @param  string  $field
+     * @param  array  $values
+     * @return $this
+     */
+    public function whereNotIn($field, array $values)
+    {
+        $this->whereNotIns[$field] = $values;
 
         return $this;
     }

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -100,6 +100,11 @@ class CollectionEngine extends Engine
                                 $query->whereIn($key, $values);
                             }
                         })
+                        ->when(! $builder->callback && count($builder->whereNotIns) > 0, function ($query) use ($builder) {
+                            foreach ($builder->whereNotIns as $key => $values) {
+                                $query->whereNotIn($key, $values);
+                            }
+                        })
                         ->when($builder->orders, function ($query) use ($builder) {
                             foreach ($builder->orders as $order) {
                                 $query->orderBy($order['column'], $order['direction']);

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -249,6 +249,10 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
             foreach ($builder->whereIns as $key => $values) {
                 $query->whereIn($key, $values);
             }
+        })->when(! $builder->callback && count($builder->whereNotIns) > 0, function ($query) use ($builder) {
+            foreach ($builder->whereNotIns as $key => $values) {
+                $query->whereNotIn($key, $values);
+            }
         })->when(! is_null($builder->queryCallback), function ($query) use ($builder) {
             call_user_func($builder->queryCallback, $query);
         });

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -186,16 +186,25 @@ class MeilisearchEngine extends Engine
                 : sprintf('%s="%s"', $key, $value);
         });
 
-        foreach ($builder->whereIns as $key => $values) {
-            $filters->push(sprintf('%s IN [%s]', $key, collect($values)->map(function ($value) {
-                if (is_bool($value)) {
-                    return sprintf('%s', $value ? 'true' : 'false');
-                }
+        $whereInOperators = [
+            'whereIns'    => 'IN',
+            'whereNotIns' => 'NOT IN'
+        ];
 
-                return filter_var($value, FILTER_VALIDATE_INT) !== false
-                    ? sprintf('%s', $value)
-                    : sprintf('"%s"', $value);
-            })->values()->implode(', ')));
+        foreach ($whereInOperators as $property => $operator) {
+            if (property_exists($builder, $property)) {
+                foreach ($builder->{$property} as $key => $values) {
+                    $filters->push(sprintf('%s %s [%s]', $key, $operator, collect($values)->map(function ($value) {
+                        if (is_bool($value)) {
+                            return sprintf('%s', $value ? 'true' : 'false');
+                        }
+
+                        return filter_var($value, FILTER_VALIDATE_INT) !== false
+                            ? sprintf('%s', $value)
+                            : sprintf('"%s"', $value);
+                    })->values()->implode(', ')));
+                }
+            }
         }
 
         return $filters->values()->implode(' AND ');

--- a/tests/Unit/MeilisearchEngineTest.php
+++ b/tests/Unit/MeilisearchEngineTest.php
@@ -541,6 +541,25 @@ class MeilisearchEngineTest extends TestCase
         $engine->search($builder);
     }
 
+    public function test_where_not_in_conditions_are_applied()
+    {
+        $builder = new Builder(new SearchableModel(), '');
+        $builder->where('foo', 'bar');
+        $builder->where('bar', 'baz');
+        $builder->whereIn('qux', [1, 2]);
+        $builder->whereIn('quux', [1, 2]);
+        $builder->whereNotIn('eaea', [3]);
+        $client = m::mock(Client::class);
+        $client->shouldReceive('index')->once()->andReturn($index = m::mock(Indexes::class));
+        $index->shouldReceive('rawSearch')->once()->with($builder->query, array_filter([
+            'filter' => 'foo="bar" AND bar="baz" AND qux IN [1, 2] AND quux IN [1, 2] AND eaea NOT IN [3]',
+            'hitsPerPage' => $builder->limit,
+        ]))->andReturn([]);
+
+        $engine = new MeilisearchEngine($client);
+        $engine->search($builder);
+    }
+
     public function test_where_in_conditions_are_applied_without_other_conditions()
     {
         $builder = new Builder(new SearchableModel(), '');
@@ -550,6 +569,23 @@ class MeilisearchEngineTest extends TestCase
         $client->shouldReceive('index')->once()->andReturn($index = m::mock(Indexes::class));
         $index->shouldReceive('rawSearch')->once()->with($builder->query, array_filter([
             'filter' => 'qux IN [1, 2] AND quux IN [1, 2]',
+            'hitsPerPage' => $builder->limit,
+        ]))->andReturn([]);
+
+        $engine = new MeilisearchEngine($client);
+        $engine->search($builder);
+    }
+
+    public function test_where_not_in_conditions_are_applied_without_other_conditions()
+    {
+        $builder = new Builder(new SearchableModel(), '');
+        $builder->whereIn('qux', [1, 2]);
+        $builder->whereIn('quux', [1, 2]);
+        $builder->whereNotIn('eaea', [3]);
+        $client = m::mock(Client::class);
+        $client->shouldReceive('index')->once()->andReturn($index = m::mock(Indexes::class));
+        $index->shouldReceive('rawSearch')->once()->with($builder->query, array_filter([
+            'filter' => 'qux IN [1, 2] AND quux IN [1, 2] AND eaea NOT IN [3]',
             'hitsPerPage' => $builder->limit,
         ]))->andReturn([]);
 


### PR DESCRIPTION
I have introduced the "whereNotIn" support to the Scout query builder to be used with Meilisearch, to continue with elegant and readable code following Laravel's coding standards:

Eliminates the need for previous hackish workarounds, example:

```php
Model::search('foo', function ($engine, $query, $options) { 
  $options['filter'] = 'id NOT IN ['.implode(',', [1,2,3]).']';
  return $meilisearch->search($query, $options);
})->get()
```

Transformed into:

```php
Model::search('foo')->whereNotIn('id',[1,2,3])->get()
```

I apologize for not including Algolia support, since its paid service and I don't have an active account with them to write and run all tests.

Best
Edgar Pimienta


