### PR TITLE
[10.x] Get the key name through getScoutKeyName() on the Database engine

### DIFF
--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -92,7 +92,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
                 }
             })
             ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
-                $query->orderBy($builder->model->getKeyName(), 'desc');
+                $query->orderBy($builder->model->getScoutKeyName(), 'desc');
             })
             ->paginate($perPage, ['*'], $pageName, $page);
     }
@@ -127,7 +127,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
                 }
             })
             ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
-                $query->orderBy($builder->model->getKeyName(), 'desc');
+                $query->orderBy($builder->model->getScoutKeyName(), 'desc');
             })
             ->simplePaginate($perPage, ['*'], $pageName, $page);
     }
@@ -152,7 +152,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
                 }
             })
             ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
-                $query->orderBy($builder->model->getKeyName(), 'desc');
+                $query->orderBy($builder->model->getScoutKeyName(), 'desc');
             })
             ->get();
     }
@@ -198,7 +198,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
             $canSearchPrimaryKey = ctype_digit($builder->query) &&
                                    in_array($builder->model->getKeyType(), ['int', 'integer']) &&
                                    ($connectionType != 'pgsql' || $builder->query <= PHP_INT_MAX) &&
-                                   in_array($builder->model->getKeyName(), $columns);
+                                   in_array($builder->model->getScoutKeyName(), $columns);
 
             if ($canSearchPrimaryKey) {
                 $query->orWhere($builder->model->getQualifiedKeyName(), $builder->query);
@@ -214,7 +214,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
                         $this->getFullTextOptions($builder)
                     );
                 } else {
-                    if ($canSearchPrimaryKey && $column === $builder->model->getKeyName()) {
+                    if ($canSearchPrimaryKey && $column === $builder->model->getScoutKeyName()) {
                         continue;
                     }
 


### PR DESCRIPTION
I'm not sure why the database engine is the only still using `getKeyName()`, but it should be using `getScoutKeyName()` as all the others. I just found this while trying to set a custom ID for my searches other than the one I'm using for normal usage of the searchable model.

While trying to join a table:

```php
Post::search($search)
    ->query(function ($query) {
        ...

        $query->join('twill_blocks', 'posts.id', '=', 'twill_blocks.blockable_id');
    })
    ->get();
```

Scout was raising a `Column 'id' in order clause is ambiguous` caused by an unqualified `order by id` that was not possible to customize as the only way would be by overloading `getKeyName()` and that would break how things work for my Post model out of the search context.