### PR TITLE
[10.x] Fix zero integer value in options parameter for Typesense

### DIFF
--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -190,7 +190,7 @@ class TypesenseEngine extends Engine
     {
         return $this->performSearch(
             $builder,
-            array_filter($this->buildSearchParameters($builder, 1, $builder->limit))
+            $this->buildSearchParameters($builder, 1, $builder->limit)
         );
     }
 
@@ -209,7 +209,7 @@ class TypesenseEngine extends Engine
     {
         return $this->performSearch(
             $builder,
-            array_filter($this->buildSearchParameters($builder, $page, $perPage))
+            $this->buildSearchParameters($builder, $page, $perPage)
         );
     }
 


### PR DESCRIPTION
Typesense accepts a zero integer value in a few search option parameters, such as `'drop_tokens_threshold': 0`.

However, when setting it inside `options()` due to the `array_filter()` function, it gets filtered out in the final search query.

```php
Occupation::search($q)->options([
          'limit' => 5,
          'drop_tokens_threshold' => 0,
])->get()
```