### PR TITLE
refactor(typesense): remove unused exists checks

### DIFF
--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -497,6 +497,7 @@ class TypesenseEngine extends Engine
     protected function getOrCreateCollectionFromModel($model, bool $indexOperation = true): TypesenseCollection
     {
         $method = $indexOperation ? 'indexableAs' : 'searchableAs';
+
         $collectionName = $model->{$method}();
         $collection = $this->typesense->getCollections()->{$collectionName};
 
@@ -504,7 +505,7 @@ class TypesenseEngine extends Engine
         try {
             $collection->retrieve();
 
-            // No error means this exists on the server
+            // No error means this collection exists on the server...
             $collection->setExists(true);
 
             return $collection;


### PR DESCRIPTION
In https://github.com/laravel/scout/pull/820 we introduced an exists check method, which then lead to static state issues as described in https://github.com/laravel/scout/issues/845

Those where addressed in https://github.com/laravel/scout/pull/846

But now that the function always double-checks the existence, we can remove the exists check entirely and only rely on the Typesense server response for this state.

This "fixes" issues where the server already has a collection and the client would try to recreate it. E.g. when it has flushed the index and another process or worker then creates the collection.
