### PR TITLE
[10.x] Ordering by model's custom `created_at` column

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -225,8 +225,12 @@ class Builder
      * @param  string  $column
      * @return $this
      */
-    public function latest($column = 'created_at')
+    public function latest($column = null)
     {
+        if (is_null($column)) {
+            $column = $this->model->getCreatedAtColumn() ?? 'created_at';
+        }
+
         return $this->orderBy($column, 'desc');
     }
 
@@ -236,8 +240,12 @@ class Builder
      * @param  string  $column
      * @return $this
      */
-    public function oldest($column = 'created_at')
+    public function oldest($column = null)
     {
+        if (is_null($column)) {
+            $column = $this->model->getCreatedAtColumn() ?? 'created_at';
+        }
+
         return $this->orderBy($column, 'asc');
     }
 

--- a/tests/Feature/CollectionEngineTest.php
+++ b/tests/Feature/CollectionEngineTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Laravel\Scout\Tests\Fixtures\SearchableModelWithUnloadedValue;
 use Laravel\Scout\Tests\Fixtures\SearchableUserModel;
+use Laravel\Scout\Tests\Fixtures\SearchableUserModelWithCustomCreatedAt;
 use Laravel\Scout\Tests\Fixtures\SearchableUserModelWithCustomSearchableData;
 use Orchestra\Testbench\Concerns\WithLaravelMigrations;
 use Orchestra\Testbench\Concerns\WithWorkbench;
@@ -131,15 +132,12 @@ class CollectionEngineTest extends TestCase
         $this->assertEquals('Taylor Otwell', $models[0]->name);
     }
 
-    public function test_it_can_order_by_latest_and_oldest()
+    public function test_it_can_order_by_custom_model_created_at_timestamp()
     {
-        $models = SearchableUserModel::search('laravel')->latest()->paginate(1, 'page', 1);
-        $this->assertCount(1, $models);
-        $this->assertEquals('Abigail Otwell', $models[0]->name);
+        $query = SearchableUserModelWithCustomCreatedAt::search()->latest();
 
-        $models = SearchableUserModel::search('laravel')->oldest()->paginate(1, 'page', 1);
-        $this->assertCount(1, $models);
-        $this->assertEquals('Taylor Otwell', $models[0]->name);
+        $this->assertCount(1, $query->orders);
+        $this->assertEquals('created', $query->orders[0]['column']);
     }
 
     public function test_it_calls_make_searchable_using_before_searching()

--- a/tests/Feature/CollectionEngineTest.php
+++ b/tests/Feature/CollectionEngineTest.php
@@ -132,6 +132,17 @@ class CollectionEngineTest extends TestCase
         $this->assertEquals('Taylor Otwell', $models[0]->name);
     }
 
+    public function test_it_can_order_by_latest_and_oldest()
+    {
+        $models = SearchableUserModel::search('laravel')->latest()->paginate(1, 'page', 1);
+        $this->assertCount(1, $models);
+        $this->assertEquals('Abigail Otwell', $models[0]->name);
+
+        $models = SearchableUserModel::search('laravel')->oldest()->paginate(1, 'page', 1);
+        $this->assertCount(1, $models);
+        $this->assertEquals('Taylor Otwell', $models[0]->name);
+    }
+
     public function test_it_can_order_by_custom_model_created_at_timestamp()
     {
         $query = SearchableUserModelWithCustomCreatedAt::search()->latest();

--- a/tests/Fixtures/SearchableUserModelWithCustomCreatedAt.php
+++ b/tests/Fixtures/SearchableUserModelWithCustomCreatedAt.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Laravel\Scout\Tests\Fixtures;
+
+use Illuminate\Foundation\Auth\User as Model;
+use Laravel\Scout\Searchable;
+
+class SearchableUserModelWithCustomCreatedAt extends Model
+{
+    use Searchable;
+
+    protected $table = 'users';
+
+    public const CREATED_AT = 'created';
+}


### PR DESCRIPTION
This PR brings Scout into 100% parity with Eloquent's `latest` and `oldest` methods, which retrieve the model's created at timestamp by default, and fall back to `created_at` when null:

https://github.com/laravel/framework/blob/784d076340d58fd584b1602955e9474a4834a8ca/src/Illuminate/Database/Eloquent/Builder.php#L372-L381

https://github.com/laravel/framework/blob/784d076340d58fd584b1602955e9474a4834a8ca/src/Illuminate/Database/Eloquent/Builder.php#L389-L398