### PR TITLE
Add Index Events & fix unnecessary Typesense Index Creation on Flush

### DIFF
--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -495,7 +495,7 @@ class TypesenseEngine extends Engine
      * Get collection from model or create new one.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @param  bool  $autoCreate = true
+     * @param  bool  $autoCreate  = true
      * @return TypesenseCollection
      *
      * @throws \Typesense\Exceptions\TypesenseClientError
@@ -507,7 +507,7 @@ class TypesenseEngine extends Engine
 
         $collectionIndex = $this->typesense->getCollections()->{$index};
 
-        if ($collectionIndex->exists() === true || !$autoCreate) {
+        if ($collectionIndex->exists() === true || ! $autoCreate) {
             return $collectionIndex;
         }
 

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -453,13 +453,7 @@ class TypesenseEngine extends Engine
     {
         $index = $model->searchableAs();
 
-        $collectionIndex = $this->typesense->getCollections()->{$index};
-
-        if ($collectionIndex->exists() !== true) {
-            return;
-        }
-
-        $collectionIndex->delete();
+        $this->getOrCreateCollectionFromModel($model, false)->delete();
 
         event(new IndexDeleted($index));
     }
@@ -501,18 +495,19 @@ class TypesenseEngine extends Engine
      * Get collection from model or create new one.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  bool  $autoCreate = true
      * @return TypesenseCollection
      *
      * @throws \Typesense\Exceptions\TypesenseClientError
      * @throws \Http\Client\Exception
      */
-    protected function getOrCreateCollectionFromModel($model): TypesenseCollection
+    protected function getOrCreateCollectionFromModel($model, $autoCreate = true): TypesenseCollection
     {
         $index = $model->searchableAs();
 
         $collectionIndex = $this->typesense->getCollections()->{$index};
 
-        if ($collectionIndex->exists() === true) {
+        if ($collectionIndex->exists() === true || !$autoCreate) {
             return $collectionIndex;
         }
 

--- a/src/Events/IndexCreated.php
+++ b/src/Events/IndexCreated.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Laravel\Scout\Events;
+
+class IndexCreated
+{
+    /**
+     * The index name.
+     *
+     * @var string
+     */
+    public $index;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $index
+     * @return void
+     */
+    public function __construct($index)
+    {
+        $this->index = $index;
+    }
+}

--- a/src/Events/IndexDeleted.php
+++ b/src/Events/IndexDeleted.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Laravel\Scout\Events;
+
+class IndexDeleted
+{
+    /**
+     * The index name.
+     *
+     * @var string
+     */
+    public $index;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $index
+     * @return void
+     */
+    public function __construct($index)
+    {
+        $this->index = $index;
+    }
+}

--- a/tests/Unit/TypesenseEngineTest.php
+++ b/tests/Unit/TypesenseEngineTest.php
@@ -211,38 +211,22 @@ class TypesenseEngineTest extends TestCase
         $this->assertEquals(0, $totalCountWithoutFound);
     }
 
-    public function test_flush_method_without_collection(): void
+    public function test_flush_method(): void
     {
         // Mock a model instance
         $model = $this->createMock(Model::class);
 
         $collection = $this->createMock(TypesenseCollection::class);
 
-        // Mock the delete method of the TypesenseCollection
-        $collection->expects($this->never())
-            ->method('delete');
-
-        // Call the flush method
-        $this->engine->flush($model);
-    }
-
-    public function test_flush_method_with_collection(): void
-    {
-        // Mock a model
-        $model = $this->createMock(SearchableModel::class);
-
         // Mock the getOrCreateCollectionFromModel method
-        $collection = $this->createMock(TypesenseCollection::class);
-
-        $this->engine->expects($this->exactly(2))
+        $this->engine->expects($this->once())
             ->method('getOrCreateCollectionFromModel')
+            ->with($model)
             ->willReturn($collection);
 
+        // Mock the delete method of the TypesenseCollection
         $collection->expects($this->once())
             ->method('delete');
-
-        // Call the update method
-        $this->engine->update(collect([$model]));
 
         // Call the flush method
         $this->engine->flush($model);


### PR DESCRIPTION
Changes:
- Added `IndexCreated` & `IndexDeleted` Events
- Removed unnecessary Typesense Index Creation when calling Flush on an non-existent Index/Collection
- Fix of #826 (touched the line anyway)

Currently there is no easy way to utilise Index/Collection based features like Synonyms provided by Meilisearch or Typesense. With the newly added events you can directly hook into after the creation and register them for example.

Example Usage:
```php

Event::listen(IndexCreated::class, function (IndexCreated $event) {
    $index = $event->index;

    logger('Created Index', ['index' => $index]);

    $typesense = app(EngineManager::class)->engine();

    $collection = $typesense->getCollections()->{$index};

    $synonyms = $collection->getSynonyms();

    $synonym = $synonyms->upsert('coat-synonyms', [
        'synonyms' => [
            'blazer', 'coat', 'jacket'
        ],
    ]);

    logger('Created Synonym', $synonym);
});

Event::listen(IndexDeleted::class, function (IndexDeleted $event) {
    $index = $event->index;

    logger('Deleted Index', ['index' => $index]);
});
```