### PR TITLE
Add Support for Algolia V4 - Breaking Change

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,16 +16,16 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['8.0', 8.1, 8.2, 8.3]
+        php: [8.0, 8.1, 8.2, 8.3]
         laravel: [9, 10, 11]
         exclude:
-          - php: '8.0'
+          - php: 8.0
             laravel: 9
-          - php: '8.0'
+          - php: 8.0
             laravel: 10
-          - php: '8.0'
+          - php: 8.0
             laravel: 11
-          - php: '8.1'
+          - php: 8.1
             laravel: 11
           - php: 8.3
             laravel: 9
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['8.0', 8.1, 8.2, 8.3]
+        php: [8.0, 8.1, 8.2, 8.3]
 
     name: PHP ${{ matrix.php }} using Meilisearch
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,15 +16,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.0, 8.1, 8.2, 8.3]
+        php: [8.1, 8.2, 8.3]
         laravel: [9, 10, 11]
         exclude:
-          - php: 8.0
-            laravel: 9
-          - php: 8.0
-            laravel: 10
-          - php: 8.0
-            laravel: 11
           - php: 8.1
             laravel: 11
           - php: 8.3

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/console": "^6.0|^7.0"
     },
     "require-dev": {
-        "algolia/algoliasearch-client-php": "^3.2",
+        "algolia/algoliasearch-client-php": "^4.3",
         "typesense/typesense-php": "^4.9.3",
         "meilisearch/meilisearch-php": "^1.0",
         "mockery/mockery": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "illuminate/bus": "^9.0|^10.0|^11.0",
         "illuminate/contracts": "^9.0|^10.0|^11.0",
         "illuminate/database": "^9.0|^10.0|^11.0",

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -39,7 +39,7 @@ class EngineManager extends Manager
     {
         $this->ensureAlgoliaClientIsInstalled();
 
-        UserAgent::addCustomUserAgent('Laravel Scout', Scout::VERSION);
+        AlgoliaAgent::addAlgoliaAgent('Laravel Scout', 'Laravel Scout', Scout::VERSION);
 
         $config = SearchConfig::create(
             config('scout.algolia.id'),

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -4,7 +4,7 @@ namespace Laravel\Scout;
 
 use Algolia\AlgoliaSearch\Config\SearchConfig;
 use Algolia\AlgoliaSearch\Api\SearchClient as Algolia;
-use Algolia\AlgoliaSearch\Support\UserAgent;
+use Algolia\AlgoliaSearch\Support\AlgoliaAgent;
 use Exception;
 use Illuminate\Support\Manager;
 use Laravel\Scout\Engines\AlgoliaEngine;

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -2,8 +2,8 @@
 
 namespace Laravel\Scout;
 
-use Algolia\AlgoliaSearch\Configuration\SearchConfig;
 use Algolia\AlgoliaSearch\Api\SearchClient as Algolia;
+use Algolia\AlgoliaSearch\Configuration\SearchConfig;
 use Algolia\AlgoliaSearch\Support\AlgoliaAgent;
 use Exception;
 use Illuminate\Support\Manager;

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -3,7 +3,7 @@
 namespace Laravel\Scout;
 
 use Algolia\AlgoliaSearch\Config\SearchConfig;
-use Algolia\AlgoliaSearch\SearchClient as Algolia;
+use Algolia\AlgoliaSearch\Api\SearchClient as Algolia;
 use Algolia\AlgoliaSearch\Support\UserAgent;
 use Exception;
 use Illuminate\Support\Manager;

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Scout;
 
-use Algolia\AlgoliaSearch\Config\SearchConfig;
+use Algolia\AlgoliaSearch\Configuration\SearchConfig;
 use Algolia\AlgoliaSearch\Api\SearchClient as Algolia;
 use Algolia\AlgoliaSearch\Support\AlgoliaAgent;
 use Exception;

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Scout\Engines;
 
-use Algolia\AlgoliaSearch\SearchClient as Algolia;
+use Algolia\AlgoliaSearch\Api\SearchClient as Algolia;
 use Exception;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\LazyCollection;
@@ -14,7 +14,7 @@ class AlgoliaEngine extends Engine
     /**
      * The Algolia client.
      *
-     * @var \Algolia\AlgoliaSearch\SearchClient
+     * @var \Algolia\AlgoliaSearch\Api\SearchClient
      */
     protected $algolia;
 
@@ -28,7 +28,7 @@ class AlgoliaEngine extends Engine
     /**
      * Create a new engine instance.
      *
-     * @param  \Algolia\AlgoliaSearch\SearchClient  $algolia
+     * @param  \Algolia\AlgoliaSearch\Api\SearchClient  $algolia
      * @param  bool  $softDelete
      * @return void
      */

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -70,7 +70,7 @@ class AlgoliaEngine extends Engine
             );
         })->filter()->values()->all();
 
