### PR TITLE
Added Typesense to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Laravel Scout provides a simple, driver-based solution for adding full-text sear
 
 - [Algolia](https://www.algolia.com/)
 - [Meilisearch](https://github.com/meilisearch/meilisearch)
+- [Typesense](https://github.com/typesense/typesense)
 
 ## Official Documentation
 


### PR DESCRIPTION
Just noticed that there is a section in the README that lists the engines that are supported. 

With #773 now merged, this PR adds mention of Typesense to the README. 