### PR TITLE
Test Improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "orchestra/testbench": "^7.31|^8.11|^9.0|^10.0",
         "php-http/guzzle7-adapter": "^1.0",
         "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^9.3|^10.4"
+        "phpunit/phpunit": "^9.3|^10.4|^11.5"
     },
     "conflict": {
         "algolia/algoliasearch-client-php": "<3.2.0|>=5.0.0"


### PR DESCRIPTION
Laravel 12 requires PHPUnit 11 and above. Fix `composer.json` to allow installation of compatible versions.
