### PR TITLE
[10.x] searchableSync / unsearchableSync

### DIFF
--- a/tests/Feature/SearchableTest.php
+++ b/tests/Feature/SearchableTest.php
@@ -19,13 +19,16 @@ class SearchableTest extends TestCase
     public function test_searchable_using_update_is_called_on_collection()
     {
         $collection = m::mock();
-        $collection->shouldReceive('isEmpty')->once()->andReturn(false);
+        $collection->shouldReceive('isEmpty')->times(2)->andReturn(false);
         $collection->shouldReceive('first->makeSearchableUsing')->with($collection)->once()->andReturn($collection);
         $collection->shouldReceive('first->searchableUsing->update')->with($collection)->once();
 
         $model = new SearchableModel;
         $model->queueMakeSearchable($collection);
+    }
 
+    public function test_searchable_using_update_is_called_on_collection_sync()
+    {
         $collection = m::mock();
         $collection->shouldReceive('isEmpty')->once()->andReturn(false);
         $collection->shouldReceive('first->makeSearchableUsing')->with($collection)->once()->andReturn($collection);
@@ -73,12 +76,15 @@ class SearchableTest extends TestCase
     public function test_searchable_using_delete_is_called_on_collection()
     {
         $collection = m::mock();
-        $collection->shouldReceive('isEmpty')->once()->andReturn(false);
+        $collection->shouldReceive('isEmpty')->times(2)->andReturn(false);
         $collection->shouldReceive('first->searchableUsing->delete')->with($collection);
 
         $model = new SearchableModel;
         $model->queueRemoveFromSearch($collection);
+    }
 
+    public function test_searchable_using_delete_is_called_on_collection_sycn()
+    {
         $collection = m::mock();
         $collection->shouldReceive('isEmpty')->once()->andReturn(false);
         $collection->shouldReceive('first->searchableUsing->delete')->with($collection);

--- a/tests/Feature/SearchableTest.php
+++ b/tests/Feature/SearchableTest.php
@@ -25,6 +25,14 @@ class SearchableTest extends TestCase
 
         $model = new SearchableModel;
         $model->queueMakeSearchable($collection);
+
+        $collection = m::mock();
+        $collection->shouldReceive('isEmpty')->once()->andReturn(false);
+        $collection->shouldReceive('first->makeSearchableUsing')->with($collection)->once()->andReturn($collection);
+        $collection->shouldReceive('first->searchableUsing->update')->with($collection)->once();
+
+        $model = new SearchableModel;
+        $model->syncMakeSearchable($collection);
     }
 
     public function test_searchable_using_update_is_not_called_on_empty_collection()
@@ -35,6 +43,13 @@ class SearchableTest extends TestCase
 
         $model = new SearchableModel;
         $model->queueMakeSearchable($collection);
+
+        $collection = m::mock();
+        $collection->shouldReceive('isEmpty')->andReturn(true);
+        $collection->shouldNotReceive('first->searchableUsing->update');
+
+        $model = new SearchableModel;
+        $model->syncMakeSearchable($collection);
     }
 
     public function test_overridden_make_searchable_is_dispatched()
@@ -63,6 +78,13 @@ class SearchableTest extends TestCase
 
         $model = new SearchableModel;
         $model->queueRemoveFromSearch($collection);
+
+        $collection = m::mock();
+        $collection->shouldReceive('isEmpty')->once()->andReturn(false);
+        $collection->shouldReceive('first->searchableUsing->delete')->with($collection);
+
+        $model = new SearchableModel;
+        $model->syncRemoveFromSearch($collection);
     }
 
     public function test_searchable_using_delete_is_not_called_on_empty_collection()
@@ -73,6 +95,13 @@ class SearchableTest extends TestCase
 
         $model = new SearchableModel;
         $model->queueRemoveFromSearch($collection);
+
+        $collection = m::mock();
+        $collection->shouldReceive('isEmpty')->once()->andReturn(true);
+        $collection->shouldNotReceive('first->searchableUsing->delete');
+
+        $model = new SearchableModel;
+        $model->syncRemoveFromSearch($collection);
     }
 
     public function test_overridden_remove_from_search_is_dispatched()


### PR DESCRIPTION
In my projects, I always configure Scout to queue the jobs that make model(s) searchable or unsearchable. This works perfectly, but sometimes you want to make a model instantly unsearchable.
For example, in a project, I show a list that is based on a Scout search result. Each item has a delete button. Deleting an item and refreshing the list will mean the refreshed list has a high change of still containing the deleted item if the job that makes the item unsearchable has not finished yet.

This PR adds methods to easily make model(s) synchronously searchable/unsearchable even if Scout config will queue those actions by default.

```php
config()->set('scout.queue', true);

// This will be queued
$models->searchable();
$models->unsearchable();

// This will happen synchronously even if 'scout.queue' config variable is set to true
$models->searchableSync();
$models->unsearchableSync();
```

The 'Sync' suffix for the method names is inspired by the 'dispatchSync' method on jobs in Laravel.