### PR TITLE
feat: add support for Meilisearch embedder settings

### DIFF
--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Scout\Engines;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Contracts\UpdatesIndexSettings;
@@ -397,7 +398,7 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
     {
         $index = $this->meilisearch->index($name);
 
-        $index->updateSettings($settings);
+        $index->updateSettings(Arr::except($settings, 'embedders'));
 
         if (! empty($settings['embedders'])) {
             $index->updateEmbedders($settings['embedders']);

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -395,7 +395,13 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
      */
     public function updateIndexSettings($name, array $settings = [])
     {
-        $this->meilisearch->index($name)->updateSettings($settings);
+        $index = $this->meilisearch->index($name);
+
+        $index->updateSettings($settings);
+
+        if (! empty($settings['embedders'])) {
+            $index->updateEmbedders($settings['embedders']);
+        }
     }
 
     /**

--- a/tests/Unit/MeilisearchEngineTest.php
+++ b/tests/Unit/MeilisearchEngineTest.php
@@ -265,7 +265,7 @@ class MeilisearchEngineTest extends TestCase
         $engine = new MeilisearchEngine($client);
         $engine->updateIndexSettings('test_index', [
             'searchableAttributes' => ['title'],
-            'embedders' => ['default' => ['source' => 'openAi']]
+            'embedders' => ['default' => ['source' => 'openAi']],
         ]);
 
         $this->assertTrue(true);

--- a/tests/Unit/MeilisearchEngineTest.php
+++ b/tests/Unit/MeilisearchEngineTest.php
@@ -255,7 +255,7 @@ class MeilisearchEngineTest extends TestCase
             ->andReturn($index);
 
         $index->shouldReceive('updateSettings')
-            ->with(['searchableAttributes' => ['title'], 'embedders' => ['default' => ['source' => 'openAi']]])
+            ->with(['searchableAttributes' => ['title']])
             ->once();
 
         $index->shouldReceive('updateEmbedders')

--- a/tests/Unit/MeilisearchEngineTest.php
+++ b/tests/Unit/MeilisearchEngineTest.php
@@ -10,6 +10,7 @@ use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\MeilisearchEngine;
 use Laravel\Scout\Tests\Fixtures\SearchableModel;
 use Meilisearch\Client;
+use Meilisearch\Endpoints\Indexes;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -241,6 +242,33 @@ class MeilisearchEngineTest extends TestCase
         $this->assertTrue((new MeilisearchEngine(m::mock(Client::class)))->getTotalCount([
             'totalHits' => 3,
         ]) === 3);
+    }
+
+    public function test_update_index_settings_with_embedders()
+    {
+        $client = m::mock(Client::class);
+        $index = m::mock(Indexes::class);
+
+        $client->shouldReceive('index')
+            ->with('test_index')
+            ->once()
+            ->andReturn($index);
+
+        $index->shouldReceive('updateSettings')
+            ->with(['searchableAttributes' => ['title'], 'embedders' => ['default' => ['source' => 'openAi']]])
+            ->once();
+
+        $index->shouldReceive('updateEmbedders')
+            ->with(['default' => ['source' => 'openAi']])
+            ->once();
+
+        $engine = new MeilisearchEngine($client);
+        $engine->updateIndexSettings('test_index', [
+            'searchableAttributes' => ['title'],
+            'embedders' => ['default' => ['source' => 'openAi']]
+        ]);
+
+        $this->assertTrue(true);
     }
 }
 


### PR DESCRIPTION
### Summary

This PR adds support for defining Meilisearch **index settings for embedders** in Laravel Scout.

Embedders are used when implementing [vector search or hybrid search](https://www.meilisearch.com/docs/learn/ai_powered_search/getting_started_with_ai_search) in Meilisearch. These settings allow Meilisearch to automatically manage vector generation and similarity ranking using external embedding providers.

The Meilisearch PHP SDK already supports this via [this PR](https://github.com/meilisearch/meilisearch-php/pull/608).

### Benefits

With this change, developers can define embedder configurations per index in their `config/scout.php` file, similar to other Meilisearch settings:

```php
// config/scout.php

return [
    // ... other settings

    'meilisearch' => [
        'host' => env('MEILISEARCH_HOST', 'http://localhost:7700'),
        'key' => env('MEILISEARCH_KEY'),

        'index-settings' => [
            'products' => [
                'searchableAttributes' => ['name', 'description'],
                'filterableAttributes' => ['category', 'price'],

                'embedders' => [
                    'default' => [
                        'source' => 'openAi',
                        'apiKey' => env('OAI_API_KEY'),
                        'model' => 'text-embedding-3-small',
                        'dimensions' => 1536,
                        'distribution' => [
                            'mean' => 0.7,
                            'sigma' => 0.3,
                        ],
                    ],
                ],
            ],
        ],
    ],

    // ... other settings
];