### PR TITLE
[Typesense]  Sync server state in getOrCreateCollectionFromModel #845

### DIFF
--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -500,8 +500,20 @@ class TypesenseEngine extends Engine
 
         $collection = $this->typesense->getCollections()->{$model->{$method}()};
 
-        if ($collection->exists() === true) {
-            return $collection;
+        $collectionExists = false;
+        if ($collection->exists()) {
+            // Also check if the collection exists in Typesense to avoid potential errors
+            $collectionName = $model->{$method}();
+            try  {
+                $this->typesense->collections[$collectionName]->retrieve();
+                $collectionExists = true;
+            } catch (TypesenseClientError $e){
+                $collectionExists = false;
+            }
+        }
+
+        if ($collectionExists) {
+            return $this->typesense->getCollections()->{$collectionName};
         }
 
         $schema = config('scout.typesense.model-settings.'.get_class($model).'.collection-schema') ?? [];

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -501,15 +501,17 @@ class TypesenseEngine extends Engine
         $collection = $this->typesense->getCollections()->{$model->{$method}()};
 
         $collectionExists = false;
+
         if ($collection->exists()) {
-            // Also check if the collection exists in Typesense to avoid potential errors
+            // Also determine if the collection exists in Typesense...
             $collectionName = $model->{$method}();
 
             try {
                 $this->typesense->collections[$collectionName]->retrieve();
+                
                 $collectionExists = true;
             } catch (TypesenseClientError $e) {
-                // No need to do anything here, collectionExists will remain false
+                //
             }
         }
 

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -504,11 +504,12 @@ class TypesenseEngine extends Engine
         if ($collection->exists()) {
             // Also check if the collection exists in Typesense to avoid potential errors
             $collectionName = $model->{$method}();
-            try  {
+
+            try {
                 $this->typesense->collections[$collectionName]->retrieve();
                 $collectionExists = true;
-            } catch (TypesenseClientError $e){
-                $collectionExists = false;
+            } catch (TypesenseClientError $e) {
+                // No need to do anything here, collectionExists will remain false
             }
         }
 


### PR DESCRIPTION
Updates the `getOrCreateCollectionFromModel` method in `TypesenseEngine` to verify if a collection exists on the server. If not found, it is created. This ensures consistency between the worker and server, fixing queue workers not being able to import after flushing, as mentioned in #845.
