### PR TITLE
fix(typesense): properly format boolean filters in Typesense

### DIFF
--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -372,7 +372,7 @@ class TypesenseEngine extends Engine
     /**
      * Parse the given filter value.
      *
-     * @param array|string|bool|int|float $value
+     * @param  array|string|bool|int|float  $value
      * @return array|bool|float|int|string
      */
     protected function parseFilterValue(array|string|bool|int|float $value)

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -355,18 +355,37 @@ class TypesenseEngine extends Engine
     protected function filters(Builder $builder): string
     {
         $whereFilter = collect($builder->wheres)
-            ->map(fn ($value, $key) => $this->parseWhereFilter($value, $key))
+            ->map(fn ($value, $key) => $this->parseWhereFilter($this->parseFilterValue($value), $key))
             ->values()
             ->implode(' && ');
 
         $whereInFilter = collect($builder->whereIns)
-            ->map(fn ($value, $key) => $this->parseWhereInFilter($value, $key))
+            ->map(fn ($value, $key) => $this->parseWhereInFilter($this->parseFilterValue($value), $key))
             ->values()
             ->implode(' && ');
 
         return $whereFilter.(
             ($whereFilter !== '' && $whereInFilter !== '') ? ' && ' : ''
         ).$whereInFilter;
+    }
+
+    /**
+     * Parse the given filter value.
+     *
+     * @param array|string|bool|int|float $value
+     * @return array|bool|float|int|string
+     */
+    protected function parseFilterValue(array|string|bool|int|float $value)
+    {
+        if (is_array($value)) {
+            return array_map([$this, 'parseFilterValue'], $value);
+        }
+
+        if (gettype($value) == 'boolean') {
+            return $value ? 'true' : 'false';
+        }
+
+        return $value;
     }
 
     /**
@@ -379,7 +398,7 @@ class TypesenseEngine extends Engine
     protected function parseWhereFilter(array|string $value, string $key): string
     {
         return is_array($value)
-            ? sprintf('%s:%s', $key, implode('', $value))
+            ? sprintf('%s:[%s]', $key, implode(',', $value))
             : sprintf('%s:=%s', $key, $value);
     }
 
@@ -392,7 +411,7 @@ class TypesenseEngine extends Engine
      */
     protected function parseWhereInFilter(array $value, string $key): string
     {
-        return sprintf('%s:=%s', $key, '['.implode(', ', $value).']');
+        return sprintf('%s:=[%s]', $key, implode(', ', $value));
     }
 
     /**

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -398,7 +398,7 @@ class TypesenseEngine extends Engine
     protected function parseWhereFilter(array|string $value, string $key): string
     {
         return is_array($value)
-            ? sprintf('%s:[%s]', $key, implode(',', $value))
+            ? sprintf('%s:%s', $key, implode('', $value))
             : sprintf('%s:=%s', $key, $value);
     }
 

--- a/tests/Unit/TypesenseEngineTest.php
+++ b/tests/Unit/TypesenseEngineTest.php
@@ -38,6 +38,71 @@ class TypesenseEngineTest extends TestCase
         m::close();
     }
 
+    /**
+     * Call protected/private method of a class.
+     *
+     * @param  object  &$object  Instantiated object that we will run method on.
+     * @param  string  $methodName  Method name to call
+     * @param  array  $parameters  Array of parameters to pass into method.
+     * @return mixed Method return.
+     */
+    public function invokeMethod(&$object, $methodName, array $parameters = [])
+    {
+        $reflection = new \ReflectionClass(get_class($object));
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $parameters);
+    }
+
+    public function test_filters_method()
+    {
+        $builder = m::mock(Builder::class);
+        $builder->wheres = [
+            'status' => 'active',
+            'age' => 25,
+        ];
+        $builder->whereIns = [
+            'category' => ['electronics', 'books'],
+        ];
+
+        $result = $this->invokeMethod($this->engine, 'filters', [$builder]);
+
+        $expected = 'status:=active && age:=25 && category:=[electronics, books]';
+        $this->assertEquals($expected, $result);
+    }
+
+    public function test_parse_filter_value_method()
+    {
+
+        $this->assertEquals('true', $this->invokeMethod($this->engine, 'parseFilterValue', [true]));
+        $this->assertEquals('false', $this->invokeMethod($this->engine, 'parseFilterValue', [false]));
+        $this->assertEquals('25', $this->invokeMethod($this->engine, 'parseFilterValue', [25]));
+        $this->assertEquals('3.14', $this->invokeMethod($this->engine, 'parseFilterValue', [3.14]));
+        $this->assertEquals('test', $this->invokeMethod($this->engine, 'parseFilterValue', ['test']));
+        $this->assertEquals('test "quoted"', $this->invokeMethod($this->engine, 'parseFilterValue', ['test "quoted"']));
+        $this->assertEquals('`special value`', $this->invokeMethod($this->engine, 'parseFilterValue', ['`special value`']));
+
+        $nestedArray = ['a', ['b', 'c'], 'd'];
+        $expectedNested = ['a', ['b', 'c'], 'd'];
+        $this->assertEquals($expectedNested, $this->invokeMethod($this->engine, 'parseFilterValue', [$nestedArray]));
+    }
+
+    public function test_parse_where_filter_method()
+    {
+
+        $this->assertEquals('status:=active', $this->invokeMethod($this->engine, 'parseWhereFilter', ['active', 'status']));
+        $this->assertEquals('age:=25', $this->invokeMethod($this->engine, 'parseWhereFilter', ['25', 'age']));
+        $this->assertEquals('tags:[tag1,tag2,tag3]', $this->invokeMethod($this->engine, 'parseWhereFilter', [['tag1', 'tag2', 'tag3'], 'tags']));
+    }
+
+    public function test_parse_where_in_filter_method()
+    {
+
+        $this->assertEquals('category:=[electronics, books]', $this->invokeMethod($this->engine, 'parseWhereInFilter', [['electronics', 'books'], 'category']));
+        $this->assertEquals('id:=[1, 2, 3]', $this->invokeMethod($this->engine, 'parseWhereInFilter', [[1, 2, 3], 'id']));
+    }
+
     public function test_update_method(): void
     {
         // Mock models and their methods

--- a/tests/Unit/TypesenseEngineTest.php
+++ b/tests/Unit/TypesenseEngineTest.php
@@ -74,7 +74,6 @@ class TypesenseEngineTest extends TestCase
 
     public function test_parse_filter_value_method()
     {
-
         $this->assertEquals('true', $this->invokeMethod($this->engine, 'parseFilterValue', [true]));
         $this->assertEquals('false', $this->invokeMethod($this->engine, 'parseFilterValue', [false]));
         $this->assertEquals('25', $this->invokeMethod($this->engine, 'parseFilterValue', [25]));
@@ -90,7 +89,6 @@ class TypesenseEngineTest extends TestCase
 
     public function test_parse_where_filter_method()
     {
-
         $this->assertEquals('status:=active', $this->invokeMethod($this->engine, 'parseWhereFilter', ['active', 'status']));
         $this->assertEquals('age:=25', $this->invokeMethod($this->engine, 'parseWhereFilter', ['25', 'age']));
         $this->assertEquals('tags:[tag1,tag2,tag3]', $this->invokeMethod($this->engine, 'parseWhereFilter', [['tag1', 'tag2', 'tag3'], 'tags']));
@@ -98,7 +96,6 @@ class TypesenseEngineTest extends TestCase
 
     public function test_parse_where_in_filter_method()
     {
-
         $this->assertEquals('category:=[electronics, books]', $this->invokeMethod($this->engine, 'parseWhereInFilter', [['electronics', 'books'], 'category']));
         $this->assertEquals('id:=[1, 2, 3]', $this->invokeMethod($this->engine, 'parseWhereInFilter', [[1, 2, 3], 'id']));
     }

--- a/tests/Unit/TypesenseEngineTest.php
+++ b/tests/Unit/TypesenseEngineTest.php
@@ -91,7 +91,7 @@ class TypesenseEngineTest extends TestCase
     {
         $this->assertEquals('status:=active', $this->invokeMethod($this->engine, 'parseWhereFilter', ['active', 'status']));
         $this->assertEquals('age:=25', $this->invokeMethod($this->engine, 'parseWhereFilter', ['25', 'age']));
-        $this->assertEquals('tags:[tag1,tag2,tag3]', $this->invokeMethod($this->engine, 'parseWhereFilter', [['tag1', 'tag2', 'tag3'], 'tags']));
+        $this->assertEquals('tags:tag1tag2tag3', $this->invokeMethod($this->engine, 'parseWhereFilter', [['tag1', 'tag2', 'tag3'], 'tags']));
     }
 
     public function test_parse_where_in_filter_method()


### PR DESCRIPTION
# Rationale
This change addresses an issue where boolean filters were not properly handled in the TypesenseEngine for Laravel Scout. When users attempted to search with a boolean filter (e.g., `Model::search($query)->where('myFilter', true)->get()`), the engine was incorrectly transforming boolean values to integers before passing them to the Typesense SDK. This resulted in a `Typesense\Exceptions\RequestMalformed` exception with the message "Value of filter field myFilter must be true or false."

By implementing this fix, we ensure that boolean filters are correctly formatted and passed to Typesense, allowing users to perform searches with boolean conditions as expected.

# Changes

## Code Changes:
1. **In `src/Engines/TypesenseEngine.php`**:
   - Modified the `filters` method to use a new `parseFilterValue` method when processing `wheres` and `whereIns`.
   - Added a new `parseFilterValue` method to handle various data types, including booleans:
     ```php
     protected function parseFilterValue(array|string|bool|int|float $value)
     {
         if (is_array($value)) {
             return array_map([$this, 'parseFilterValue'], $value);
         }

         if (gettype($value) == 'boolean') {
             return $value ? 'true' : 'false';
         }

         return $value;
     }
     ```
   - Updated `parseWhereInFilter` method to use string interpolation for better readability.

## Test Updates:
1. **In `tests/Unit/TypesenseEngineTest.php`**:
   - Added new test methods to cover the changes:
     - `test_filters_method`: Ensures the `filters` method correctly formats multiple conditions.
     - `test_parse_filter_value_method`: Verifies the new `parseFilterValue` method handles various input types correctly.
     - `test_parse_where_filter_method`: Checks the `parseWhereFilter` method's output for different inputs.
     - `test_parse_where_in_filter_method`: Validates the `parseWhereInFilter` method's formatting.
   - Implemented a helper method `invokeMethod` to test protected methods.

# Context
This change was prompted by #873. @bredmor  encountered a `RequestMalformed` exception when attempting to use boolean filters with Typesense in Laravel Scout. The problem was traced to the `TypesenseEngine::filters()` method, which was not properly handling boolean values.

This fix ensures that boolean values are correctly formatted as strings ('true' or 'false') before being sent to Typesense, resolving the exception and allowing users to successfully perform searches with boolean filters.
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
