### PR TITLE
[10.x] Check for default total count return in meilisearch

### DIFF
--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -353,7 +353,7 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
      */
     public function getTotalCount($results)
     {
-        return $results['totalHits'];
+        return $results['totalHits'] ?? $results['estimatedTotalHits'];
     }
 
     /**


### PR DESCRIPTION
As per meilisearch documentation:
By default, Meilisearch only returns an estimate of the total number of search results in a query: estimatedTotalHits. This happens because Meilisearch prioritizes relevancy and performance over providing an exhaustive number of search results. When working with estimatedTotalHits, use offset and limit to navigate between search results.


Fixes
https://github.com/laravel/scout/issues/895