### PR TITLE
[10.x] Allow setting custom scout builder class

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -118,7 +118,7 @@ trait Searchable
      */
     public static function search($query = '', $callback = null)
     {
-        return app(Builder::class, [
+        return app(static::$scoutBuilder ?? Builder::class, [
             'model' => new static,
             'query' => $query,
             'callback' => $callback,


### PR DESCRIPTION
If you want to create a dedicated scout builder class for a model, you currently have to override the static `search()` method.
```php
// Before

class Company extends Model
{
    use Searchable;

    public static function search($query = '', $callback = null)
    {
        return app(CompanyScoutBuilder::class, [
            'model' => new static,
            'query' => $query,
            'callback' => $callback,
            'softDelete' => static::usesSoftDelete() && config('scout.soft_delete', false),
        ]);
    }
}
```

 This PR fixes that so you only have to define a static property on your model

```php
// After

class Company extends Model
{
    use Searchable;

    protected static string $scoutBuilder = CompanyScoutBuilder::class;
}
```
```php
class CompanyScoutBuilder extends \Laravel\Scout\Builder
{
    public function withinRadius() : self
   {
        // Some complex filter that you want to use in multiple scout searches.
        // Creating a method in a custom scout builder class makes this easy.
        return $this->where(...);
   }
}
```

This is similar to the static `$builder` and `$collectionClass` properties on a model. Those properties respectively allow you to set a custom Eloquent Builder class and an Eloquent Collection class.