### PR TITLE
Allow Typesense Search Parameter Definition on Models

### DIFF
--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -262,7 +262,7 @@ class TypesenseEngine extends Engine
         ];
 
         if (method_exists($builder->model, 'typesenseSearchParameters')) {
-            $parameters = array_merge($builder->model->typesenseSearchParameters());
+            $parameters = array_merge($parameters, $builder->model->typesenseSearchParameters());
         }
 
         if (! empty($builder->options)) {

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -261,6 +261,10 @@ class TypesenseEngine extends Engine
             'highlight_affix_num_tokens' => 4,
         ];
 
+        if (method_exists($builder->model, 'typesenseSearchParameters')) {
+            $parameters = array_merge($builder->model->typesenseSearchParameters());
+        }
+
         if (! empty($builder->options)) {
             $parameters = array_merge($parameters, $builder->options);
         }


### PR DESCRIPTION
Added the optional `typesenseSearchParameters` Model Definition to allow declaration of Typesense Search Parameters using Models to extend and streamline the already existing `typesenseCollectionSchema` functionality. 

Currently when utilising the existing `typesenseCollectionSchema` function, you have to mix and match Model based Defintion with Config Usage, which is not ideal.

With the added `typesenseSearchParameters` you can define everything utilising only Models.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>

File: `Model.php`

```php    
public function typesenseCollectionSchema(): array
{
    return [
        'enable_nested_fields' => true,
        'fields' => [
            [
                'name' => '.*',
                'type' => 'auto',
            ],
        ],
    ];
}
```

with

File: `config/scout.php`

```php
return [
    'typesense' => [
        'model-settings' => [
            Model::class => [
                'search-parameters' => [
                    'query_by' => 'name'
                ]
            ]
        ]
    ]
];
```
</td>
<td>

File: `Model.php`

```php    
public function typesenseCollectionSchema(): array
{
    return [
        'enable_nested_fields' => true,
        'fields' => [
            [
                'name' => '.*',
                'type' => 'auto',
            ],
        ],
    ];
}

public function typesenseSearchParameters(): array
{
    return [
        'query_by' => 'name'
    ];
}
```
</td>
</tr>
</tbody>
</table>