### PR TITLE
fix: permit makeSearchableUsing to realy modify the collection

### DIFF
--- a/src/Jobs/MakeSearchable.php
+++ b/src/Jobs/MakeSearchable.php
@@ -39,6 +39,7 @@ class MakeSearchable implements ShouldQueue
             return;
         }
 
-        $this->models->first()->makeSearchableUsing($this->models)->first()->searchableUsing()->update($this->models);
+        $this->models = $this->models->first()->makeSearchableUsing($this->models);
+        $this->models->first()->searchableUsing()->update($this->models);
     }
 }


### PR DESCRIPTION
The `makeSearchableUsing` method is aime for modifying the collection.

 I wanted to use the `load` method on my current collection but for that it need to assign the return to the current object. 

Without this changes you can't really modify the collection, all modifications are not passe to the last call `->update($this->models)`