-        if (!empty($objects)) {
+        if (! empty($objects)) {
             $this->algolia->saveObjects($indexName, $objects);
         }
     }

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -52,7 +52,7 @@ class AlgoliaEngine extends Engine
             return;
         }
 
-        $index = $this->algolia->initIndex($models->first()->indexableAs());
+        $indexName = $models->first()->indexableAs();
 
         if ($this->usesSoftDelete($models->first()) && $this->softDelete) {
             $models->each->pushSoftDeleteMetadata();
@@ -60,18 +60,18 @@ class AlgoliaEngine extends Engine
 
         $objects = $models->map(function ($model) {
             if (empty($searchableData = $model->toSearchableArray())) {
-                return;
+                return null;
             }
 
             return array_merge(
                 $searchableData,
                 $model->scoutMetadata(),
-                ['objectID' => $model->getScoutKey()],
+                ['objectID' => $model->getScoutKey()]
             );
         })->filter()->values()->all();
 
-        if (! empty($objects)) {
-            $index->saveObjects($objects);
+        if (!empty($objects)) {
+            $this->algolia->saveObjects($indexName, $objects);
         }
     }
 
@@ -87,13 +87,13 @@ class AlgoliaEngine extends Engine
             return;
         }
 
-        $index = $this->algolia->initIndex($models->first()->indexableAs());
+        $indexName = $models->first()->indexableAs();
 
         $keys = $models instanceof RemoveableScoutCollection
             ? $models->pluck($models->first()->getScoutKeyName())
             : $models->map->getScoutKey();
 
