### PR TITLE
[10.x] Add search engine meta data to results

### DIFF
--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -210,6 +210,16 @@ class AlgoliaEngine extends Engine
             $builder, $objectIds
         )->filter(function ($model) use ($objectIds) {
             return in_array($model->getScoutKey(), $objectIds);
+        })->map(function ($model) use ($results, $objectIdPositions) {
+            $result = $results['hits'][$objectIdPositions[$model->getScoutKey()]] ?? [];
+
+            foreach ($result as $key => $value) {
+                if (substr($key, 0, 1) === '_') {
+                    $model->withScoutMetadata($key, $value);
+                }
+            }
+
+            return $model;
         })->sortBy(function ($model) use ($objectIdPositions) {
             return $objectIdPositions[$model->getScoutKey()];
         })->values();

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -246,6 +246,16 @@ class AlgoliaEngine extends Engine
             $builder, $objectIds
         )->cursor()->filter(function ($model) use ($objectIds) {
             return in_array($model->getScoutKey(), $objectIds);
+        })->map(function ($model) use ($results, $objectIdPositions) {
+            $result = $results['hits'][$objectIdPositions[$model->getScoutKey()]] ?? [];
+
+            foreach ($result as $key => $value) {
+                if (substr($key, 0, 1) === '_') {
+                    $model->withScoutMetadata($key, $value);
+                }
+            }
+
+            return $model;
         })->sortBy(function ($model) use ($objectIdPositions) {
             return $objectIdPositions[$model->getScoutKey()];
         })->values();

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -291,7 +291,16 @@ class MeilisearchEngine extends Engine
 
         return $model->getScoutModelsByIds(
             $builder, $objectIds
-        )->filter(function ($model) use ($objectIds) {
+        )->map(function ($model) use ($results, $objectIdPositions) {
+            $result = $results['hits'][$objectIdPositions[$model->getScoutKey()]] ?? [];
+            foreach ($result as $key => $value) {
+                if (substr($key, 0, 1) === '_') {
+                    $model->withScoutMetadata($key, $value);
+                }
+            }
+
+            return $model;
+        })->filter(function ($model) use ($objectIds) {
             return in_array($model->getScoutKey(), $objectIds);
         })->sortBy(function ($model) use ($objectIdPositions) {
             return $objectIdPositions[$model->getScoutKey()];

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -293,6 +293,7 @@ class MeilisearchEngine extends Engine
             $builder, $objectIds
         )->map(function ($model) use ($results, $objectIdPositions) {
             $result = $results['hits'][$objectIdPositions[$model->getScoutKey()]] ?? [];
+
             foreach ($result as $key => $value) {
                 if (substr($key, 0, 1) === '_') {
                     $model->withScoutMetadata($key, $value);

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -329,6 +329,16 @@ class MeilisearchEngine extends Engine
             $builder, $objectIds
         )->cursor()->filter(function ($model) use ($objectIds) {
             return in_array($model->getScoutKey(), $objectIds);
+        })->map(function ($model) use ($results, $objectIdPositions) {
+            $result = $results['hits'][$objectIdPositions[$model->getScoutKey()]] ?? [];
+
+            foreach ($result as $key => $value) {
+                if (substr($key, 0, 1) === '_') {
+                    $model->withScoutMetadata($key, $value);
+                }
+            }
+
+            return $model;
         })->sortBy(function ($model) use ($objectIdPositions) {
             return $objectIdPositions[$model->getScoutKey()];
         })->values();

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -291,7 +291,9 @@ class MeilisearchEngine extends Engine
 
         return $model->getScoutModelsByIds(
             $builder, $objectIds
-        )->map(function ($model) use ($results, $objectIdPositions) {
+        )->filter(function ($model) use ($objectIds) {
+            return in_array($model->getScoutKey(), $objectIds);
+        })->map(function ($model) use ($results, $objectIdPositions) {
             $result = $results['hits'][$objectIdPositions[$model->getScoutKey()]] ?? [];
 
             foreach ($result as $key => $value) {
@@ -301,8 +303,6 @@ class MeilisearchEngine extends Engine
             }
 
             return $model;
-        })->filter(function ($model) use ($objectIds) {
-            return in_array($model->getScoutKey(), $objectIds);
         })->sortBy(function ($model) use ($objectIdPositions) {
             return $objectIdPositions[$model->getScoutKey()];
         })->values();

--- a/tests/Fixtures/SearchableModel.php
+++ b/tests/Fixtures/SearchableModel.php
@@ -14,15 +14,10 @@ class SearchableModel extends Model
      *
      * @var array
      */
-    protected $fillable = ['id'];
+    protected $fillable = ['id', 'name'];
 
     public function searchableAs()
     {
         return 'table';
-    }
-
-    public function scoutMetadata()
-    {
-        return [];
     }
 }

--- a/tests/Unit/AlgoliaEngineTest.php
+++ b/tests/Unit/AlgoliaEngineTest.php
@@ -167,7 +167,7 @@ class AlgoliaEngineTest extends TestCase
             'nbHits' => 1,
             'hits' => [
                 ['objectID' => 1, 'id' => 1, '_rankingInfo' => ['nbTypos' => 0]],
-            ]
+            ],
         ], $model);
 
         $this->assertCount(1, $results);
@@ -322,6 +322,6 @@ class AlgoliaCustomKeySearchableModel extends SearchableModel
 {
     public function getScoutKey()
     {
-        return 'my-algolia-key.' . $this->getKey();
+        return 'my-algolia-key.'.$this->getKey();
     }
 }

--- a/tests/Unit/AlgoliaEngineTest.php
+++ b/tests/Unit/AlgoliaEngineTest.php
@@ -156,17 +156,23 @@ class AlgoliaEngineTest extends TestCase
         $engine = new AlgoliaEngine($client);
 
         $model = m::mock(stdClass::class);
+
         $model->shouldReceive('getScoutModelsByIds')->andReturn($models = Collection::make([
-            new SearchableModel(['id' => 1]),
+            new SearchableModel(['id' => 1, 'name' => 'test']),
         ]));
 
         $builder = m::mock(Builder::class);
 
-        $results = $engine->map($builder, ['nbHits' => 1, 'hits' => [
-            ['objectID' => 1, 'id' => 1],
-        ]], $model);
+        $results = $engine->map($builder, [
+            'nbHits' => 1,
+            'hits' => [
+                ['objectID' => 1, 'id' => 1, '_rankingInfo' => ['nbTypos' => 0]],
+            ]
+        ], $model);
 
         $this->assertCount(1, $results);
+        $this->assertEquals(['id' => 1, 'name' => 'test'], $results->first()->toArray());
+        $this->assertEquals(['_rankingInfo' => ['nbTypos' => 0]], $results->first()->scoutMetaData());
     }
 
     public function test_map_method_respects_order()
@@ -314,6 +320,6 @@ class AlgoliaCustomKeySearchableModel extends SearchableModel
 {
     public function getScoutKey()
     {
-        return 'my-algolia-key.'.$this->getKey();
+        return 'my-algolia-key.' . $this->getKey();
     }
 }

--- a/tests/Unit/AlgoliaEngineTest.php
+++ b/tests/Unit/AlgoliaEngineTest.php
@@ -216,16 +216,18 @@ class AlgoliaEngineTest extends TestCase
 
         $model = m::mock(stdClass::class);
         $model->shouldReceive('queryScoutModelsByIds->cursor')->andReturn($models = LazyCollection::make([
-            new SearchableModel(['id' => 1]),
+            new SearchableModel(['id' => 1, 'name' => 'test']),
         ]));
 
         $builder = m::mock(Builder::class);
 
         $results = $engine->lazyMap($builder, ['nbHits' => 1, 'hits' => [
-            ['objectID' => 1, 'id' => 1],
+            ['objectID' => 1, 'id' => 1, '_rankingInfo' => ['nbTypos' => 0]],
         ]], $model);
 
         $this->assertCount(1, $results);
+        $this->assertEquals(['id' => 1, 'name' => 'test'], $results->first()->toArray());
+        $this->assertEquals(['_rankingInfo' => ['nbTypos' => 0]], $results->first()->scoutMetaData());
     }
 
     public function test_lazy_map_method_respects_order()

