### PR TITLE
Allow filtering by comparison operators 

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -72,6 +72,13 @@ class Builder
     public $whereNotIns = [];
 
     /**
+     * The "where" comparisons added to the query.
+     *
+     * @var array
+     */
+    public $whereComparisons = [];
+
+    /**
      * The "limit" that should be applied to the search.
      *
      * @var int
@@ -163,6 +170,21 @@ class Builder
     public function whereNotIn($field, array $values)
     {
         $this->whereNotIns[$field] = $values;
+
+        return $this;
+    }
+
+    /**
+     * Add a "where comparison" constraint to the search query.
+     *
+     * @param  string  $field
+     * @param  string  $operator
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function whereComparison($field, $operator, $value)
+    {
+        $this->whereComparisons[] = compact('field', 'operator', 'value');
 
         return $this;
     }

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -174,6 +174,9 @@ class AlgoliaEngine extends Engine
             return collect($values)->map(function ($value) use ($key) {
                 return $key.'='.$value;
             })->all();
+        })->values())
+        ->merge(collect($builder->whereComparisons)->map(function ($comparison) {
+            return $comparison['field'].$comparison['operator'].$comparison['value'];
         })->values())->values()->all();
     }
 

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -105,6 +105,11 @@ class CollectionEngine extends Engine
                                 $query->whereNotIn($key, $values);
                             }
                         })
+                        ->when(! $builder->callback && count($builder->whereComparisons) > 0, function ($query) use ($builder) {
+                            foreach ($builder->whereComparisons as $comparison) {
+                                $query->where($comparison['field'], $comparison['operator'], $comparison['value']);
+                            }
+                        })
                         ->when($builder->orders, function ($query) use ($builder) {
                             foreach ($builder->orders as $order) {
                                 $query->orderBy($order['column'], $order['direction']);

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -253,6 +253,10 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
             foreach ($builder->whereNotIns as $key => $values) {
                 $query->whereNotIn($key, $values);
             }
+        })->when(! $builder->callback && count($builder->whereComparisons) > 0, function ($query) use ($builder) {
+            foreach ($builder->whereComparisons as $comparison) {
+                $query->where($comparison['field'], $comparison['operator'], $comparison['value']);
+            }
         })->when(! is_null($builder->queryCallback), function ($query) use ($builder) {
             call_user_func($builder->queryCallback, $query);
         });

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -300,9 +300,15 @@ class TypesenseEngine extends Engine
             ->values()
             ->implode(' && ');
 
-        return $whereFilter.(
-            ($whereFilter !== '' && $whereInFilter !== '') ? ' && ' : ''
-        ).$whereInFilter;
+        $whereComparisonFilter = collect($builder->whereComparisons)
+            ->map(fn ($comparison) => sprintf('%s:%s%s', $comparison['field'], $comparison['operator'], $comparison['value']))
+            ->values()
+            ->implode(' && ');
+
+        return collect([$whereFilter, $whereInFilter, $whereComparisonFilter])
+            ->filter()
+            ->values()
+            ->implode(' && ');
     }
 
     /**

--- a/tests/Unit/AlgoliaEngineTest.php
+++ b/tests/Unit/AlgoliaEngineTest.php
@@ -150,6 +150,25 @@ class AlgoliaEngineTest extends TestCase
         $engine->search($builder);
     }
 
+    public function test_search_sends_correct_parameters_to_algolia_for_where_comparison_search()
+    {
+        $client = m::mock(SearchClient::class);
+        $client->shouldReceive('initIndex')->with('table')->andReturn($index = m::mock(stdClass::class));
+        $index->shouldReceive('search')->with('zonda', [
+            'numericFilters' => ['foo=1', ['bar=1', 'bar=2'], 'baz>2', 'qux<=3'],
+        ]);
+
+        $engine = new AlgoliaEngine($client);
+        $builder = new Builder(new SearchableModel, 'zonda');
+        $builder
+            ->where('foo', 1)
+            ->whereIn('bar', [1, 2])
+            ->whereComparison('baz', '>', 2)
+            ->whereComparison('qux', '<=', 3);
+
+        $engine->search($builder);
+    }
+
     public function test_map_correctly_maps_results_to_models()
     {
         $client = m::mock(SearchClient::class);


### PR DESCRIPTION
Allows the use of different comparison operators (>, <, <=, >=, etc) in supported search engines. 

A new method `whereComparison` and its underlying property have been created to avoid breaking changes. It can be used as: 
```php
User::search('john')->whereComparison('age', '>=', 18)
```

Related issues:
https://github.com/laravel/scout/issues/799
https://github.com/laravel/scout/issues/776
https://github.com/laravel/scout/issues/744
https://github.com/laravel/scout/issues/529



<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
