### PR TITLE
fix(pagination): prevent integer overflow in typesense pagination

### DIFF
--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -228,6 +228,14 @@ class TypesenseEngine extends Engine
      */
     public function paginate(Builder $builder, $perPage, $page)
     {
+        $maxInt = 4294967295;
+        $page = max(1, (int)$page);
+        $perPage = max(1, (int)$perPage);
+
+        if ($page * $perPage > $maxInt) {
+            $page = floor($maxInt / $perPage);
+        }
+        
         return $this->performSearch(
             $builder,
             $this->buildSearchParameters($builder, $page, $perPage)

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -229,13 +229,13 @@ class TypesenseEngine extends Engine
     public function paginate(Builder $builder, $perPage, $page)
     {
         $maxInt = 4294967295;
-        $page = max(1, (int)$page);
-        $perPage = max(1, (int)$perPage);
+        $page = max(1, (int) $page);
+        $perPage = max(1, (int) $perPage);
 
         if ($page * $perPage > $maxInt) {
             $page = floor($maxInt / $perPage);
         }
-        
+
         return $this->performSearch(
             $builder,
             $this->buildSearchParameters($builder, $page, $perPage)

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -229,6 +229,7 @@ class TypesenseEngine extends Engine
     public function paginate(Builder $builder, $perPage, $page)
     {
         $maxInt = 4294967295;
+
         $page = max(1, (int) $page);
         $perPage = max(1, (int) $perPage);
 

--- a/tests/Integration/TypesenseSearchableTest.php
+++ b/tests/Integration/TypesenseSearchableTest.php
@@ -223,6 +223,21 @@ class TypesenseSearchableTest extends TestCase
         $this->assertArrayHasKey('search_time_ms', $rawResults);
     }
 
+    public function test_it_handles_pagination_with_max_int_overflow()
+    {
+        $maxInt = 4294967295;
+        $perPage = 10;
+        $overflowPage = 4294967296; // max int + 1
+        $expectedPage = floor($maxInt / $perPage);
+
+        $results = SearchableUser::search('lar')
+            ->paginate($perPage, $overflowPage);
+
+        // Verify the page was adjusted correctly
+        $this->assertEquals($expectedPage, $results->currentPage());
+        $this->assertEquals($perPage, $results->perPage());
+    }
+
     protected static function scoutDriver(): string
     {
         return 'typesense';


### PR DESCRIPTION
Fixes #922


- normalize page parameter to the last possible for Typesense server
- add test to verify pagination works correctly with overflow page numbers

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
