### PR TITLE
[10.x] Implement scopeSearch

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -128,8 +128,7 @@ trait Searchable
 
     /**
      * Perform a search against the model's indexed data. This method is an alias of the search method.
-     * Using a scoped search method allows you to use the search method in a query scope.
-     * This will not work after queries such as groupBy, having, or other aggregate functions.
+     * Uses locally scoped search function to enable flexible queries.
      *
      * @param  \EloquentBuilder  $eloquentQuery
      * @param  string  $query

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -22,11 +22,11 @@ trait Searchable
      */
     public static function bootSearchable()
     {
-        static::addGlobalScope(new SearchableScope());
+        static::addGlobalScope(new SearchableScope);
 
-        static::observe(new ModelObserver());
+        static::observe(new ModelObserver);
 
-        (new static())->registerSearchableMacros();
+        (new static)->registerSearchableMacros();
     }
 
     /**

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -119,7 +119,7 @@ trait Searchable
     public static function search($query = '', $callback = null)
     {
         return app(Builder::class, [
-            'model' => new static(),
+            'model' => new static,
             'query' => $query,
             'callback' => $callback,
             'softDelete' => static::usesSoftDelete() && config('scout.soft_delete', false),
@@ -155,7 +155,7 @@ trait Searchable
      */
     public static function makeAllSearchable($chunk = null)
     {
-        $self = new static();
+        $self = new static;
 
         $softDelete = static::usesSoftDelete() && config('scout.soft_delete', false);
 
@@ -211,7 +211,7 @@ trait Searchable
      */
     public static function removeAllFromSearch()
     {
-        $self = new static();
+        $self = new static;
 
         $self->searchableUsing()->flush($self);
     }

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -278,7 +278,8 @@ trait Searchable
             'whereIntegerInRaw' :
             'whereIn';
 
-        return $query->{$whereIn}($this->qualifyColumn($this->getScoutKeyName()), $ids);
+        return $query->{$whereIn}(
+            $this->qualifyColumn($this->getScoutKeyName()), $ids);
     }
 
     /**

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -59,7 +59,7 @@ trait Searchable
             return;
         }
 
-        if (!config('scout.queue')) {
+        if (! config('scout.queue')) {
             return $models->first()->makeSearchableUsing($models)->first()->searchableUsing()->update($models);
         }
 
@@ -80,7 +80,7 @@ trait Searchable
             return;
         }
 
-        if (!config('scout.queue')) {
+        if (! config('scout.queue')) {
             return $models->first()->searchableUsing()->delete($models);
         }
 
@@ -131,7 +131,7 @@ trait Searchable
      * Using a scoped search method allows you to use the search method in a query scope.
      * This will not work after queries such as groupBy, having, or other aggregate functions.
      *
-     * @param  \EloquentBuilder $eloquentQuery
+     * @param  \EloquentBuilder  $eloquentQuery
      * @param  string  $query
      * @param  \Closure  $callback
      * @return \Laravel\Scout\Builder

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -140,7 +140,11 @@ trait Searchable
     {
         // Given some eloquent query (that we know has not been executed), we can run our search first,
         // and then merge the constraints from the eloquent query into the search query.
-        return static::search($query, $callback)->query(fn (EloquentBuilder $builder) => $builder->mergeConstraintsFrom($eloquentQuery));
+        return static::search($query, $callback)->query(
+            function (EloquentBuilder $builder) use ($eloquentQuery) {
+                return $builder->setQuery($eloquentQuery->getQuery());
+            }
+        );
     }
 
     /**

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -278,10 +278,7 @@ trait Searchable
             'whereIntegerInRaw' :
             'whereIn';
 
-        return $query->{$whereIn}(
-            $this->qualifyColumn($this->getScoutKeyName()),
-            $ids
-        );
+        return $query->{$whereIn}($this->qualifyColumn($this->getScoutKeyName()), $ids);
     }
 
     /**

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -279,7 +279,8 @@ trait Searchable
             'whereIn';
 
         return $query->{$whereIn}(
-            $this->qualifyColumn($this->getScoutKeyName()), $ids);
+            $this->qualifyColumn($this->getScoutKeyName()), $ids
+        );
     }
 
     /**

--- a/tests/Feature/BuilderTest.php
+++ b/tests/Feature/BuilderTest.php
@@ -62,19 +62,6 @@ class BuilderTest extends TestCase
         $this->assertSame(15, $paginator->perPage());
     }
 
-    public function test_it_can_paginate_scoped_with_custom_query_callback()
-    {
-        $this->prepareScoutSearchMockUsing('Laravel');
-
-        $paginator = SearchableUserModel::where(function ($builder) {
-            return $builder->where('id', '<', 11);
-        })->search('Laravel')->paginate();
-
-        $this->assertSame(10, $paginator->total());
-        $this->assertSame(1, $paginator->lastPage());
-        $this->assertSame(15, $paginator->perPage());
-    }
-
     public function test_it_can_paginate_raw_without_custom_query_callback()
     {
         $this->prepareScoutSearchMockUsing('Laravel');
@@ -99,7 +86,20 @@ class BuilderTest extends TestCase
         $this->assertSame(15, $paginator->perPage());
     }
 
-    public function test_it_can_paginate_raw_scoped_with_custom_query_callback()
+    public function test_it_can_paginate_on_locally_scoped_search_after_query()
+    {
+        $this->prepareScoutSearchMockUsing('Laravel');
+
+        $paginator = SearchableUserModel::where(function ($builder) {
+            return $builder->where('id', '<', 11);
+        })->search('Laravel')->paginate();
+
+        $this->assertSame(10, $paginator->total());
+        $this->assertSame(1, $paginator->lastPage());
+        $this->assertSame(15, $paginator->perPage());
+    }
+
+    public function test_it_can_paginate_raw_on_locally_scoped_search_after_query()
     {
         $this->prepareScoutSearchMockUsing('Laravel');
 
@@ -109,6 +109,30 @@ class BuilderTest extends TestCase
 
         $this->assertSame(10, $paginator->total());
         $this->assertSame(1, $paginator->lastPage());
+        $this->assertSame(15, $paginator->perPage());
+    }
+
+    public function test_it_can_paginate_on_locally_scoped_search_after_order_by()
+    {
+        $this->prepareScoutSearchMockUsing('Laravel');
+
+        $paginator = SearchableUserModel::orderBy('id', 'DESC')->search('Laravel')->paginate();
+
+        // We get 50 as that is how many 'Laravel' records we have
+        $this->assertSame(50, $paginator->total());
+        $this->assertSame(4, $paginator->lastPage());
+        $this->assertSame(15, $paginator->perPage());
+    }
+
+    public function test_it_can_paginate_raw_on_locally_scoped_search_after_order_by()
+    {
+        $this->prepareScoutSearchMockUsing('Laravel');
+
+        $paginator = SearchableUserModel::orderBy('id', 'DESC')->search('Laravel')->paginateRaw();
+
+        // We get 50 as that is how many 'Laravel' records we have
+        $this->assertSame(50, $paginator->total());
+        $this->assertSame(4, $paginator->lastPage());
         $this->assertSame(15, $paginator->perPage());
     }
 

--- a/tests/Feature/BuilderTest.php
+++ b/tests/Feature/BuilderTest.php
@@ -17,7 +17,10 @@ use Orchestra\Testbench\TestCase;
 
 class BuilderTest extends TestCase
 {
-    use LazilyRefreshDatabase, WithFaker, WithLaravelMigrations, WithWorkbench;
+    use LazilyRefreshDatabase;
+    use WithFaker;
+    use WithLaravelMigrations;
+    use WithWorkbench;
 
     protected function defineEnvironment($app)
     {
@@ -59,6 +62,19 @@ class BuilderTest extends TestCase
         $this->assertSame(15, $paginator->perPage());
     }
 
+    public function test_it_can_paginate_scoped_with_custom_query_callback()
+    {
+        $this->prepareScoutSearchMockUsing('Laravel');
+
+        $paginator = SearchableUserModel::where(function ($builder) {
+            return $builder->where('id', '<', 11);
+        })->search('Laravel')->paginate();
+
+        $this->assertSame(10, $paginator->total());
+        $this->assertSame(1, $paginator->lastPage());
+        $this->assertSame(15, $paginator->perPage());
+    }
+
     public function test_it_can_paginate_raw_without_custom_query_callback()
     {
         $this->prepareScoutSearchMockUsing('Laravel');
@@ -77,6 +93,19 @@ class BuilderTest extends TestCase
         $paginator = SearchableUserModel::search('Laravel')->query(function ($builder) {
             return $builder->where('id', '<', 11);
         })->paginateRaw();
+
+        $this->assertSame(10, $paginator->total());
+        $this->assertSame(1, $paginator->lastPage());
+        $this->assertSame(15, $paginator->perPage());
+    }
+
+    public function test_it_can_paginate_raw_scoped_with_custom_query_callback()
+    {
+        $this->prepareScoutSearchMockUsing('Laravel');
+
+        $paginator = SearchableUserModel::where(function ($builder) {
+            return $builder->where('id', '<', 11);
+        })->search('Laravel')->paginateRaw();
 
         $this->assertSame(10, $paginator->total());
         $this->assertSame(1, $paginator->lastPage());

--- a/tests/Feature/BuilderTest.php
+++ b/tests/Feature/BuilderTest.php
@@ -17,10 +17,7 @@ use Orchestra\Testbench\TestCase;
 
 class BuilderTest extends TestCase
 {
-    use LazilyRefreshDatabase;
-    use WithFaker;
-    use WithLaravelMigrations;
-    use WithWorkbench;
+    use LazilyRefreshDatabase, WithFaker, WithLaravelMigrations, WithWorkbench;
 
     protected function defineEnvironment($app)
     {

--- a/tests/Integration/SearchableTests.php
+++ b/tests/Integration/SearchableTests.php
@@ -104,4 +104,9 @@ trait SearchableTests
             User::search('lar')->take(10)->query($queryCallback)->paginate(5, 'page', 2),
         ];
     }
+
+    protected function itCanUseLocalScopeSearch()
+    {
+        return User::where('email_verified_at', null)->search('lar')->take(10)->get();
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

### Implementation

Implements the changes proposed in #803.

This adds a scopeSearch to rely on laravel's [query scopes](https://laravel.com/docs/10.x/eloquent#local-scopes). I think that this is a really powerful feature, as it allows really flexible queries.

For example:

```php
// Query on Has/BelongsTo Relationships

// finds todos that belong to a user and searches through them.
User::first()->todos()->search('buy eggs'); 

// gets a user's managers and searches through them.
User::managers()->search('John'); 



// Allow more semantically "nice" queries.
User::where('id', '>' , '10')->search('John');
```



Sorry about all the annoying file changes, my linter is pretty aggressive. Can be removed if necessary. 