### PR TITLE
Add support for importing and flushing all models

### DIFF
--- a/src/Console/FlushCommand.php
+++ b/src/Console/FlushCommand.php
@@ -46,7 +46,7 @@ class FlushCommand extends Command
     /**
      * Flush the model's records from the index.
      *
-     * @param string<class-string> $class
+     * @param  string<class-string> $class
      * @return void
      */
     protected function flushModel(string $class)

--- a/src/Console/FlushCommand.php
+++ b/src/Console/FlushCommand.php
@@ -46,7 +46,7 @@ class FlushCommand extends Command
     /**
      * Flush the model's records from the index.
      *
-     * @param  string<class-string> $class
+     * @param  string<class-string>  $class
      * @return void
      */
     protected function flushModel(string $class)

--- a/src/Console/FlushCommand.php
+++ b/src/Console/FlushCommand.php
@@ -4,6 +4,7 @@ namespace Laravel\Scout\Console;
 
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Exception\RuntimeException;
 
 #[AsCommand(name: 'scout:flush')]
 class FlushCommand extends Command
@@ -13,7 +14,9 @@ class FlushCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'scout:flush {model : Class name of the model to flush}';
+    protected $signature = 'scout:flush
+        {model? : Class name of the model to flush}
+        {--all : Flush all configured models}';
 
     /**
      * The console command description.
@@ -29,12 +32,41 @@ class FlushCommand extends Command
      */
     public function handle()
     {
-        $class = $this->argument('model');
+        if (! $this->argument('model') && ! $this->option('all')) {
+            throw new RuntimeException('Not enough arguments (missing: "model")');
+        }
 
+        if ($class = $this->argument('model')) {
+            return $this->flushModel($class);
+        }
+
+        $this->flushAllModels();
+    }
+
+    /**
+     * Flush the model's records from the index.
+     *
+     * @param string<class-string> $class
+     * @return void
+     */
+    protected function flushModel(string $class)
+    {
         $model = new $class;
 
         $model::removeAllFromSearch();
 
         $this->info('All ['.$class.'] records have been flushed.');
+    }
+
+    protected function flushAllModels()
+    {
+        $driver = config('scout.driver');
+        $modelsKey = $driver === 'typesense' ? 'model-settings' : 'index-settings';
+        $settings = (array) config('scout.'.$driver.'.'.$modelsKey);
+        $classes = array_keys($settings);
+
+        foreach ($classes as $class) {
+            $this->flushModel($class);
+        }
     }
 }

--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Scout\Events\ModelsImported;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Exception\RuntimeException;
 
 #[AsCommand(name: 'scout:import')]
 class ImportCommand extends Command
@@ -16,8 +17,9 @@ class ImportCommand extends Command
      * @var string
      */
     protected $signature = 'scout:import
-            {model : Class name of model to bulk import}
-            {--c|chunk= : The number of records to import at a time (Defaults to configuration value: `scout.chunk.searchable`)}';
+            {model? : Class name of model to bulk import}
+            {--c|chunk= : The number of records to import at a time (Defaults to configuration value: `scout.chunk.searchable`)}
+            {--all : Import all configured models}';
 
     /**
      * The console command description.
@@ -25,6 +27,8 @@ class ImportCommand extends Command
      * @var string
      */
     protected $description = 'Import the given model into the search index';
+
+    protected Dispatcher $events;
 
     /**
      * Execute the console command.
@@ -34,11 +38,24 @@ class ImportCommand extends Command
      */
     public function handle(Dispatcher $events)
     {
-        $class = $this->argument('model');
+        $this->events = $events;
 
+        if (! $this->argument('model') && ! $this->option('all')) {
+            throw new RuntimeException('Not enough arguments (missing: "model")');
+        }
+
+        if ($class = $this->argument('model')) {
+            return $this->importModel($class);
+        }
+
+        $this->importAllModels();
+    }
+
+    protected function importModel(string $class)
+    {
         $model = new $class;
 
-        $events->listen(ModelsImported::class, function ($event) use ($class) {
+        $this->events->listen(ModelsImported::class, function ($event) use ($class) {
             $key = $event->models->last()->getScoutKey();
 
             $this->line('<comment>Imported ['.$class.'] models up to ID:</comment> '.$key);
@@ -46,8 +63,20 @@ class ImportCommand extends Command
 
         $model::makeAllSearchable($this->option('chunk'));
 
-        $events->forget(ModelsImported::class);
+        $this->events->forget(ModelsImported::class);
 
         $this->info('All ['.$class.'] records have been imported.');
+    }
+
+    protected function importAllModels()
+    {
+        $driver = config('scout.driver');
+        $modelsKey = $driver === 'typesense' ? 'model-settings' : 'index-settings';
+        $settings = (array) config('scout.'.$driver.'.'.$modelsKey);
+        $classes = array_keys($settings);
+
+        foreach ($classes as $class) {
+            $this->importModel($class);
+        }
     }
 }


### PR DESCRIPTION
This PR adds the ability to flush and import all models configured in a scout config. This is helpful to run a single command to handle all your model updates, such as during deployments when you may have adjusted model settings and need to have them re-indexed.

It checks to see if you have included the now optional `model` argument or new `--all` flag, falling back to the argument. If neither are provided, a `RuntimeException` is thrown alerting the user to the missing `model` argument.