### PR TITLE
[Typesense] Fix Paginate Function Returning Limited Records in Laravel Scout with Typesense Engine (#824)

### DIFF
--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -205,8 +205,6 @@ class TypesenseEngine extends Engine
      */
     public function paginate(Builder $builder, $perPage, $page)
     {
-        $builder->take($builder->limit ?? $perPage);
-
         return $this->performSearch(
             $builder,
             $this->buildSearchParameters($builder, $page, $perPage)


### PR DESCRIPTION
This pull request addresses an issue where the paginate function in Laravel Scout with the Typesense engine always returns a number of records limited to the perPage value, rather than reflecting the actual total number of matches from the Typesense server. This behavior was traced back to the limit attribute being set to the perPage value, which restricted the number of records returned. (#824)

## Changes Made:

* Removed the assignment of the `perPage` value to the limit attribute in the `TypesenseEngine` class to allow the pagination to reflect the actual total number of matches.

## Rationale:

The current behavior prevents users from receiving all the results they expect based on the actual total number of matches on the Typesense server. By removing the forced assignment of the `perPage` value to the `limit` attribute, we allow the pagination to work correctly, returning the correct number of records.