### PR TITLE
Fix searchable queue configuration

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -42,7 +42,10 @@ return [
     |
     */
 
-    'queue' => env('SCOUT_QUEUE', false),
+    'queue' => [
+        'connection' => env('SCOUT_CONNECTION'),
+        'queue' => env('SCOUT_QUEUE', false),
+    ],
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -59,8 +59,9 @@ trait Searchable
             return;
         }
 
-        if (! config('scout.queue')) {
-            return $models->first()->makeSearchableUsing($models)->first()->searchableUsing()->update($models);
+        if (! config('scout.queue.queue')) {
+            $models->first()->makeSearchableUsing($models)->first()->searchableUsing()->update($models);
+            return;
         }
 
         dispatch((new Scout::$makeSearchableJob($models))

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -81,7 +81,7 @@ trait Searchable
             return;
         }
 
-        if (! config('scout.queue')) {
+        if (! config('scout.queue.queue')) {
             return $models->first()->searchableUsing()->delete($models);
         }
 

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -61,6 +61,7 @@ trait Searchable
 
         if (! config('scout.queue.queue')) {
             $models->first()->makeSearchableUsing($models)->first()->searchableUsing()->update($models);
+            
             return;
         }
 

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -61,7 +61,7 @@ trait Searchable
 
         if (! config('scout.queue.queue')) {
             $models->first()->makeSearchableUsing($models)->first()->searchableUsing()->update($models);
-            
+
             return;
         }
 


### PR DESCRIPTION
This PR fixes how the `Searchable` trait determines whether to queue jobs. Also, the published configuration file is updated to be compatible with the current version of the trait.

---

The `Searchable` trait currently determines the queue connection and queue using the following two methods:

```php
    public function syncWithSearchUsing()
    {
        return config('scout.queue.connection') ?: config('queue.default');
    }

    public function syncWithSearchUsingQueue()
    {
        return config('scout.queue.queue');
    }
```

However, the config file that is published by this package only contained the following config option:

```php
return [
    'queue' => env('SCOUT_QUEUE', false),
];
```

This has been updated to the keys actually used by the trait:

```php
return [
    'queue' => [
        'connection' => env('SCOUT_CONNECTION'),
        'queue' => env('SCOUT_QUEUE', false),
    ],
]
```

Subsequently, another update to the `Searchable` trait itself was necessary, since this used the old `scout.queue` key to determine if jobs should be queued. It now correctly uses `scout.queue.queue`:


```php
    public function queueMakeSearchable($models)
    {
        if ($models->isEmpty()) {
            return;
        }

        if (! config('scout.queue.queue')) {
            $models->first()->makeSearchableUsing($models)->first()->searchableUsing()->update($models);
            return;
        }

        dispatch((new Scout::$makeSearchableJob($models))
                ->onQueue($models->first()->syncWithSearchUsingQueue())
                ->onConnection($models->first()->syncWithSearchUsing()));
    }
```

Edit: The same was done for the `queueRemoveFromSearch` method.