### PR TITLE
Added possibility to version indexes. 

### DIFF
--- a/src/Console/DeleteIndexCommand.php
+++ b/src/Console/DeleteIndexCommand.php
@@ -51,7 +51,7 @@ class DeleteIndexCommand extends Command
     protected function indexName($name)
     {
         if (class_exists($name)) {
-            return (new $name)->searchableAs();
+            return (new $name)->indexableAs();
         }
 
         $prefix = config('scout.prefix');

--- a/src/Console/IndexCommand.php
+++ b/src/Console/IndexCommand.php
@@ -88,7 +88,7 @@ class IndexCommand extends Command
     protected function indexName($name)
     {
         if (class_exists($name)) {
-            return (new $name)->searchableAs();
+            return (new $name)->indexableAs();
         }
 
         $prefix = config('scout.prefix');

--- a/src/Console/SyncIndexSettingsCommand.php
+++ b/src/Console/SyncIndexSettingsCommand.php
@@ -84,7 +84,7 @@ class SyncIndexSettingsCommand extends Command
     protected function indexName($name)
     {
         if (class_exists($name)) {
-            return (new $name)->searchableAs();
+            return (new $name)->indexableAs();
         }
 
         $prefix = config('scout.prefix');

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -52,7 +52,7 @@ class AlgoliaEngine extends Engine
             return;
         }
 
-        $index = $this->algolia->initIndex($models->first()->searchableAs());
+        $index = $this->algolia->initIndex($models->first()->indexableAs());
 
         if ($this->usesSoftDelete($models->first()) && $this->softDelete) {
             $models->each->pushSoftDeleteMetadata();
@@ -87,7 +87,7 @@ class AlgoliaEngine extends Engine
             return;
         }
 
-        $index = $this->algolia->initIndex($models->first()->searchableAs());
+        $index = $this->algolia->initIndex($models->first()->indexableAs());
 
         $keys = $models instanceof RemoveableScoutCollection
             ? $models->pluck($models->first()->getScoutKeyName())
@@ -280,7 +280,7 @@ class AlgoliaEngine extends Engine
      */
     public function flush($model)
     {
-        $index = $this->algolia->initIndex($model->searchableAs());
+        $index = $this->algolia->initIndex($model->indexableAs());
 
         $index->clearObjects();
     }

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -53,7 +53,7 @@ class MeilisearchEngine extends Engine
             return;
         }
 
-        $index = $this->meilisearch->index($models->first()->searchableAs());
+        $index = $this->meilisearch->index($models->first()->indexableAs());
 
         if ($this->usesSoftDelete($models->first()) && $this->softDelete) {
             $models->each->pushSoftDeleteMetadata();
@@ -88,7 +88,7 @@ class MeilisearchEngine extends Engine
             return;
         }
 
-        $index = $this->meilisearch->index($models->first()->searchableAs());
+        $index = $this->meilisearch->index($models->first()->indexableAs());
 
         $keys = $models instanceof RemoveableScoutCollection
             ? $models->pluck($models->first()->getScoutKeyName())
@@ -363,7 +363,7 @@ class MeilisearchEngine extends Engine
      */
     public function flush($model)
     {
-        $index = $this->meilisearch->index($model->searchableAs());
+        $index = $this->meilisearch->index($model->indexableAs());
 
         $index->deleteAllDocuments();
     }

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -225,7 +225,7 @@ class TypesenseEngine extends Engine
      */
     protected function performSearch(Builder $builder, array $options = []): mixed
     {
-        $documents = $this->getOrCreateCollectionFromModel($builder->model)->getDocuments();
+        $documents = $this->getOrCreateCollectionFromModel($builder->model,false)->getDocuments();
 
         if ($builder->callback) {
             return call_user_func($builder->callback, $documents, $builder->query, $options);
@@ -494,9 +494,10 @@ class TypesenseEngine extends Engine
      * @throws \Typesense\Exceptions\TypesenseClientError
      * @throws \Http\Client\Exception
      */
-    protected function getOrCreateCollectionFromModel($model): TypesenseCollection
+    protected function getOrCreateCollectionFromModel($model,bool $indexOperation = true): TypesenseCollection
     {
-        $collection = $this->typesense->getCollections()->{$model->searchableAs()};
+        $operation = $indexOperation ? 'indexableAs' : 'searchableAs';
+        $collection = $this->typesense->getCollections()->{$model->{$operation}()};
 
         if ($collection->exists() === true) {
             return $collection;

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -496,8 +496,9 @@ class TypesenseEngine extends Engine
      */
     protected function getOrCreateCollectionFromModel($model, bool $indexOperation = true): TypesenseCollection
     {
-        $operation = $indexOperation ? 'indexableAs' : 'searchableAs';
-        $collection = $this->typesense->getCollections()->{$model->{$operation}()};
+        $method = $indexOperation ? 'indexableAs' : 'searchableAs';
+
+        $collection = $this->typesense->getCollections()->{$model->{$method}()};
 
         if ($collection->exists() === true) {
             return $collection;

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -225,7 +225,7 @@ class TypesenseEngine extends Engine
      */
     protected function performSearch(Builder $builder, array $options = []): mixed
     {
-        $documents = $this->getOrCreateCollectionFromModel($builder->model,false)->getDocuments();
+        $documents = $this->getOrCreateCollectionFromModel($builder->model, false)->getDocuments();
 
         if ($builder->callback) {
             return call_user_func($builder->callback, $documents, $builder->query, $options);
@@ -494,7 +494,7 @@ class TypesenseEngine extends Engine
      * @throws \Typesense\Exceptions\TypesenseClientError
      * @throws \Http\Client\Exception
      */
-    protected function getOrCreateCollectionFromModel($model,bool $indexOperation = true): TypesenseCollection
+    protected function getOrCreateCollectionFromModel($model, bool $indexOperation = true): TypesenseCollection
     {
         $operation = $indexOperation ? 'indexableAs' : 'searchableAs';
         $collection = $this->typesense->getCollections()->{$model->{$operation}()};

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -300,11 +300,21 @@ trait Searchable
     }
 
     /**
-     * Get the index name for the model.
+     * Get the index name for the model when searching
      *
      * @return string
      */
     public function searchableAs()
+    {
+        return config('scout.prefix').$this->getTable();
+    }
+
+    /**
+     * Get the index name for the model when indexing
+     *
+     * @return string
+     */
+    public function indexableAs()
     {
         return config('scout.prefix').$this->getTable();
     }

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -300,7 +300,7 @@ trait Searchable
     }
 
     /**
-     * Get the index name for the model when searching
+     * Get the index name for the model when searching.
      *
      * @return string
      */
@@ -310,7 +310,7 @@ trait Searchable
     }
 
     /**
-     * Get the index name for the model when indexing
+     * Get the index name for the model when indexing.
      *
      * @return string
      */

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -316,7 +316,7 @@ trait Searchable
      */
     public function indexableAs()
     {
-        return config('scout.prefix').$this->getTable();
+        return $this->searchableAs();
     }
 
     /**

--- a/tests/Fixtures/SearchableModel.php
+++ b/tests/Fixtures/SearchableModel.php
@@ -20,4 +20,9 @@ class SearchableModel extends Model
     {
         return 'table';
     }
+
+    public function indexableAs()
+    {
+        return 'table';
+    }
 }

--- a/tests/Fixtures/VersionableModel.php
+++ b/tests/Fixtures/VersionableModel.php
@@ -20,6 +20,7 @@ class VersionableModel extends Model
     {
         return 'table';
     }
+
     public function indexableAs()
     {
         return 'table_v2';

--- a/tests/Fixtures/VersionableModel.php
+++ b/tests/Fixtures/VersionableModel.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Laravel\Scout\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Scout\Searchable;
+
+class VersionableModel extends Model
+{
+    use Searchable;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = ['id', 'name'];
+
+    public function searchableAs()
+    {
+        return 'table';
+    }
+    public function indexableAs()
+    {
+        return 'table_v2';
+    }
+}

--- a/tests/Integration/MeilisearchSearchableTest.php
+++ b/tests/Integration/MeilisearchSearchableTest.php
@@ -153,6 +153,7 @@ class MeilisearchSearchableTest extends TestCase
             20 => 'Prof. Larry Prosacco DVM',
         ], $page2->pluck('name', 'id')->all());
     }
+
     public function test_uses_different_indexes()
     {
         $client = m::mock(Client::class);

--- a/tests/Integration/MeilisearchSearchableTest.php
+++ b/tests/Integration/MeilisearchSearchableTest.php
@@ -2,8 +2,15 @@
 
 namespace Laravel\Scout\Tests\Integration;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Env;
+use Laravel\Scout\Builder;
+use Laravel\Scout\Engines\MeilisearchEngine;
 use Laravel\Scout\Tests\Fixtures\User;
+use Laravel\Scout\Tests\Fixtures\VersionableModel;
+use Meilisearch\Client;
+use Meilisearch\Endpoints\Indexes;
+use Mockery as m;
 
 /**
  * @group meilisearch
@@ -145,6 +152,23 @@ class MeilisearchSearchableTest extends TestCase
             44 => 'Amos Larson Sr.',
             20 => 'Prof. Larry Prosacco DVM',
         ], $page2->pluck('name', 'id')->all());
+    }
+    public function test_uses_different_indexes()
+    {
+        $client = m::mock(Client::class);
+        $client->shouldReceive('index')->with('table_v2')->andReturn($index = m::mock(Indexes::class));
+        $index->shouldReceive('deleteDocuments')->with([1]);
+
+        $engine = new MeilisearchEngine($client);
+        $engine->delete(Collection::make([new VersionableModel(['id' => 1])]));
+
+        $client = m::mock(Client::class);
+        $client->shouldReceive('index')->with('table')->once()->andReturn($index = m::mock(Indexes::class));
+        $index->shouldReceive('rawSearch')->once()->andReturn([]);
+
+        $engine = new MeilisearchEngine($client);
+        $builder = new Builder(new VersionableModel(), '');
+        $engine->search($builder);
     }
 
     public function test_it_can_use_paginated_search_with_query_callback()


### PR DESCRIPTION
Hi everyone,
This is a simple pr that adds the indexableAs method in the searchable trait.

Why?
- Rolling updates: It ensures zero downtime by indexing data into a new index while searching continues on the old one. This is something I feel is missing from scout, especially for high traffic websites that want to use it and it is quite easy to achieve this way.
- Backwards compatible: users that don't care for this feature wont be affected since by default the indexableAs and searchableAs have the same return.

Usage scenario:
1. Users Model is searchable
2. You define the indexableAs with return 'users_v2'
3. You reimport everything in users_v2, meanwhile your website can still perform searches on the old index
4. You deploy a new version of your code with the searchableAs returning 'users_v2'
5. profit!