### PR TITLE
[10.x] Fix Typesense search parameters issue 

### DIFF
--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -34,7 +34,7 @@ class TypesenseEngine extends Engine
     /**
      * Create new Typesense engine instance.
      *
-     * @param  \Typesense  $typesense
+     * @param  Typesense  $typesense
      */
     public function __construct(Typesense $typesense)
     {
@@ -261,8 +261,8 @@ class TypesenseEngine extends Engine
             'highlight_affix_num_tokens' => 4,
         ];
 
-        if (! empty($this->searchParameters)) {
-            $parameters = array_merge($parameters, $this->searchParameters);
+        if (! empty($builder->options)) {
+            $parameters = array_merge($parameters, $builder->options);
         }
 
         if (! empty($builder->orders)) {
@@ -520,30 +520,6 @@ class TypesenseEngine extends Engine
     protected function usesSoftDelete($model): bool
     {
         return in_array(SoftDeletes::class, class_uses_recursive($model), true);
-    }
-
-    /**
-     * Set the search options provided by user.
-     *
-     * @param  array  $options
-     * @return $this
-     */
-    public function withSearchParameters(array $options): static
-    {
-        return $this->setSearchParameters($options);
-    }
-
-    /**
-     * Set the search options provided by user.
-     *
-     * @param  array  $options
-     * @return $this
-     */
-    public function setSearchParameters(array $options): static
-    {
-        $this->searchParameters = $options;
-
-        return $this;
     }
 
     /**

--- a/tests/Unit/TypesenseEngineTest.php
+++ b/tests/Unit/TypesenseEngineTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Scout\Tests\Unit;
 
+use Http\Client\Exception;
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
@@ -13,6 +14,7 @@ use PHPUnit\Framework\TestCase;
 use Typesense\Client as TypesenseClient;
 use Typesense\Collection as TypesenseCollection;
 use Typesense\Documents;
+use Typesense\Exceptions\TypesenseClientError;
 
 class TypesenseEngineTest extends TestCase
 {
@@ -234,6 +236,10 @@ class TypesenseEngineTest extends TestCase
         $this->engine->createIndex('test_index');
     }
 
+    /**
+     * @throws Exception
+     * @throws TypesenseClientError
+     */
     public function test_set_search_params_method(): void
     {
         // Mock the Builder
@@ -260,8 +266,10 @@ class TypesenseEngineTest extends TestCase
                 'highlight_affix_num_tokens' => 4,
             ]);
 
+        // Set search options
+        $builder->options(['query_by' => 'id']);
         // Call the search method
-        $this->engine->setSearchParameters(['query_by' => 'id'])->search($builder);
+        $this->engine->search($builder);
     }
 
     public function test_soft_deleted_objects_are_returned_with_only_trashed_method()


### PR DESCRIPTION
Fixed the problem with "withSearchParameters" method, removed that method, and used Scout/Builder $options to allow users to add additional options to the query.