### PR TITLE
[10.x] Fix Algolia 3/4 engines

### DIFF
--- a/src/Engines/Algolia3Engine.php
+++ b/src/Engines/Algolia3Engine.php
@@ -4,6 +4,7 @@ namespace Laravel\Scout\Engines;
 
 use Algolia\AlgoliaSearch\Config\SearchConfig as Algolia3SearchConfig;
 use Algolia\AlgoliaSearch\SearchClient as Algolia3SearchClient;
+use Illuminate\Support\Arr;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Jobs\RemoveableScoutCollection;
 
@@ -34,24 +35,23 @@ class Algolia3Engine extends AlgoliaEngine
      */
     public static function make(array $config, array $headers, bool $softDelete = false)
     {
-        $config = Algolia3SearchConfig::create([
-            'appId' => $config['id'],
-            'apiKey' => $config['secret'],
-        ])->setDefaultHeaders($headers);
+        $configuration = Algolia3SearchConfig::create(
+            $config['id'], $config['secret'],
+        )->setDefaultHeaders($headers);
 
-        if (is_int($connectTimeout = $config['connect_timeout'])) {
+        if (is_int($connectTimeout = Arr::get($config, 'connect_timeout'))) {
             $configuration->setConnectTimeout($connectTimeout);
         }
 
-        if (is_int($readTimeout = $config['read_timeout'])) {
+        if (is_int($readTimeout = Arr::get($config, 'read_timeout'))) {
             $configuration->setReadTimeout($readTimeout);
         }
 
-        if (is_int($writeTimeout = $config['write_timeout'])) {
+        if (is_int($writeTimeout = Arr::get($config, 'write_timeout'))) {
             $configuration->setWriteTimeout($writeTimeout);
         }
 
-        if (is_int($batchSize = $config['batch_size'])) {
+        if (is_int($batchSize = Arr::get($config, 'batch_size'))) {
             $configuration->setBatchSize($batchSize);
         }
 

--- a/src/Engines/Algolia4Engine.php
+++ b/src/Engines/Algolia4Engine.php
@@ -39,7 +39,7 @@ class Algolia4Engine extends AlgoliaEngine
             'appId' => $config['id'],
             'apiKey' => $config['secret'],
         ]), array_filter([
-            'batchSize' => Arr::get($config, 'batch_size'),
+            'batchSize' => transform(Arr::get($config, 'batch_size'), fn ($batchSize) => is_int($batchSize) ? $batchSize : null),
         ])))->setDefaultHeaders($headers);
 
         if (is_int($connectTimeout = Arr::get($config, 'connect_timeout'))) {

--- a/src/Engines/Algolia4Engine.php
+++ b/src/Engines/Algolia4Engine.php
@@ -4,6 +4,7 @@ namespace Laravel\Scout\Engines;
 
 use Algolia\AlgoliaSearch\Api\SearchClient as Algolia4SearchClient;
 use Algolia\AlgoliaSearch\Configuration\SearchConfig as Algolia4SearchConfig;
+use Illuminate\Support\Arr;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Jobs\RemoveableScoutCollection;
 
@@ -38,18 +39,18 @@ class Algolia4Engine extends AlgoliaEngine
             'appId' => $config['id'],
             'apiKey' => $config['secret'],
         ]), array_filter([
-            'batchSize' => $config['batch_size'],
+            'batchSize' => Arr::get($config, 'batch_size'),
         ])))->setDefaultHeaders($headers);
 
-        if (is_int($connectTimeout = $config['connect_timeout'])) {
+        if (is_int($connectTimeout = Arr::get($config, 'connect_timeout'))) {
             $configuration->setConnectTimeout($connectTimeout);
         }
 
-        if (is_int($readTimeout = $config['read_timeout'])) {
+        if (is_int($readTimeout = Arr::get($config, 'read_timeout'))) {
             $configuration->setReadTimeout($readTimeout);
         }
 
-        if (is_int($writeTimeout = $config['write_timeout'])) {
+        if (is_int($writeTimeout = Arr::get($config, 'write_timeout'))) {
             $configuration->setWriteTimeout($writeTimeout);
         }
 


### PR DESCRIPTION
After upgrading from Scout 10.11.4 to 10.11.6 I started having issues with Algolia.

```
Cannot use object of type Algolia\AlgoliaSearch\Config\SearchConfig as array
```

I believe the issue is due to bugs introduced in #872 which added support for Algolia v4, but also broke support for Algolia v3. #881 has also been opened as other people have run into the same issue.

When I first saw the error I thought it was because I still had Algolia v3, so I bumped straight to v4 and then got another error.

```
Undefined array key "batch_size"
```

I've tested these fixes locally using both Algolia v3 and v4 and my search results are working again where previously they were not.

It appears the PR made mistakes:
* It attempted to access config keys directly when previously the `config` helper was used,
* It attempted to give the an array of configuration to the v3 search config object, when previously the `id`/`secret` were provided as separate arguments,
* It confused local variables `$config` (the Laravel configuration array) and `$configuration` (the Algolia search config object)