### PR TITLE
[10.x] Call makeSearchableUsing before searching on CollectionEngine

### DIFF
--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -121,7 +121,7 @@ class CollectionEngine extends Engine
             return $models;
         }
 
-        return $models->filter(function ($model) use ($builder) {
+        return $models->first()->makeSearchableUsing($models)->filter(function ($model) use ($builder) {
             if (! $model->shouldBeSearchable()) {
                 return false;
             }

--- a/tests/Feature/CollectionEngineTest.php
+++ b/tests/Feature/CollectionEngineTest.php
@@ -2,7 +2,9 @@
 
 namespace Laravel\Scout\Tests\Feature;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Laravel\Scout\Tests\Fixtures\SearchableModelWithUnloadedValue;
 use Laravel\Scout\Tests\Fixtures\SearchableUserModel;
 use Laravel\Scout\Tests\Fixtures\SearchableUserModelWithCustomSearchableData;
 use Orchestra\Testbench\Concerns\WithLaravelMigrations;
@@ -138,5 +140,14 @@ class CollectionEngineTest extends TestCase
         $models = SearchableUserModel::search('laravel')->oldest()->paginate(1, 'page', 1);
         $this->assertCount(1, $models);
         $this->assertEquals('Taylor Otwell', $models[0]->name);
+    }
+
+    public function test_it_calls_make_searchable_using_before_searching()
+    {
+        Model::preventAccessingMissingAttributes(true);
+
+        $models = SearchableModelWithUnloadedValue::search('loaded')->get();
+
+        $this->assertCount(2, $models);
     }
 }

--- a/tests/Fixtures/SearchableModelWithUnloadedValue.php
+++ b/tests/Fixtures/SearchableModelWithUnloadedValue.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Laravel\Scout\Tests\Fixtures;
+
+use Illuminate\Foundation\Auth\User as Model;
+use Illuminate\Support\Collection;
+use Laravel\Scout\Searchable;
+
+class SearchableModelWithUnloadedValue extends Model
+{
+    use Searchable;
+
+    protected $table = 'users';
+
+    public function toSearchableArray()
+    {
+        return [
+            'value' => $this->unloadedValue,
+        ];
+    }
+
+    public function makeSearchableUsing(Collection $models)
+    {
+        return $models->each(
+            fn ($model) => $model->unloadedValue = 'loaded',
+        );
+    }
+}


### PR DESCRIPTION
Other engines (asides from the Database engine) call `makeSearchableUsing` as part of importing the data, giving them the chance to eager load relationships and such. The Collection engine never has this opportunity since they are never imported. In the case of `Model`s being strict, `toSearchableArray` being called individually several times in a row can then cause a `LazyLoadingViolationException`.

Instead, the Collection engine should have the opportunity to make the models searchable before doing its search.