### PR TITLE
 Fix Typesense pagination issue when using query callback

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -173,6 +173,7 @@ return [
             'num_retries' => env('TYPESENSE_NUM_RETRIES', 3),
             'retry_interval_seconds' => env('TYPESENSE_RETRY_INTERVAL_SECONDS', 1),
         ],
+        // 'max_total_results' => env('TYPESENSE_MAX_TOTAL_RESULTS', 1000),
         'model-settings' => [
             // User::class => [
             //     'collection-schema' => [

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -153,9 +153,10 @@ class EngineManager extends Manager
      */
     public function createTypesenseDriver()
     {
+        $config = config('scout.typesense');
         $this->ensureTypesenseClientIsInstalled();
 
-        return new TypesenseEngine(new Typesense(config('scout.typesense.client-settings')));
+        return new TypesenseEngine(new Typesense($config['client-settings']), $config['max_total_results'] ?? 1000);
     }
 
     /**

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -48,9 +48,10 @@ class TypesenseEngine extends Engine
      *
      * @param  Typesense  $typesense
      */
-    public function __construct(Typesense $typesense)
+    public function __construct(Typesense $typesense, int $maxTotalResults)
     {
         $this->typesense = $typesense;
+        $this->maxTotalResults = $maxTotalResults;
     }
 
     /**

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -36,7 +36,6 @@ class TypesenseEngine extends Engine
      */
     protected array $searchParameters = [];
 
-
     /**
      * The maximum amount of results that can be fetched for pagination.
      *
@@ -216,7 +215,7 @@ class TypesenseEngine extends Engine
     /**
      * Perform a paginated search on the engine.
      *
-     * @param \Laravel\Scout\Builder $builder
+     * @param  \Laravel\Scout\Builder  $builder
      * @return mixed
      *
      * @throws \Http\Client\Exception
@@ -256,7 +255,6 @@ class TypesenseEngine extends Engine
             'request_params' => $this->buildSearchParameters($builder, 1, $builder->limit ?? $this->maxPerPage),
         ];
     }
-
 
     /**
      * Perform the given search on the engine with pagination.

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -17,6 +17,7 @@ class TypesenseEngine extends Engine
 {
     /**
      * The maximum amount of results that can be fetched per page.
+     *
      * @var int
      */
     private int $maxPerPage = 250;
@@ -37,8 +38,8 @@ class TypesenseEngine extends Engine
 
 
     /**
-     *
      * The maximum amount of results that can be fetched for pagination.
+     *
      * @var int
      */
     protected int $maxTotalResults;
@@ -214,6 +215,7 @@ class TypesenseEngine extends Engine
 
     /**
      * Perform a paginated search on the engine.
+     *
      * @param \Laravel\Scout\Builder $builder
      * @return mixed
      *

--- a/tests/Integration/SearchableTests.php
+++ b/tests/Integration/SearchableTests.php
@@ -107,7 +107,8 @@ trait SearchableTests
 
     protected function itCanUsePaginatedSearchWithEmptyQueryCallback()
     {
-        $queryCallback = function ($query) {};
+        $queryCallback = function ($query) {
+        };
 
         return User::search('*')->query($queryCallback)->paginate();
     }

--- a/tests/Integration/SearchableTests.php
+++ b/tests/Integration/SearchableTests.php
@@ -104,4 +104,11 @@ trait SearchableTests
             User::search('lar')->take(10)->query($queryCallback)->paginate(5, 'page', 2),
         ];
     }
+
+    protected function itCanUsePaginatedSearchWithEmptyQueryCallback()
+    {
+        $queryCallback = function ($query) {};
+
+        return User::search('*')->query($queryCallback)->paginate();
+    }
 }

--- a/tests/Integration/TypesenseSearchableTest.php
+++ b/tests/Integration/TypesenseSearchableTest.php
@@ -164,6 +164,14 @@ class TypesenseSearchableTest extends TestCase
         ], $page2->pluck('name', 'id')->all());
     }
 
+    public function test_it_can_usePaginatedSearchWithEmptyQueryCallback()
+    {
+        $res = $this->itCanUsePaginatedSearchWithEmptyQueryCallback();
+
+        $this->assertSame($res->total(), 44);
+        $this->assertSame($res->lastPage(), 3);
+    }
+
     protected static function scoutDriver(): string
     {
         return 'typesense';

--- a/tests/Unit/TypesenseEngineTest.php
+++ b/tests/Unit/TypesenseEngineTest.php
@@ -27,7 +27,7 @@ class TypesenseEngineTest extends TestCase
         // Mock the Typesense client and pass it to the engine constructor
         $typesenseClient = $this->createMock(TypesenseClient::class);
         $this->engine = $this->getMockBuilder(TypesenseEngine::class)
-            ->setConstructorArgs([$typesenseClient])
+            ->setConstructorArgs([$typesenseClient, 1000])
             ->onlyMethods(['getOrCreateCollectionFromModel', 'buildSearchParameters'])
             ->getMock();
     }


### PR DESCRIPTION
# Rationale

This pull request addresses a regression introduced in PR #858 that affects Typesense pagination when using query callbacks. The current implementation causes an error (#865) when the resulting query matches more than 250 results (Typesense's limit).

The motivation for these changes is to:
- Restore the ability to use query callbacks with Typesense without encountering pagination limitations.
- Optimize the handling of large result sets to prevent performance degradation.
- Maintain consistency with Typesense's limitation of 250 results per page while allowing for efficient pagination of larger datasets.
- Maintain consistency with other scout engines defaulting to a maximum of 1000 results by default, when using the `paginate` function.

# Changes

## Code Changes:

1. **In `src/Engines/TypesenseEngine.php`**:
   - Modified `search()` method to properly handle the `per_page` parameter  set by the builder when using query callbacks, specifically on the `getTotalCount` method.
   - Implemented `performPaginatedSearch()` to respect the explicitly set pagination limit.

2. **In `src/EngineManager.php`**:
   - Adjusted `createTypesenseDriver()` to ensure compatibility with the updated TypesenseEngine.

## Added Features:

1. **New Test in `tests/Integration/TypesenseSearchableTest.php`**:
   - Added `test_it_can_paginate_with_query_callback_and_custom_limit()`: Verifies that pagination works correctly with query callbacks and custom limits.

## Documentation Updates:

1. **In `config/scout.php`**:
   - Updated comments for Typesense configuration to clarify pagination behavior.

These changes restore the functionality that was working prior to MR #858 and ensure that Typesense pagination works correctly when using query callbacks, particularly for eager loading relations.

The fix allows developers to use code like this without encountering the "Only up to 250 hits can be fetched per page" error:

```php
$results = Names::search($keyword)
    ->options([
        'filter_by' => $filterString,
        'sort_by' => $sortBy,
    ])
    ->query(fn (Builder $query) => $query->with('someRelation'))
    ->paginate(48);
```

This removes the need to explicitly set a limit for the builder, while ensuring that the correct amount of results will be returned by the `getTotalAmount` function, as previously it would only get the limit set by the `paginate` function.