### PR TITLE
[10.x] Allow configuration of Algolia batch size

### DIFF
--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -58,6 +58,10 @@ class EngineManager extends Manager
             $config->setWriteTimeout($writeTimeout);
         }
 
+        if (is_int($batchSize = config('scout.algolia.batch_size'))) {
+            $config->setBatchSize($batchSize);
+        }
+
         return new AlgoliaEngine(Algolia::createWithConfig($config), config('scout.soft_delete'));
     }
 


### PR DESCRIPTION
This is a minor change to allow us to set the batch size for Algolia mass-update actions.

It optionally allows you to set `batch_size` in the `scout.algolia` config array, which it will pass through to the `SearchConfig` object.
