### PR TITLE
[10.x] Improve scout:index command

### DIFF
--- a/src/Console/IndexCommand.php
+++ b/src/Console/IndexCommand.php
@@ -83,6 +83,23 @@ class IndexCommand extends Command
     }
 
     /**
+     * Create a search index.
+     *
+     * @param  \Laravel\Scout\Engines\Engine  $engine
+     * @param  string  $name
+     * @param  array  $options
+     * @return void
+     */
+    protected function createIndex(Engine $engine, $name, $options): void
+    {
+        try {
+            $engine->createIndex($name, $options);
+        } catch (NotSupportedException) {
+            return;
+        }
+    }
+
+    /**
      * Get the fully-qualified index name for the given index.
      *
      * @param  string  $name
@@ -97,22 +114,5 @@ class IndexCommand extends Command
         $prefix = config('scout.prefix');
 
         return ! Str::startsWith($name, $prefix) ? $prefix.$name : $name;
-    }
-
-    /**
-     * Create a search index.
-     *
-     * @param  Engine  $engine
-     * @param  string  $name
-     * @param  array  $options
-     * @return void
-     */
-    protected function createIndex(Engine $engine, $name, $options): void
-    {
-        try {
-            $engine->createIndex($name, $options);
-        } catch (NotSupportedException) {
-            return;
-        }
     }
 }

--- a/src/Console/IndexCommand.php
+++ b/src/Console/IndexCommand.php
@@ -102,9 +102,9 @@ class IndexCommand extends Command
     /**
      * Create a search index.
      *
-     * @param Engine $engine
-     * @param string $name
-     * @param array $options
+     * @param  Engine  $engine
+     * @param  string  $name
+     * @param  array  $options
      * @return void
      */
     protected function createIndex(Engine $engine, $name, $options): void

--- a/src/Console/IndexCommand.php
+++ b/src/Console/IndexCommand.php
@@ -8,6 +8,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
 use Laravel\Scout\Contracts\UpdatesIndexSettings;
 use Laravel\Scout\EngineManager;
+use Laravel\Scout\Engines\Engine;
+use Laravel\Scout\Exceptions\NotSupportedException;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'scout:index')]
@@ -52,7 +54,7 @@ class IndexCommand extends Command
 
             $name = $this->indexName($this->argument('name'));
 
-            $engine->createIndex($name, $options);
+            $this->createIndex($engine, $name, $options);
 
             if ($engine instanceof UpdatesIndexSettings) {
                 $driver = config('scout.driver');
@@ -74,7 +76,7 @@ class IndexCommand extends Command
                 }
             }
 
-            $this->info('Index ["'.$name.'"] created successfully.');
+            $this->info('Synchronised index ["'.$name.'"] successfully.');
         } catch (Exception $exception) {
             $this->error($exception->getMessage());
         }
@@ -95,5 +97,22 @@ class IndexCommand extends Command
         $prefix = config('scout.prefix');
 
         return ! Str::startsWith($name, $prefix) ? $prefix.$name : $name;
+    }
+
+    /**
+     * Create a search index.
+     *
+     * @param Engine $engine
+     * @param string $name
+     * @param array $options
+     * @return void
+     */
+    protected function createIndex(Engine $engine, $name, $options): void
+    {
+        try {
+            $engine->createIndex($name, $options);
+        } catch (NotSupportedException) {
+            return;
+        }
     }
 }

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Contracts\UpdatesIndexSettings;
+use Laravel\Scout\Exceptions\NotSupportedException;
 
 /**
  * @template TAlgoliaClient of object
@@ -246,11 +247,11 @@ abstract class AlgoliaEngine extends Engine implements UpdatesIndexSettings
      * @param  array  $options
      * @return mixed
      *
-     * @throws \Exception
+     * @throws NotSupportedException
      */
     public function createIndex($name, array $options = [])
     {
-        throw new Exception('Algolia indexes are created automatically upon adding objects.');
+        throw new NotSupportedException('Algolia indexes are created automatically upon adding objects.');
     }
 
     /**

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Scout\Engines;
 
-use Exception;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -32,7 +32,6 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
     /**
      * Create a new MeilisearchEngine instance.
      *
-     * @param  \Meilisearch\Client  $meilisearch
      * @param  bool  $softDelete
      * @return void
      */
@@ -136,8 +135,6 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
     /**
      * Perform the given search on the engine.
      *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @param  array  $searchParams
      * @return mixed
      */
     protected function performSearch(Builder $builder, array $searchParams = [])
@@ -174,7 +171,6 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
     /**
      * Get the filter array for the query.
      *
-     * @param  \Laravel\Scout\Builder  $builder
      * @return string
      */
     protected function filters(Builder $builder)
