### PR TITLE
Add newScoutQuery() for Database Engine

### DIFF
--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -188,11 +188,15 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
      */
     protected function initializeSearchQuery(Builder $builder, array $columns, array $prefixColumns = [], array $fullTextColumns = [])
     {
+        $query = method_exists($builder->model, 'newScoutQuery')
+            ? $builder->model->newScoutQuery()
+            : $builder->model->newQuery();
+
         if (blank($builder->query)) {
-            return $builder->model->newQuery();
+            return $query;
         }
 
-        return $builder->model->newQuery()->where(function ($query) use ($builder, $columns, $prefixColumns, $fullTextColumns) {
+        return $query->where(function ($query) use ($builder, $columns, $prefixColumns, $fullTextColumns) {
             $connectionType = $builder->model->getConnection()->getDriverName();
 
             $canSearchPrimaryKey = ctype_digit($builder->query) &&

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -189,7 +189,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
     protected function initializeSearchQuery(Builder $builder, array $columns, array $prefixColumns = [], array $fullTextColumns = [])
     {
         $query = method_exists($builder->model, 'newScoutQuery')
-            ? $builder->model->newScoutQuery()
+            ? $builder->model->newScoutQuery($builder)
             : $builder->model->newQuery();
 
         if (blank($builder->query)) {

--- a/tests/Feature/DatabaseEngineTest.php
+++ b/tests/Feature/DatabaseEngineTest.php
@@ -7,7 +7,10 @@ use Illuminate\Foundation\Testing\WithFaker;
 use Orchestra\Testbench\Concerns\WithLaravelMigrations;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
+use Workbench\App\Models\Bookmark;
 use Workbench\App\Models\SearchableUser;
+use Workbench\Database\Factories\BookmarkFactory;
+use Workbench\Database\Factories\ChirpFactory;
 use Workbench\Database\Factories\SearchableUserFactory;
 
 class DatabaseEngineTest extends TestCase
@@ -185,5 +188,20 @@ class DatabaseEngineTest extends TestCase
         $modelsSimplePaginate = SearchableUser::search('laravel')->orderByDesc('name')->simplePaginate(1, 'page', 1);
         $this->assertCount(1, $modelsSimplePaginate);
         $this->assertEquals('Taylor Otwell', $modelsSimplePaginate[0]->name);
+    }
+
+    public function test_it_uses_scout_query()
+    {
+        // create bookmarks with chirp_id
+        BookmarkFactory::new()
+            ->for(ChirpFactory::new()->create(['content' => 'This chirp is searchable']))
+            ->create([
+                'label' => 'laravel',
+            ]);
+
+        $models = Bookmark::search('chirp')->get();
+        $this->assertCount(1, $models);
+        $this->assertEquals('laravel', $models[0]->label);
+        $this->assertEquals('This chirp is searchable', $models[0]->chirp->content);
     }
 }

--- a/workbench/app/Models/Bookmark.php
+++ b/workbench/app/Models/Bookmark.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Workbench\App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Laravel\Scout\Searchable;
+
+class Bookmark extends Model
+{
+    use HasFactory;
+    use Searchable;
+
+    public function chirp(): BelongsTo
+    {
+        return $this->belongsTo(Chirp::class);
+    }
+
+    public function newScoutQuery(): Builder
+    {
+        return $this->newQuery()->join('chirps', 'chirps.id', '=', 'bookmarks.chirp_id');
+    }
+
+    public function toSearchableArray()
+    {
+        if (isset($_ENV['bookmark.toSearchableArray'])) {
+            return value($_ENV['bookmark.toSearchableArray'], $this);
+        }
+
+        return [
+            'label' => $this->label,
+            'chirps.content' => '',
+        ];
+    }
+}
+

--- a/workbench/app/Models/Bookmark.php
+++ b/workbench/app/Models/Bookmark.php
@@ -35,4 +35,3 @@ class Bookmark extends Model
         ];
     }
 }
-

--- a/workbench/database/factories/BookmarkFactory.php
+++ b/workbench/database/factories/BookmarkFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Workbench\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Workbench\App\Models\Bookmark;
+
+/**
+ * @template TModel of \Workbench\App\Models\Bookmark
+ *
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<TModel>
+ */
+class BookmarkFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var class-string<TModel>
+     */
+    protected $model = Bookmark::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'chirp_id' => ChirpFactory::new(),
+            'label' => fake()->word(),
+        ];
+    }
+}

--- a/workbench/database/migrations/2025_05_13_092928_create_bookmarks_table.php
+++ b/workbench/database/migrations/2025_05_13_092928_create_bookmarks_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('bookmarks', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('chirp_id');
+            $table->string('label');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('bookmarks');
+    }
+};


### PR DESCRIPTION
This PR adds the possibility to define a `newScoutQuery()` in models. This method allows you to customize the underlying database query used during a search.

For many applications the database engine is everything you need. In almost every project I had 2-3 models which should be searchable by their relations like "Find orders by customers email".

With this change, you can define the necessary joins:

```php
// Order.php
public function newScoutQuery()
{
    return $this->newQuery()->join('customers', 'orders.customer_id', '=', 'customers.id');
}
    
public function toSearchableArray(): array
{
    return [
        'orders.id' => $this->id,
        'customers.email' => '',
        'customers.name' => '',
    ];
}
```

And we can get the results

```php
Order::search('mail@example.com')->get();
```

If we need the search string we can get that from the scout builder
```php
public function newScoutQuery(\Laravel\Scout\Builder $builder): Builder
{
    // use $builder->query in query
    return $this->newQuery();
}
```

## Why it matters

It is already somehow possible, but you have to extend the search method. And this does not work with laravel nova, because nova overrides the query callback of the scout builder

```php
// Order.php

use Searchable {
    Searchable::search as parentSearch;
}

public static function search($query = '', $callback = null): \Laravel\Scout\Builder
{
    return static::parentSearch($query, $callback)->query(function ($query) {
        $query->join('customers', 'orders.customer_id', '=', 'customers.id')
    });
}
```