### PR TITLE
Add clear-cache option to the Flush command

### DIFF
--- a/src/Console/FlushCommand.php
+++ b/src/Console/FlushCommand.php
@@ -31,7 +31,7 @@ class FlushCommand extends Command
     {
         $class = $this->argument('model');
         $clearCache = $this->option('clear-cache');
-        
+
         $model = new $class;
 
         $model::removeAllFromSearch();

--- a/src/Console/FlushCommand.php
+++ b/src/Console/FlushCommand.php
@@ -13,7 +13,7 @@ class FlushCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'scout:flush {model : Class name of the model to flush}';
+    protected $signature = 'scout:flush {model : Class name of the model to flush} {--clear-cache : Clear the cache after flushing the model}';
 
     /**
      * The console command description.
@@ -36,5 +36,10 @@ class FlushCommand extends Command
         $model::removeAllFromSearch();
 
         $this->info('All ['.$class.'] records have been flushed.');
+
+        if ($clearCache) {
+            $this->call('cache:clear');
+            $this->info('Cache cleared successfully.');
+        }
     }
 }

--- a/src/Console/FlushCommand.php
+++ b/src/Console/FlushCommand.php
@@ -20,7 +20,7 @@ class FlushCommand extends Command
      *
      * @var string
      */
-    protected $description = "Flush all of the model's records from the index";
+    protected $description = "Flush all of the model's records from the index and optionally, clear cache";
 
     /**
      * Execute the console command.
@@ -30,7 +30,8 @@ class FlushCommand extends Command
     public function handle()
     {
         $class = $this->argument('model');
-
+        $clearCache = $this->option('clear-cache');
+        
         $model = new $class;
 
         $model::removeAllFromSearch();


### PR DESCRIPTION
The flush command currently only removes the saved records from the database (or whatever data storage is used), it does not 'flush' records in the cache. As the name suggests, flush should remove the record from the db, and clear cache (probably more of a personal opinion - but since it's not flush-from-storage, it's just flush). 

This is useful because (from my work experience), after flushing records, I always clear cache. And it'll be useful to just have that option along side the flush command. I'm not entirely sure how many people do the same, but i would personally find this useful.

Hopefully someone agrees. 

it's a simple addition to the codebase, and i hope this explanation above is sufficient, otherwise, please let me know if there are any feedback/questions regarding this.

**Fingers crossed**