--- a/tests/Unit/MeilisearchEngineTest.php
+++ b/tests/Unit/MeilisearchEngineTest.php
@@ -286,17 +286,22 @@ class MeilisearchEngineTest extends TestCase
 
         $model = m::mock(stdClass::class);
         $model->shouldReceive(['getScoutKeyName' => 'id']);
-        $model->shouldReceive('getScoutModelsByIds')->andReturn($models = Collection::make([new SearchableModel(['id' => 1])]));
+        $model->shouldReceive('getScoutModelsByIds')->andReturn($models = Collection::make([
+            new SearchableModel(['id' => 1, 'name' => 'test']),
+        ]));
+
         $builder = m::mock(Builder::class);
 
         $results = $engine->map($builder, [
             'totalHits' => 1,
             'hits' => [
-                ['id' => 1],
-            ],
+                ['id' => 1, '_rankingScore' => 0.86],
+            ]
         ], $model);
 
-        $this->assertEquals(1, count($results));
+        $this->assertCount(1, $results);
+        $this->assertEquals(['id' => 1, 'name' => 'test'], $results->first()->toArray());
+        $this->assertEquals(['_rankingScore' => 0.86], $results->first()->scoutMetadata());
     }
 
     public function test_map_method_respects_order()
@@ -633,7 +638,7 @@ class MeilisearchCustomKeySearchableModel extends SearchableModel
 {
     public function getScoutKey()
     {
-        return 'my-meilisearch-key.'.$this->getKey();
+        return 'my-meilisearch-key.' . $this->getKey();
     }
 
     public function getScoutKeyName()

--- a/tests/Unit/MeilisearchEngineTest.php
+++ b/tests/Unit/MeilisearchEngineTest.php
@@ -296,7 +296,7 @@ class MeilisearchEngineTest extends TestCase
             'totalHits' => 1,
             'hits' => [
                 ['id' => 1, '_rankingScore' => 0.86],
-            ]
+            ],
         ], $model);
 
         $this->assertCount(1, $results);
