### PR TITLE
[10.x] Optional field definitions on model

### DIFF
--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -500,8 +500,9 @@ class TypesenseEngine extends Engine
             return $index;
         } catch (ObjectNotFound $exception) {
             $schema = config('scout.typesense.model-settings.'.get_class($model).'.collection-schema') ?? [];
-            if(method_exists($model, 'typesenseCollectionSchemaFields')) {
-                $schema['fields'] = $model::typesenseCollectionSchemaFields();
+
+            if (method_exists($model, 'typesenseCollectionSchemaFields')) {
+                $schema['fields'] = $model->typesenseCollectionSchemaFields();
             }
 
             if (! isset($schema['name'])) {

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -501,8 +501,8 @@ class TypesenseEngine extends Engine
         } catch (ObjectNotFound $exception) {
             $schema = config('scout.typesense.model-settings.'.get_class($model).'.collection-schema') ?? [];
 
-            if (method_exists($model, 'typesenseCollectionSchemaFields')) {
-                $schema['fields'] = $model->typesenseCollectionSchemaFields();
+            if (method_exists($model, 'typesenseCollectionSchema')) {
+                $schema = $model->typesenseCollectionSchema();
             }
 
             if (! isset($schema['name'])) {

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -500,6 +500,9 @@ class TypesenseEngine extends Engine
             return $index;
         } catch (ObjectNotFound $exception) {
             $schema = config('scout.typesense.model-settings.'.get_class($model).'.collection-schema') ?? [];
+            if(method_exists($model, 'typesenseCollectionSchemaFields')) {
+                $schema['fields'] = $model::typesenseCollectionSchemaFields();
+            }
 
             if (! isset($schema['name'])) {
                 $schema['name'] = $model->searchableAs();


### PR DESCRIPTION
Check if field definitions has been added on the model and use if that is the case

**Reasoning**
Search engine would like to have a definition of fields and their type. According to documentation, this is done in a (potentially huge) array in scout config. I propose an optional alternative where you _can_ define the fields alongside your toSearchableArray() method for a searchable model. 

1. This has the benefit of colocation with the properties 
I feel this data belongs on the model rather in the global config, just like the toSearchableArray

2. It opens the option to use php to generate some logic around the schema definition
Consider you want to generate the index with a loop over the toSearchableArray keys detecting the typesense type automatically. 

**Notes**
I propose to replace the field definitions if they are in the model. This ensures there is no breaks with the base approach and the definitions are only used if they are specifically added

I will of course update the documentation accordingly.