### PR TITLE
Fix: [Typesense] Add custom index support

### DIFF
--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -243,7 +243,12 @@ class TypesenseEngine extends Engine
      */
     protected function performSearch(Builder $builder, array $options = []): mixed
     {
-        $documents = $this->getOrCreateCollectionFromModel($builder->model, false)->getDocuments();
+        $documents = $this->getOrCreateCollectionFromModel(
+            $builder->model,
+            false,
+            $builder->index
+        )->getDocuments();
+
 
         if ($builder->callback) {
             return call_user_func($builder->callback, $documents, $builder->query, $options);
@@ -593,14 +598,17 @@ class TypesenseEngine extends Engine
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return TypesenseCollection
      *
-     * @throws \Typesense\Exceptions\TypesenseClientError
+     * @throws TypesenseClientError
      * @throws \Http\Client\Exception
      */
-    protected function getOrCreateCollectionFromModel($model, bool $indexOperation = true): TypesenseCollection
+    protected function getOrCreateCollectionFromModel($model, bool $indexOperation = true, string $collectionName = null): TypesenseCollection
     {
-        $method = $indexOperation ? 'indexableAs' : 'searchableAs';
+        if (!$indexOperation) {
+            $collectionName = $collectionName ?? $model->searchableAs();
+        } else {
+            $collectionName = $model->indexableAs();
+        }
 
-        $collectionName = $model->{$method}();
         $collection = $this->typesense->getCollections()->{$collectionName};
 
         if (! $indexOperation) {

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -245,8 +245,8 @@ class TypesenseEngine extends Engine
     {
         $documents = $this->getOrCreateCollectionFromModel(
             $builder->model,
+            $builder->index,
             false,
-            $builder->index
         )->getDocuments();
 
 
@@ -596,14 +596,14 @@ class TypesenseEngine extends Engine
      * Get collection from model or create new one.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return TypesenseCollection
+     * @return \Typesense\Collection
      *
-     * @throws TypesenseClientError
+     * @throws \Typesense\Exceptions\TypesenseClientError
      * @throws \Http\Client\Exception
      */
-    protected function getOrCreateCollectionFromModel($model, bool $indexOperation = true, string $collectionName = null): TypesenseCollection
+    protected function getOrCreateCollectionFromModel($model, ?string $collectionName = null, bool $indexOperation = true): TypesenseCollection
     {
-        if (!$indexOperation) {
+        if (! $indexOperation) {
             $collectionName = $collectionName ?? $model->searchableAs();
         } else {
             $collectionName = $model->indexableAs();


### PR DESCRIPTION
This PR adds support for custom index selection via `within()` method to the TypesenseEngine:
```php 
Model::search('query')->within('custom-index')->get();
```
Previously, the `within()` method was ignored in TypesenseEngine. This change allows users to search specific collections dynamically, which is particularly useful when dealing with time-based or partitioned data.

Benefits:
- Allows searching specific collections via `within()`, matching behavior available in other Scout engines
- Maintains backward compatibility with no breaking changes
- Requires no configuration changes