-        $index->deleteObjects($keys->all());
+        $this->algolia->deleteObjects($indexName, $keys->all());
     }
 
     /**
@@ -136,22 +136,20 @@ class AlgoliaEngine extends Engine
      */
     protected function performSearch(Builder $builder, array $options = [])
     {
-        $algolia = $this->algolia->initIndex(
-            $builder->index ?: $builder->model->searchableAs()
-        );
+        $indexName = $builder->index ?: $builder->model->searchableAs();
 
         $options = array_merge($builder->options, $options);
 
         if ($builder->callback) {
             return call_user_func(
                 $builder->callback,
-                $algolia,
+                $this->algolia,
                 $builder->query,
                 $options
             );
         }
 
-        return $algolia->search($builder->query, $options);
+        return $this->algolia->searchSingleIndex($indexName, array_merge(['query' => $builder->query], $options));
     }
 
     /**
@@ -280,9 +278,9 @@ class AlgoliaEngine extends Engine
      */
     public function flush($model)
     {
-        $index = $this->algolia->initIndex($model->indexableAs());
+        $indexName = $model->indexableAs();
 
-        $index->clearObjects();
+        $this->algolia->clearObjects($indexName);
     }
 
     /**
@@ -307,7 +305,7 @@ class AlgoliaEngine extends Engine
      */
     public function deleteIndex($name)
     {
-        return $this->algolia->initIndex($name)->delete();
+        return $this->algolia->deleteIndex($name);
     }
 
     /**

--- a/tests/Unit/AlgoliaEngineTest.php
+++ b/tests/Unit/AlgoliaEngineTest.php
@@ -35,8 +35,7 @@ class AlgoliaEngineTest extends TestCase
     public function test_update_adds_objects_to_index()
     {
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => ''])->andReturn($index = m::mock(stdClass::class));
-        $index->shouldReceive('saveObjects')->with([[
+        $client->shouldReceive('saveObjects')->with('table', [[
             'id' => 1,
             'objectID' => 1,
         ]]);
@@ -48,8 +47,7 @@ class AlgoliaEngineTest extends TestCase
     public function test_delete_removes_objects_to_index()
     {
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => ''])->andReturn($index = m::mock(stdClass::class));
-        $index->shouldReceive('deleteObjects')->with([1]);
+        $client->shouldReceive('deleteObjects')->with('table', [1]);
 
         $engine = new AlgoliaEngine($client);
         $engine->delete(Collection::make([new SearchableModel(['id' => 1])]));
@@ -58,8 +56,7 @@ class AlgoliaEngineTest extends TestCase
     public function test_delete_removes_objects_to_index_with_a_custom_search_key()
     {
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => ''])->andReturn($index = m::mock(Indexes::class));
-        $index->shouldReceive('deleteObjects')->once()->with(['my-algolia-key.5']);
+        $client->shouldReceive('deleteObjects')->once()->with('table', ['my-algolia-key.5']);
 
         $engine = new AlgoliaEngine($client);
         $engine->delete(Collection::make([new AlgoliaCustomKeySearchableModel(['id' => 5])]));
@@ -74,8 +71,7 @@ class AlgoliaEngineTest extends TestCase
         $job = unserialize(serialize($job));
 
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => ''])->andReturn($index = m::mock(stdClass::class));
-        $index->shouldReceive('deleteObjects')->once()->with(['my-algolia-key.5']);
+        $client->shouldReceive('deleteObjects')->once()->with('table', ['my-algolia-key.5']);
 
         $engine = new AlgoliaEngine($client);
         $engine->delete($job->models);
@@ -111,7 +107,10 @@ class AlgoliaEngineTest extends TestCase
     public function test_search_sends_correct_parameters_to_algolia()
     {
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => 'zonda', 'numericFilters' => ['foo=1']])->andReturn($index = m::mock(stdClass::class));
+        $client->shouldReceive('searchSingleIndex')->with('table', [
+            'query' => 'zonda',
+            'numericFilters' => ['foo=1'],
+        ]);
 
         $engine = new AlgoliaEngine($client);
         $builder = new Builder(new SearchableModel, 'zonda');
@@ -122,7 +121,10 @@ class AlgoliaEngineTest extends TestCase
     public function test_search_sends_correct_parameters_to_algolia_for_where_in_search()
     {
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => 'zonda', 'numericFilters' => ['foo=1', ['bar=1', 'bar=2']]])->andReturn($index = m::mock(stdClass::class));
+        $client->shouldReceive('searchSingleIndex')->with('table', [
+            'query' => 'zonda',
+            'numericFilters' => ['foo=1', ['bar=1', 'bar=2']],
+        ]);
 
         $engine = new AlgoliaEngine($client);
         $builder = new Builder(new SearchableModel, 'zonda');
@@ -133,7 +135,10 @@ class AlgoliaEngineTest extends TestCase
     public function test_search_sends_correct_parameters_to_algolia_for_empty_where_in_search()
     {
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => 'zonda', 'numericFilters' => ['foo=1', '0=1']])->andReturn($index = m::mock(stdClass::class));
+        $client->shouldReceive('searchSingleIndex')->with('table', [
+            'query' => 'zonda',
+            'numericFilters' => ['foo=1', '0=1'],
+        ]);
 
         $engine = new AlgoliaEngine($client);
         $builder = new Builder(new SearchableModel, 'zonda');
@@ -258,8 +263,7 @@ class AlgoliaEngineTest extends TestCase
     public function test_a_model_is_indexed_with_a_custom_algolia_key()
     {
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => ''])->andReturn($index = m::mock(stdClass::class));
-        $index->shouldReceive('saveObjects')->with([[
+        $client->shouldReceive('saveObjects')->with('table', [[
             'id' => 1,
             'objectID' => 'my-algolia-key.1',
         ]]);
@@ -271,8 +275,7 @@ class AlgoliaEngineTest extends TestCase
     public function test_a_model_is_removed_with_a_custom_algolia_key()
     {
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => ''])->andReturn($index = m::mock(stdClass::class));
-        $index->shouldReceive('deleteObjects')->with(['my-algolia-key.1']);
+        $client->shouldReceive('deleteObjects')->with('table', ['my-algolia-key.1']);
 
         $engine = new AlgoliaEngine($client);
         $engine->delete(Collection::make([new AlgoliaCustomKeySearchableModel(['id' => 1])]));
@@ -281,8 +284,7 @@ class AlgoliaEngineTest extends TestCase
     public function test_flush_a_model_with_a_custom_algolia_key()
     {
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => ''])->andReturn($index = m::mock(stdClass::class));
-        $index->shouldReceive('clearObjects');
+        $client->shouldReceive('clearObjects')->with('table');
 
         $engine = new AlgoliaEngine($client);
         $engine->flush(new AlgoliaCustomKeySearchableModel);
@@ -291,8 +293,7 @@ class AlgoliaEngineTest extends TestCase
     public function test_update_empty_searchable_array_does_not_add_objects_to_index()
     {
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => ''])->andReturn($index = m::mock(stdClass::class));
-        $index->shouldNotReceive('saveObjects');
+        $client->shouldNotReceive('saveObjects');
 
         $engine = new AlgoliaEngine($client);
         $engine->update(Collection::make([new EmptySearchableModel]));
@@ -301,8 +302,7 @@ class AlgoliaEngineTest extends TestCase
     public function test_update_empty_searchable_array_from_soft_deleted_model_does_not_add_objects_to_index()
     {
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => ''])->andReturn($index = m::mock('StdClass'));
-        $index->shouldNotReceive('saveObjects');
+        $client->shouldNotReceive('saveObjects');
 
         $engine = new AlgoliaEngine($client, true);
         $engine->update(Collection::make([new SoftDeletedEmptySearchableModel]));

--- a/tests/Unit/AlgoliaEngineTest.php
+++ b/tests/Unit/AlgoliaEngineTest.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Scout\Tests\Unit;
 
-use Algolia\AlgoliaSearch\SearchClient;
+use Algolia\AlgoliaSearch\Api\SearchClient;
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Config;
@@ -35,7 +35,7 @@ class AlgoliaEngineTest extends TestCase
     public function test_update_adds_objects_to_index()
     {
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('initIndex')->with('table')->andReturn($index = m::mock(stdClass::class));
+        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => ''])->andReturn($index = m::mock(stdClass::class));
         $index->shouldReceive('saveObjects')->with([[
             'id' => 1,
             'objectID' => 1,
@@ -48,7 +48,7 @@ class AlgoliaEngineTest extends TestCase
     public function test_delete_removes_objects_to_index()
     {
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('initIndex')->with('table')->andReturn($index = m::mock(stdClass::class));
+        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => ''])->andReturn($index = m::mock(stdClass::class));
         $index->shouldReceive('deleteObjects')->with([1]);
 
         $engine = new AlgoliaEngine($client);
@@ -58,7 +58,7 @@ class AlgoliaEngineTest extends TestCase
     public function test_delete_removes_objects_to_index_with_a_custom_search_key()
     {
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('initIndex')->with('table')->andReturn($index = m::mock(Indexes::class));
+        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => ''])->andReturn($index = m::mock(Indexes::class));
         $index->shouldReceive('deleteObjects')->once()->with(['my-algolia-key.5']);
 
         $engine = new AlgoliaEngine($client);
@@ -74,7 +74,7 @@ class AlgoliaEngineTest extends TestCase
         $job = unserialize(serialize($job));
 
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('initIndex')->with('table')->andReturn($index = m::mock(stdClass::class));
+        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => ''])->andReturn($index = m::mock(stdClass::class));
         $index->shouldReceive('deleteObjects')->once()->with(['my-algolia-key.5']);
 
         $engine = new AlgoliaEngine($client);
@@ -111,10 +111,7 @@ class AlgoliaEngineTest extends TestCase
     public function test_search_sends_correct_parameters_to_algolia()
     {
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('initIndex')->with('table')->andReturn($index = m::mock(stdClass::class));
-        $index->shouldReceive('search')->with('zonda', [
-            'numericFilters' => ['foo=1'],
-        ]);
+        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => 'zonda', 'numericFilters' => ['foo=1']])->andReturn($index = m::mock(stdClass::class));
 
         $engine = new AlgoliaEngine($client);
         $builder = new Builder(new SearchableModel, 'zonda');
@@ -125,10 +122,7 @@ class AlgoliaEngineTest extends TestCase
     public function test_search_sends_correct_parameters_to_algolia_for_where_in_search()
     {
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('initIndex')->with('table')->andReturn($index = m::mock(stdClass::class));
-        $index->shouldReceive('search')->with('zonda', [
-            'numericFilters' => ['foo=1', ['bar=1', 'bar=2']],
-        ]);
+        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => 'zonda', 'numericFilters' => ['foo=1', ['bar=1', 'bar=2']]])->andReturn($index = m::mock(stdClass::class));
 
         $engine = new AlgoliaEngine($client);
         $builder = new Builder(new SearchableModel, 'zonda');
@@ -139,10 +133,7 @@ class AlgoliaEngineTest extends TestCase
     public function test_search_sends_correct_parameters_to_algolia_for_empty_where_in_search()
     {
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('initIndex')->with('table')->andReturn($index = m::mock(stdClass::class));
-        $index->shouldReceive('search')->with('zonda', [
-            'numericFilters' => ['foo=1', '0=1'],
-        ]);
+        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => 'zonda', 'numericFilters' => ['foo=1', '0=1']])->andReturn($index = m::mock(stdClass::class));
 
         $engine = new AlgoliaEngine($client);
         $builder = new Builder(new SearchableModel, 'zonda');
@@ -267,7 +258,7 @@ class AlgoliaEngineTest extends TestCase
     public function test_a_model_is_indexed_with_a_custom_algolia_key()
     {
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('initIndex')->with('table')->andReturn($index = m::mock(stdClass::class));
+        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => ''])->andReturn($index = m::mock(stdClass::class));
         $index->shouldReceive('saveObjects')->with([[
             'id' => 1,
             'objectID' => 'my-algolia-key.1',
@@ -280,7 +271,7 @@ class AlgoliaEngineTest extends TestCase
     public function test_a_model_is_removed_with_a_custom_algolia_key()
     {
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('initIndex')->with('table')->andReturn($index = m::mock(stdClass::class));
+        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => ''])->andReturn($index = m::mock(stdClass::class));
         $index->shouldReceive('deleteObjects')->with(['my-algolia-key.1']);
 
         $engine = new AlgoliaEngine($client);
@@ -290,7 +281,7 @@ class AlgoliaEngineTest extends TestCase
     public function test_flush_a_model_with_a_custom_algolia_key()
     {
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('initIndex')->with('table')->andReturn($index = m::mock(stdClass::class));
+        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => ''])->andReturn($index = m::mock(stdClass::class));
         $index->shouldReceive('clearObjects');
 
         $engine = new AlgoliaEngine($client);
@@ -300,7 +291,7 @@ class AlgoliaEngineTest extends TestCase
     public function test_update_empty_searchable_array_does_not_add_objects_to_index()
     {
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('initIndex')->with('table')->andReturn($index = m::mock(stdClass::class));
+        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => ''])->andReturn($index = m::mock(stdClass::class));
         $index->shouldNotReceive('saveObjects');
 
         $engine = new AlgoliaEngine($client);
@@ -310,7 +301,7 @@ class AlgoliaEngineTest extends TestCase
     public function test_update_empty_searchable_array_from_soft_deleted_model_does_not_add_objects_to_index()
     {
         $client = m::mock(SearchClient::class);
-        $client->shouldReceive('initIndex')->with('table')->andReturn($index = m::mock('StdClass'));
+        $client->shouldReceive('searchSingleIndex')->with('table', ['query' => ''])->andReturn($index = m::mock('StdClass'));
         $index->shouldNotReceive('saveObjects');
 
         $engine = new AlgoliaEngine($client, true);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This pull request updates the Laravel Scout package to support Algolia V4. This update addresses the lack of compatibility with Algolia V4, as discussed in [Issue #855](https://github.com/laravel/scout/issues/855).

**Key Changes:**
- Added support for Algolia V4.
- Removed support for Algolia V3, making this a breaking change.
- Removed support for PHP 8.0 as Algolia V4 requires php 8.1

This guide helped with the upgrade: [Algolia V4 Upgrade Guide](https://www.algolia.com/doc/libraries/php/v4/upgrade/).


Please review the following:
1. I'll leave it up to you whether this should be merged, considering the breaking change that removes Algolia V3 compatibility and introduces a PHP 8.1 requirement.
2. I'm not sure why the Meilisearch checks are failing, as this update shouldn't have affected them. It looks like they are just timing out 🤷 
3. I've had this running in production for two days without issue.
