### PR TITLE
[11.x] Use scout prefix when deleting all indexes

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,10 @@
 
 In previous Scout releases, the Algolia engine utilized `numericFilters` to power `where` conditions. However, `numericFilters` does not support simple string matching. In Scout 11.x, `filters` is now used instead of `numericFilters`.
 
+### Meilisearch Engine `scout:delete-all-indexes` command
+
+In previous releases, the Meilisearch engine’s `scout:delete-all-indexes` command would drop all indexes from the Meilisearch server. In Scout 11.x, the command drops only indexes with the app’s currently-configured Scout prefix (see `SCOUT_PREFIX` env variable and/or `scout.prefix` config key).
+
 ## Upgrading To 10.0 From 9.x
 
 ### Minimum Versions

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,9 +6,9 @@
 
 In previous Scout releases, the Algolia engine utilized `numericFilters` to power `where` conditions. However, `numericFilters` does not support simple string matching. In Scout 11.x, `filters` is now used instead of `numericFilters`.
 
-### Meilisearch Engine `scout:delete-all-indexes` command
+### Meilisearch Engine `scout:delete-all-indexes` Command
 
-In previous releases, the Meilisearch engine’s `scout:delete-all-indexes` command would drop all indexes from the Meilisearch server. In Scout 11.x, the command drops only indexes with the app’s currently-configured Scout prefix (see `SCOUT_PREFIX` env variable and/or `scout.prefix` config key).
+In previous releases, the Meilisearch engine’s `scout:delete-all-indexes` command would drop all indexes from the Meilisearch server. In Scout 11.x, the command now only drops indexes with the application's currently configured Scout prefix. Typically, this corresponds to the `SCOUT_PREFIX` environment variable and / or the `scout.prefix` configuration value.
 
 ## Upgrading To 10.0 From 9.x
 

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -431,11 +431,9 @@ class MeilisearchEngine extends Engine
         $indexes = $this->meilisearch->getIndexes($query);
 
         foreach ($indexes->getResults() as $index) {
-            if (! str($index->getUid())->startsWith(Config::get('scout.prefix'))) {
-                continue;
+            if (str($index->getUid())->startsWith(Config::get('scout.prefix'))) {
+                $tasks[] = $index->delete();
             }
-
-            $tasks[] = $index->delete();
         }
 
         return $tasks;

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -3,6 +3,7 @@
 namespace Laravel\Scout\Engines;
 
 use BackedEnum;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Jobs\RemoveableScoutCollection;
@@ -430,6 +431,10 @@ class MeilisearchEngine extends Engine
         $indexes = $this->meilisearch->getIndexes($query);
 
         foreach ($indexes->getResults() as $index) {
+            if (! str($index->getUid())->startsWith(Config::get('scout.prefix'))) {
+                continue;
+            }
+
             $tasks[] = $index->delete();
         }
 


### PR DESCRIPTION
I use Laravel Scout and Meilisearch with several local development sites and use `SCOUT_PREFIX` to avoid collisions between apps.

I recently wanted to drop and recreate the indexes for one app so used `php artisan scout:delete-all-indexes` assuming that it would delete just the indexes for the current app…but it actually deleted _all_ indexes in the Meilisearch server.

This PR respects the `scout.prefix` config value and only deletes the indexes that begin with the prefix.

The `php artisan scout:delete-index` is _not_ affected, since you have to supply the index name and it’s in theory more obvious which index you are deleting.

Alternative idea instead of this approach: the `scout:delete-all-indexes` command could instead notify the user that it will delete _all_ indexes, not just those with this app’s prefix, and ask them to confirm before deleting.

Alternative idea in conjunction with this approach: the `scout:delete-all-indexes` command could include a `--ignore-prefix` or similar flag to override the behavior in this PR for those cases where the user does in fact want to remove all indexes, even those without the prefix.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
