### PR TITLE
Repaces when and tap functions with Conditionable and Tappable traits

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -5,13 +5,15 @@ namespace Laravel\Scout;
 use Illuminate\Container\Container;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Traits\Tappable;
 use Laravel\Scout\Contracts\PaginatesEloquentModels;
 use Laravel\Scout\Contracts\PaginatesEloquentModelsUsingDatabase;
 
 class Builder
 {
-    use Macroable;
+    use Conditionable, Macroable, Tappable;
 
     /**
      * The model instance.
@@ -260,36 +262,6 @@ class Builder
         $this->options = $options;
 
         return $this;
-    }
-
-    /**
-     * Apply the callback's query changes if the given "value" is true.
-     *
-     * @param  mixed  $value
-     * @param  callable  $callback
-     * @param  callable  $default
-     * @return mixed
-     */
-    public function when($value, $callback, $default = null)
-    {
-        if ($value) {
-            return $callback($this, $value) ?: $this;
-        } elseif ($default) {
-            return $default($this, $value) ?: $this;
-        }
-
-        return $this;
-    }
-
-    /**
-     * Pass the query to a given callback.
-     *
-     * @param  \Closure  $callback
-     * @return $this
-     */
-    public function tap($callback)
-    {
-        return $this->when(true, $callback);
     }
 
     /**


### PR DESCRIPTION
Removes when and tap functions from scout Builder and replaces them Conditionable and Tappable traits.

This way we can also use the "unless" function and also use the "when" and "tap" higher order implementations:

```
Example::search('foo')
  ->when($request->has('bar'))->where('bar', $request->bar)
  ->get();
```