### PR TITLE
[10.x] Optimize database engine keys query

### DIFF
--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -351,6 +351,27 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
     }
 
     /**
+     * Get the results of the query as a Collection of primary keys.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return \Illuminate\Support\Collection
+     */
+    public function keys(Builder $builder)
+    {
+        return $this->mapIds($this->search(tap(clone $builder, function ($builder) {
+            $queryCallback = $builder->queryCallback;
+         
+            $builder->query(function ($databaseQuery) use ($builder, $queryCallback) {
+                $databaseQuery->select($builder->model->getScoutKeyName());
+
+                if ($queryCallback) {
+                    $queryCallback($databaseQuery);
+                }
+            });
+        })));
+    }
+
+    /**
      * Pluck and return the primary keys of the given results.
      *
      * @param  mixed  $results


### PR DESCRIPTION
In the database engine, to get keys, this PR replaces the ```SELECT *``` with ```SELECT `id` ``` for better performance in tables with too many columns.

Before and after for our use case:
![image](https://github.com/user-attachments/assets/70aefb02-6f7d-4cad-9024-2c21d1821f43)

