### PR TITLE
feat(typesense): add 'infix' option to search parameters

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -184,6 +184,7 @@ return [
             //             [
             //                 'name' => 'name',
             //                 'type' => 'string',
+            //                 'infix' => true,
             //             ],
             //             [
             //                 'name' => 'created_at',
@@ -193,7 +194,8 @@ return [
             //         'default_sorting_field' => 'created_at',
             //     ],
             //     'search-parameters' => [
-            //         'query_by' => 'name'
+            //         'query_by' => 'name',
+            //         'infix' => 'allways',
             //     ],
             // ],
         ],

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -247,7 +247,7 @@ class TypesenseEngine extends Engine
         $parameters = [
             'q' => $builder->query,
             'query_by' => config('scout.typesense.model-settings.'.get_class($builder->model).'.search-parameters.query_by') ?? '',
-            'infix' => config('scout.typesense.model-settings.'.get_class($builder->model).'.search-parameters.infix') ?? '',
+            'infix' => config('scout.typesense.model-settings.'.get_class($builder->model).'.search-parameters.infix') ?? null,
             'filter_by' => $this->filters($builder),
             'per_page' => $perPage,
             'page' => $page,

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -247,6 +247,7 @@ class TypesenseEngine extends Engine
         $parameters = [
             'q' => $builder->query,
             'query_by' => config('scout.typesense.model-settings.'.get_class($builder->model).'.search-parameters.query_by') ?? '',
+            'infix' => config('scout.typesense.model-settings.'.get_class($builder->model).'.search-parameters.infix') ?? '',
             'filter_by' => $this->filters($builder),
             'per_page' => $perPage,
             'page' => $page,


### PR DESCRIPTION
This PR adds the infix option to the Typesense search parameters in Laravel Scout.

The Infix Search option allows users to perform more flexible searches by matching substrings in the middle of words. This provides greater accuracy and control over search results, especially when dealing with partial matches. It improves the search experience in applications where infix matching is critical, such as autocomplete features or when searching for terms that may not be at the beginning or end of a string.