### PR TITLE
Excludes `/types` via `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 
 /.github export-ignore
 /art export-ignore
+/types export-ignore
 /tests export-ignore
 .editorconfig export-ignore
 .gitattributes export-ignore


### PR DESCRIPTION
fixes #906