### PR TITLE
fix: numericFilters will be overwritten if softDelete = true

### DIFF
--- a/src/Engines/Algolia4Engine.php
+++ b/src/Engines/Algolia4Engine.php
@@ -144,7 +144,7 @@ class Algolia4Engine extends AlgoliaEngine
      */
     protected function performSearch(Builder $builder, array $options = [])
     {
-        $options = array_merge($builder->options, $options);
+        $options = array_merge_recursive($builder->options, $options);
 
         if ($builder->callback) {
             return call_user_func(

--- a/tests/Feature/Engines/Algolia4EngineTest.php
+++ b/tests/Feature/Engines/Algolia4EngineTest.php
@@ -146,6 +146,20 @@ class Algolia4EngineTest extends TestCase
         $engine->search($builder);
     }
 
+    public function test_search_sends_correct_parameters_and_keep_soft_delete_flag_to_algolia_in_search()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+
+        $this->client->shouldReceive('searchSingleIndex')->once()->with(
+            'users',
+            ['query' => 'zonda', 'numericFilters' => ['baz=2', '__soft_deleted=0', 'foo=1', '0=1']],
+        );
+
+        $builder = new Builder(new SearchableUser, 'zonda', softDelete: true);
+        $builder->where('foo', 1)->whereIn('bar', [])->options(['numericFilters' => ['baz=2']]);
+        $engine->search($builder);
+    }
+
     public function test_map_correctly_maps_results_to_models()
     {
         $model = SearchableUserFactory::new()->createQuietly(['name' => 'zonda']);


### PR DESCRIPTION
When additional options is set by `options` method on `Builder`, those value will be overwritten by following value:

https://github.com/laravel/scout/blob/b000080cf75da9ee5f7b936ca5df868e0aec5aef/src/Engines/AlgoliaEngine.php#L94

which results in lost all `numericFilters` manually set with `options` method.

This PR fixes it by using recursive version of array_merge to merge all `numericFilters`.

Thank you.