### PR TITLE
fix(typesense): handle missing collection during search (#914)

### DIFF
--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -1,5 +1,6 @@
 <?php
 
+
 namespace Laravel\Scout\Engines;
 
 use Exception;
@@ -13,6 +14,7 @@ use stdClass;
 use Typesense\Client as Typesense;
 use Typesense\Collection as TypesenseCollection;
 use Typesense\Exceptions\ObjectAlreadyExists;
+use Typesense\Exceptions\ObjectNotFound;
 use Typesense\Exceptions\TypesenseClientError;
 
 class TypesenseEngine extends Engine
@@ -255,7 +257,13 @@ class TypesenseEngine extends Engine
             return call_user_func($builder->callback, $documents, $builder->query, $options);
         }
 
-        return $documents->search($options);
+
+        try {
+            return $documents->search($options);
+        } catch (ObjectNotFound) {
+            $this->getOrCreateCollectionFromModel($builder->model, $builder->index, true);
+            return $documents->search($options);
+        }
     }
 
     /**

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Laravel\Scout\Engines;
 
 use Exception;
@@ -257,11 +256,11 @@ class TypesenseEngine extends Engine
             return call_user_func($builder->callback, $documents, $builder->query, $options);
         }
 
-
         try {
             return $documents->search($options);
         } catch (ObjectNotFound) {
             $this->getOrCreateCollectionFromModel($builder->model, $builder->index, true);
+
             return $documents->search($options);
         }
     }


### PR DESCRIPTION
Address #914
- wrap `search` operation in try-catch block to handle `ObjectNotFound` exception
- automatically create collection when not found and retry search
- improve error recovery flow for typesense engine
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