@@ -219,9 +215,6 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
 
     /**
      * Get the sort array for the query.
-     *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @return array
      */
     protected function buildSortFromOrderByClauses(Builder $builder): array
     {
@@ -240,7 +233,7 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
      */
     public function mapIds($results)
     {
-        if (0 === count($results['hits'])) {
+        if (count($results['hits']) === 0) {
             return collect();
         }
 
@@ -268,7 +261,6 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
     /**
      * Get the results of the query as a Collection of primary keys.
      *
-     * @param  \Laravel\Scout\Builder  $builder
      * @return \Illuminate\Support\Collection
      */
     public function keys(Builder $builder)
@@ -281,14 +273,13 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
     /**
      * Map the given results to instances of the given model.
      *
-     * @param  \Laravel\Scout\Builder  $builder
      * @param  mixed  $results
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return \Illuminate\Database\Eloquent\Collection
      */
     public function map(Builder $builder, $results, $model)
     {
-        if (is_null($results) || 0 === count($results['hits'])) {
+        if (is_null($results) || count($results['hits']) === 0) {
             return $model->newCollection();
         }
 
@@ -318,7 +309,6 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
     /**
      * Map the given results to instances of the given model via a lazy collection.
      *
-     * @param  \Laravel\Scout\Builder  $builder
      * @param  mixed  $results
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return \Illuminate\Support\LazyCollection
@@ -376,32 +366,21 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
     }
 
     /**
-     * Check whether an index exists or not.
-     *
-     * @param  string  $name
-     * @return Indexes|null
-     */
-    protected function getIndex($name)
-    {
-        try {
-            return $this->meilisearch->getIndex($name);
-        } catch (ApiException $e) {
-            return null;
-        }
-    }
-
-    /**
      * Create a search index.
      *
      * @param  string  $name
-     * @param  array  $options
      * @return mixed
      *
      * @throws \Meilisearch\Exceptions\ApiException
      */
     public function createIndex($name, array $options = [])
     {
-        $index = $this->getIndex($name);
+        try {
+            $index = $this->meilisearch->getIndex($name);
+        } catch (ApiException $e) {
+            $index = null;
+        }
+
         if ($index?->getUid() !== null) {
             return $index;
         }
@@ -454,7 +433,7 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
         $tasks = [];
         $limit = 1000000;
 
-        $query = new IndexesQuery();
+        $query = new IndexesQuery;
         $query->setLimit($limit);
 
         $indexes = $this->meilisearch->getIndexes($query);

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -8,6 +8,8 @@ use Laravel\Scout\Contracts\UpdatesIndexSettings;
 use Laravel\Scout\Jobs\RemoveableScoutCollection;
 use Meilisearch\Client as MeilisearchClient;
 use Meilisearch\Contracts\IndexesQuery;
+use Meilisearch\Endpoints\Indexes;
+use Meilisearch\Exceptions\ApiException;
 use Meilisearch\Meilisearch;
 use Meilisearch\Search\SearchResult;
 
@@ -374,6 +376,21 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
     }
 
     /**
+     * Check whether an index exists or not.
+     *
+     * @param string $name
+     * @return Indexes|null
+     */
+    protected function getIndex($name)
+    {
+        try {
+            return $this->meilisearch->getIndex($name);
+        } catch (ApiException $e) {
+            return null;
+        }
+    }
+
+    /**
      * Create a search index.
      *
      * @param  string  $name
@@ -384,6 +401,11 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
      */
     public function createIndex($name, array $options = [])
     {
+        $index = $this->getIndex($name);
+        if ($index?->getUid() !== null) {
+            return $index;
+        }
+
         return $this->meilisearch->createIndex($name, $options);
     }
 

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -378,7 +378,7 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
     /**
      * Check whether an index exists or not.
      *
-     * @param string $name
+     * @param  string  $name
      * @return Indexes|null
      */
     protected function getIndex($name)

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;
+use Laravel\Scout\Exceptions\NotSupportedException;
 use stdClass;
 use Typesense\Client as Typesense;
 use Typesense\Collection as TypesenseCollection;
@@ -570,11 +571,11 @@ class TypesenseEngine extends Engine
      * @param  array  $options
      * @return void
      *
-     * @throws \Exception
+     * @throws NotSupportedException
      */
     public function createIndex($name, array $options = [])
     {
-        throw new Exception('Typesense indexes are created automatically upon adding objects.');
+        throw new NotSupportedException('Typesense indexes are created automatically upon adding objects.');
     }
 
     /**

--- a/src/Exceptions/NotSupportedException.php
+++ b/src/Exceptions/NotSupportedException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Laravel\Scout\Exceptions;
 
 class NotSupportedException extends ScoutException

--- a/src/Exceptions/NotSupportedException.php
+++ b/src/Exceptions/NotSupportedException.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Laravel\Scout\Exceptions;
 

--- a/src/Exceptions/NotSupportedException.php
+++ b/src/Exceptions/NotSupportedException.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Laravel\Scout\Exceptions;
+
+class NotSupportedException extends ScoutException
+{
+    //
+}

--- a/src/Exceptions/ScoutException.php
+++ b/src/Exceptions/ScoutException.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Laravel\Scout\Exceptions;
+
+use Exception;
+
+class ScoutException extends Exception
+{
+    //
+}

--- a/src/Exceptions/ScoutException.php
+++ b/src/Exceptions/ScoutException.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Laravel\Scout\Exceptions;
 

--- a/src/Exceptions/ScoutException.php
+++ b/src/Exceptions/ScoutException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Laravel\Scout\Exceptions;
 
 use Exception;


### PR DESCRIPTION
The `scout:index` command was written so that it works for all engines - [quote](https://github.com/laravel/scout/pull/457):
> I've also implemented a generic way so it works for all engines.

There are two issues which this PR improves:

* Previously, if you ran the command when using Algolia, the `createIndex()` call threw `'Algolia indexes are created automatically upon adding objects.'` That exception is now caught.
* Previously, on Meilisearch, `createIndex()` would run successfully because it just pushes a task to the queue, but the task later fails though because `index_already_exists` - https://docs.meilisearch.com/errors#index_already_exists. I've changed it so that it checks whether the index exists first.

IMO these changes simplify usage of the scout commands. `scout:index` handles both creating and updating an index. 