### PR TITLE
feat(typesense): add `whereNotIn` filter to typesense engine

### DIFF
--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -364,9 +364,16 @@ class TypesenseEngine extends Engine
             ->values()
             ->implode(' && ');
 
-        return $whereFilter.(
-            ($whereFilter !== '' && $whereInFilter !== '') ? ' && ' : ''
-        ).$whereInFilter;
+        $whereNotInFilter = collect($builder->whereNotIns)
+            ->map(fn ($value, $key) => $this->parseWhereNotInFilter($this->parseFilterValue($value), $key))
+            ->values()
+            ->implode(' && ');
+
+        $filters = collect([$whereFilter, $whereInFilter, $whereNotInFilter])
+            ->filter()
+            ->implode(' && ');
+
+        return $filters;
     }
 
     /**
@@ -412,6 +419,18 @@ class TypesenseEngine extends Engine
     protected function parseWhereInFilter(array $value, string $key): string
     {
         return sprintf('%s:=[%s]', $key, implode(', ', $value));
+    }
+
+    /**
+     * Create a "where not in" filter string.
+     *
+     * @param  array|string  $value
+     * @param  string  $key
+     * @return string
+     */
+    protected function parseWhereNotInFilter(array $value, string $key): string
+    {
+        return sprintf('%s:!=[%s]', $key, implode(', ', $value));
     }
 
     /**

--- a/tests/Unit/TypesenseEngineTest.php
+++ b/tests/Unit/TypesenseEngineTest.php
@@ -65,10 +65,13 @@ class TypesenseEngineTest extends TestCase
         $builder->whereIns = [
             'category' => ['electronics', 'books'],
         ];
+        $builder->whereNotIns = [
+            'category' => ['furniture', 'phones'],
+        ];
 
         $result = $this->invokeMethod($this->engine, 'filters', [$builder]);
 
-        $expected = 'status:=active && age:=25 && category:=[electronics, books]';
+        $expected = 'status:=active && age:=25 && category:=[electronics, books] && category:!=[furniture, phones]';
         $this->assertEquals($expected, $result);
     }
 
@@ -100,6 +103,11 @@ class TypesenseEngineTest extends TestCase
         $this->assertEquals('id:=[1, 2, 3]', $this->invokeMethod($this->engine, 'parseWhereInFilter', [[1, 2, 3], 'id']));
     }
 
+    public function test_parse_where_not_in_filter_metheod()
+    {
+        $this->assertEquals('category:!=[electronics, books]', $this->invokeMethod($this->engine, 'parseWhereNotInFilter', [['electronics', 'books'], 'category']));
+        $this->assertEquals('id:!=[1, 2, 3]', $this->invokeMethod($this->engine, 'parseWhereNotInFilter', [[1, 2, 3], 'id']));
+    }
     public function test_update_method(): void
     {
         // Mock models and their methods

--- a/tests/Unit/TypesenseEngineTest.php
+++ b/tests/Unit/TypesenseEngineTest.php
@@ -108,6 +108,7 @@ class TypesenseEngineTest extends TestCase
         $this->assertEquals('category:!=[electronics, books]', $this->invokeMethod($this->engine, 'parseWhereNotInFilter', [['electronics', 'books'], 'category']));
         $this->assertEquals('id:!=[1, 2, 3]', $this->invokeMethod($this->engine, 'parseWhereNotInFilter', [[1, 2, 3], 'id']));
     }
+
     public function test_update_method(): void
     {
         // Mock models and their methods


### PR DESCRIPTION
## Rationale
Currently, the Typesense driver doesn't process `whereNotIn` constraints in search queries, which limits the ability to exclude specific records from search results. 

For example, when searching for products and wanting to exclude specific categories:
```php
Product::search('laptop')->whereNotIn('category', ['refurbished', 'used'])->get();
```

This enhancement implements the missing `whereNotIn` functionality, allowing users to properly filter out unwanted results from their Typesense searches, making the search experience more flexible and precise.

## Changes

### Added Features:
1. **New Methods in `src/Engines/TypesenseEngine.php`**:
   - `parseWhereNotInFilter()`: Handles the conversion of whereNotIn constraints to 
     Typesense filter syntax using `!=[...]` notation.

### Code Changes:
1. **In `src/Engines/TypesenseEngine.php`**:
   - Enhanced `filters()` method to process `whereNotIn` constraints alongside 
     existing `where` and `whereIn` filters
   - Improved filter concatenation logic to handle all filter types using collection 
     methods
   - Updated filter string generation to maintain proper `&&` operator placement

### Test Updates:
1. **In `tests/Unit/TypesenseEngineTest.php`**:
   - Added new test method `test_parse_where_not_in_filter_metheod()` to verify 
     whereNotIn filter generation
   - Enhanced `test_filters_method()` to include whereNotIn scenarios
   - Added test cases for both string and numeric value exclusions
 
## Context
This PR addresses issue #876 reported by @alexfierro where `whereNotIn` constraints were 
not being handled by the Typesense driver. The implementation follows the suggested 
approach of adapting the existing `whereIn` logic with the appropriate Typesense 
filter syntax for exclusions.

**Before**:
```php
Product::search('laptop')->whereNotIn('category', ['refurbished']) // ❌ Ignored
```

**After**:
```php
// Generates: category:!=[refurbished]
Product::search('laptop')->whereNotIn('category', ['refurbished']) // ✅ Works!
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
