### PR TITLE
Fix: ambigious queries when adding other tables to the query builder

### DIFF
--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -92,7 +92,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
                 }
             })
             ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
-                $query->orderBy($builder->model->getScoutKeyName(), 'desc');
+                $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
             })
             ->paginate($perPage, ['*'], $pageName, $page);
     }
@@ -127,7 +127,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
                 }
             })
             ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
-                $query->orderBy($builder->model->getScoutKeyName(), 'desc');
+                $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
             })
             ->simplePaginate($perPage, ['*'], $pageName, $page);
     }
@@ -152,7 +152,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
                 }
             })
             ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
-                $query->orderBy($builder->model->getScoutKeyName(), 'desc');
+                $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
             })
             ->get();
     }


### PR DESCRIPTION
when joining in a HasMany relation, the orderBy only targets the column name, and does not select the table, which will result in ambigious errors. 

This PR focuses the table, which does not influence "normal" queries, but it will help when joining in other tables.


Old situation, source of PR:

Rule.php (Rule model)
```

/**
     * Perform a search against the model's indexed data.
     */
    public static function search($query = '', $callback = null)
    {
        return static::parentSearch($query, $callback)->query(function (Builder $builder): void {
            $builder
                ->join('rule_versions', 'rules.id', '=', 'rule_versions.rule_id');
        });
    }

```
(Resulting issue)

SQLSTATE[42702]: Ambiguous column: 7 ERROR: ORDER BY "id" is ambiguous LINE 1: ...like $5) and "rules"."deleted_at" is null order by "id" desc ^
```

select
  *
from
  "rules"
  inner join "rule_versions" on "rules"."id" = "rule_versions"."rule_id"
where
  (
    "rules"."id":: text ilike % asdf %
    or "rules"."code":: text ilike % asdf %
    or "rule_versions"."summary":: text ilike % asdf %
    or "rule_versions"."is_published":: text ilike % asdf %
    or "rule_versions"."id":: text ilike % asdf %
  )
  and "rules"."deleted_at" is null
order by
  "id" desc
```