### PR TITLE
fix Builder.php - not actually using returned results from afterRawSearchCallback

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -564,7 +564,7 @@ class Builder
     public function applyAfterRawSearchCallback($results)
     {
         if ($this->afterRawSearchCallback) {
-            $results = call_user_func($this->afterRawSearchCallback, $results);
+            $results = call_user_func($this->afterRawSearchCallback, $results) ?: $results;
         }
 
         return $results;

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -564,7 +564,7 @@ class Builder
     public function applyAfterRawSearchCallback($results)
     {
         if ($this->afterRawSearchCallback) {
-            call_user_func($this->afterRawSearchCallback, $results);
+            $results = call_user_func($this->afterRawSearchCallback, $results);
         }
 
         return $results;


### PR DESCRIPTION
Fix using afterRawSearchCallback without actually getting back the returned results. 
If the purpose of the afterRawSearchCallback is to allow changes to be made on preprocessed raw results then this part was probably left out by mistake.

I believe this was the intended use for this callback that was unintentionally missed.

