### PR TITLE
[10.x] Allow to pass Arrayable to `whereIn` and `whereNotIn` queries

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -3,6 +3,7 @@
 namespace Laravel\Scout;
 
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Traits\Conditionable;
@@ -10,7 +11,6 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\Tappable;
 use Laravel\Scout\Contracts\PaginatesEloquentModels;
 use Laravel\Scout\Contracts\PaginatesEloquentModelsUsingDatabase;
-use Illuminate\Contracts\Support\Arrayable;
 
 /**
  * @template TModel of \Illuminate\Database\Eloquent\Model

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\Tappable;
 use Laravel\Scout\Contracts\PaginatesEloquentModels;
 use Laravel\Scout\Contracts\PaginatesEloquentModelsUsingDatabase;
+use Illuminate\Contracts\Support\Arrayable;
 
 /**
  * @template TModel of \Illuminate\Database\Eloquent\Model
@@ -146,11 +147,15 @@ class Builder
      * Add a "where in" constraint to the search query.
      *
      * @param  string  $field
-     * @param  array  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $values
      * @return $this
      */
-    public function whereIn($field, array $values)
+    public function whereIn($field, $values)
     {
+        if ($values instanceof Arrayable) {
+            $values = $values->toArray();
+        }
+
         $this->whereIns[$field] = $values;
 
         return $this;
@@ -160,11 +165,15 @@ class Builder
      * Add a "where not in" constraint to the search query.
      *
      * @param  string  $field
-     * @param  array  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $values
      * @return $this
      */
-    public function whereNotIn($field, array $values)
+    public function whereNotIn($field, $values)
     {
+        if ($values instanceof Arrayable) {
+            $values = $values->toArray();
+        }
+
         $this->whereNotIns[$field] = $values;
 
         return $this;


### PR DESCRIPTION
One annoyance that we often have and where the ecosystem doesn't feel cohesive throughout, is when adding search to an existing query and it suddenly stops working because of a collection being passed to `whereIn`or `whereNotIn`.

```php
$users = collect([1]);
````

Existing query without Scout
```php
User::whereIn("id", $users)->get(); 
// Returns 1 user
```

_Adding Scout..._

**Before change**
```php
User::search("Taylor")->whereIn("id", $users)->get(); 
// TypeError  Laravel\Scout\Builder::whereIn(): Argument #2 ($values) must be of type array, Illuminate\Support\Collection given
````

**After change**

```php
User::search("Taylor")->whereIn("id", $users)->get(); 
// Returns 1 user
``` 


I don't like that I had to remove a type declaration, but by looking at other classes ([1](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Collections/Traits/EnumeratesValues.php#L668), [2](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Validation/Rules/In.php)) this seems to be the way to go.