### PR TITLE
Fix filtering `null` values in `where()` with Meilisearch

### DIFF
--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -182,6 +182,10 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
                 return sprintf('%s=%s', $key, $value ? 'true' : 'false');
             }
 
+            if (is_null($value)) {
+                return sprintf('%s %s', $key, 'IS NULL');
+            }
+
             return is_numeric($value)
                 ? sprintf('%s=%s', $key, $value)
                 : sprintf('%s="%s"', $key, $value);

--- a/tests/Feature/Engines/MeilisearchEngineTest.php
+++ b/tests/Feature/Engines/MeilisearchEngineTest.php
@@ -206,12 +206,13 @@ class MeilisearchEngineTest extends TestCase
         $builder = new Builder(new SearchableUser, '');
         $builder->where('foo', 'bar');
         $builder->where('bar', 'baz');
+        $builder->where('baz', null);
         $builder->whereIn('qux', [1, 2]);
         $builder->whereIn('quux', [1, 2]);
 
         $this->client->shouldReceive('index')->once()->with('users')->andReturn($index = m::mock(Indexes::class));
         $index->shouldReceive('rawSearch')->once()->with($builder->query, array_filter([
-            'filter' => 'foo="bar" AND bar="baz" AND qux IN [1, 2] AND quux IN [1, 2]',
+            'filter' => 'foo="bar" AND bar="baz" AND baz IS NULL AND qux IN [1, 2] AND quux IN [1, 2]',
             'hitsPerPage' => $builder->limit,
         ]))->andReturn([]);
 


### PR DESCRIPTION
Currently filtering attributes by `null` value returns incorrect results.

```php
TestModel::search('test')->where('parent_id', null)->count();
// 0
```

This is because the generated filter value is `parent_id=""`. The correct value filtering for null is `parent_id IS NULL` and this PR fixes it.

A way to get around this bug is:

```php
TestModel::search('test')->options(['filter' => 'parent_id IS NULL'])->count();
// x
```

But that's not very intuitive or convenient ;)