### PR TITLE
fix: merge Algolia4 options into query parameters

### DIFF
--- a/src/Engines/Algolia4Engine.php
+++ b/src/Engines/Algolia4Engine.php
@@ -155,12 +155,11 @@ class Algolia4Engine extends AlgoliaEngine
             );
         }
 
-        $queryParams = ['query' => $builder->query];
+        $queryParams = array_merge(['query' => $builder->query], $options);
 
         return $this->algolia->searchSingleIndex(
             $builder->index ?: $builder->model->searchableAs(),
-            $queryParams,
-            $options
+            $queryParams
         );
     }
 }


### PR DESCRIPTION
## Background
In Algolia v3, search options were included directly in the query parameters. However, in Algolia v4, options passed as the third parameter to the searchSingleIndex method are interpreted as request options, affecting headers and query strings, which can lead to unintended behavior—specifically, options like hitsPerPage become ineffective.

## Changes:

- **Merge $options into $queryParams**
Used array_merge to combine $options with $queryParams, ensuring all search options are included in the query parameters as expected by Algolia v4.
- **Remove Third Parameter**
Stopped passing $options as the third argument to searchSingleIndex to prevent them from being misinterpreted as request options.
# Impact:

- **Correct Application of Search Options**
Ensures that options like hitsPerPage now function correctly.
- **Consistency with Algolia v4 Behavior**
Aligns our implementation with Algolia v4's expected input handling.