### PR TITLE
[10.x] Add filter support with comparison operators for the case of Meilisearch Engine

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -70,6 +70,13 @@ class Builder
     public $whereNotIns = [];
 
     /**
+     * The "between" constraints added to the query.
+     *
+     * @var array
+     */
+    public $whereBetween = [];
+
+    /**
      * The "limit" that should be applied to the search.
      *
      * @var int
@@ -161,6 +168,20 @@ class Builder
     public function whereNotIn($field, array $values)
     {
         $this->whereNotIns[$field] = $values;
+
+        return $this;
+    }
+
+    /**
+     * Add a "between" constraint to the search query.
+     *
+     * @param  string  $field
+     * @param  array  $values
+     * @return $this
+     */
+    public function whereBetween($field, array $values)
+    {
+        $this->whereBetween[$field] = $values;
 
         return $this;
     }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -141,12 +141,19 @@ class Builder
      * Add a constraint to the search query.
      *
      * @param  string  $field
+     * @param  string  $operator
      * @param  mixed  $value
      * @return $this
      */
-    public function where($field, $value)
+    public function where($field, $operator = null, $value = null)
     {
-        $this->wheres[$field] = $value;
+        if (func_num_args() === 2) {
+            $this->wheres[$field] = $operator;
+        } elseif (trim($operator) === '=') {
+            $this->wheres[$field] = $value;
+        } else {
+            $this->whereComparisons[$field] = ['operator' => $operator, 'value' => $value];
+        }
 
         return $this;
     }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -56,6 +56,13 @@ class Builder
     public $wheres = [];
 
     /**
+     * The "where comparison" constraints added to the query.
+     *
+     * @var array
+     */
+    public $whereComparisons = [];
+
+    /**
      * The "where in" constraints added to the query.
      *
      * @var array

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -186,6 +186,12 @@ class MeilisearchEngine extends Engine
                 : sprintf('%s="%s"', $key, $value);
         });
 
+        if (property_exists($builder, 'whereBetween')) {
+            foreach ($builder->whereBetween as $key => $values) {
+                $filters->push(sprintf('%s %s TO %s', $key, $values[0], $values[1]));
+            }
+        }
+
         $whereInOperators = [
             'whereIns'    => 'IN',
             'whereNotIns' => 'NOT IN',


### PR DESCRIPTION
Add filter support with comparison operators for the case of Meilisearch Engine.

Meilisearch (v1.4) currently supports filtering features with comparison operators `(>, <, >=, <=, TO)`. Laravel scout only supports `=` operation with where clause.

However, in this PR
* I have extended the `where clause` capability by adding an extra optional parameter in the second position to mention the comparison operator. I've handled the case when user will only provide two parameters. This will keep the existing functionality as it is.  
* I've also added new `whereBetween` builder property and functions to facilitate where between comparison.
* Lastly I have modified the filter function for the meilisearch engine to support the comparison operations in the Engines/MeilisearchEngine.php file.