### PR TITLE
perf(typesense): skip collection check for search operations

### DIFF
--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -603,7 +603,7 @@ class TypesenseEngine extends Engine
         $collectionName = $model->{$method}();
         $collection = $this->typesense->getCollections()->{$collectionName};
 
-        if (!$indexOperation) {
+        if (! $indexOperation) {
             return $collection;
         }
 

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -603,6 +603,10 @@ class TypesenseEngine extends Engine
         $collectionName = $model->{$method}();
         $collection = $this->typesense->getCollections()->{$collectionName};
 
+        if (!$indexOperation) {
+            return $collection;
+        }
+
         // Determine if the collection exists in Typesense...
         try {
             $collection->retrieve();


### PR DESCRIPTION
### What is this?
This PR improves search performance in the Typesense driver by removing an unnecessary collection existence check during search operations. Currently, before executing any search, there's an API call out to the collection's endpoint that verifies if a collection exists, which adds latency that increases with collection size and complexity. By skipping this verification **specifically** for search operations while maintaining it for indexing, we can significantly improve search response times.

### Changes
#### Code Changes:
1. **In `src/Engines/TypesenseEngine.php`**:
   - Modified `getOrCreateCollectionFromModel()` to add early return when `indexOperation` is false
   - Collection existence verification now only runs during index operations
   - Search operations bypass collection check and directly execute search queries

#### Performance Improvements:
- Eliminates extra API call to verify collection existence before each search
- Reduces search latency, especially beneficial for large collections with many fields
- Maintains safety checks during index operations where verification is crucial

### Demo
Before this change, each search operation required two API calls:
1. GET `/collections/{name}` - Collection verification
2. GET `/collections/{name}/documents/search` - Actual search

After this change, search operations only make the necessary search API call, while index operations maintain all safety checks.

### Context
This optimization was prompted by a user's report of latency issues during search operations, particularly noticeable in larger collections. The change aligns with performance best practices by eliminating redundant API calls while maintaining data integrity through appropriate verification during index operations. I opened up an issue on #897 to keep track of the issue and the changes. This PR closes #897.