### PR TITLE
Update Algolia config to replace ALGOLIA_SECRET with ALGOLIA_API_KEY

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -114,7 +114,7 @@ return [
 
     'algolia' => [
         'id' => env('ALGOLIA_APP_ID', ''),
-        'secret' => env('ALGOLIA_SECRET', ''),
+        'secret' => env('ALGOLIA_API_KEY', ''),
         'index-settings' => [
             // 'users' => [
             //     'searchableAttributes' => ['id', 'name', 'email'],


### PR DESCRIPTION
Official Algolia docs give us this;
ALGOLIA_APP_ID=
ALGOLIA_API_KEY=

But the Laravel Scout has different fields for this. We should update this.
