### PR TITLE
Sort models after fetching when orders conditions are applied to search

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -237,7 +237,7 @@ trait Searchable
         return $this->queryScoutModelsByIds($builder, $ids)
             ->get()
             ->when(
-                !empty($builder->orders),
+                ! empty($builder->orders),
                 fn ($models) => $models->sortBy(fn ($model) => array_search($model->{$this->getScoutKeyName()}, $ids))
             );
     }

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -234,7 +234,12 @@ trait Searchable
      */
     public function getScoutModelsByIds(Builder $builder, array $ids)
     {
-        return $this->queryScoutModelsByIds($builder, $ids)->get();
+        return $this->queryScoutModelsByIds($builder, $ids)
+            ->get()
+            ->when(
+                !empty($builder->orders),
+                fn ($models) => $models->sortBy(fn ($model) => array_search($model->{$this->getScoutKeyName()}, $ids))
+            );
     }
 
     /**
@@ -259,11 +264,6 @@ trait Searchable
 
         return $query->{$whereIn}(
             $this->qualifyColumn($this->getScoutKeyName()), $ids
-        )->orderByRaw(
-            sprintf('FIELD(%s,%s)',
-                $this->qualifyColumn($this->getScoutKeyName()),
-                implode(',', $ids),
-            )
         );
     }
 

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -259,6 +259,11 @@ trait Searchable
 
         return $query->{$whereIn}(
             $this->qualifyColumn($this->getScoutKeyName()), $ids
+        )->orderByRaw(
+            sprintf('FIELD(%s,%s)',
+                $this->qualifyColumn($this->getScoutKeyName()),
+                implode(',', $ids),
+            )
         );
     }
 


### PR DESCRIPTION
I've found that after applying a custom order logic to the search engine and retrieving a subset of ids, these ids can be re-sorted during the fetching of the models.