@@ -642,7 +642,7 @@ class MeilisearchCustomKeySearchableModel extends SearchableModel
 {
     public function getScoutKey()
     {
-        return 'my-meilisearch-key.' . $this->getKey();
+        return 'my-meilisearch-key.'.$this->getKey();
     }
 
     public function getScoutKeyName()

--- a/tests/Unit/MeilisearchEngineTest.php
+++ b/tests/Unit/MeilisearchEngineTest.php
@@ -346,17 +346,21 @@ class MeilisearchEngineTest extends TestCase
 
         $model = m::mock(stdClass::class);
         $model->shouldReceive(['getScoutKeyName' => 'id']);
-        $model->shouldReceive('queryScoutModelsByIds->cursor')->andReturn($models = LazyCollection::make([new SearchableModel(['id' => 1])]));
+        $model->shouldReceive('queryScoutModelsByIds->cursor')->andReturn($models = LazyCollection::make([
+            new SearchableModel(['id' => 1, 'name' => 'test']),
+        ]));
         $builder = m::mock(Builder::class);
 
         $results = $engine->lazyMap($builder, [
             'totalHits' => 1,
             'hits' => [
-                ['id' => 1],
+                ['id' => 1, '_rankingScore' => 0.86],
             ],
         ], $model);
 
         $this->assertEquals(1, count($results));
+        $this->assertEquals(['id' => 1, 'name' => 'test'], $results->first()->toArray());
+        $this->assertEquals(['_rankingScore' => 0.86], $results->first()->scoutMetadata());
     }
 
     public function test_lazy_map_method_respects_order()


### PR DESCRIPTION
When adding extra options to search queries, xtra data may be return in the raw result - this PR adds the relevant details to the resulting Models via the `withScoutMetadata()` method.

Example:

```php

$products = Product::search(
    $request->term,
    fn ($e, $q, $o) => $e->search($q, array_merge($o, [
        'attributesToHighlight' => ['title'],
        'showRankingScore' => true,
    ]))
)->paginate(48);

dd($products->first()->scoutMetadata());

// output
array:2 [
  "_formatted" => array:31 [
    "title" => "<em>HP</em> <em>Elitebook</em> 1040 G10 14 Inch i5-1335U 4.6GHz 16GB RAM 256GB SSD Laptop with Windows 10/11 Pro"
    ...
  ]
  "_rankingScore" => 0.86111111111111
]
```