### PR TITLE
feat: can disable typesense prefix

### DIFF
--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -345,6 +345,7 @@ class TypesenseEngine extends Engine
             'prioritize_exact_match' => true,
             'enable_overrides' => true,
             'highlight_affix_num_tokens' => 4,
+            'prefix' => config('scout.typesense.model-settings.'.get_class($builder->model).'.search-parameters.prefix') ?? true,
         ];
 
         if (method_exists($builder->model, 'typesenseSearchParameters')) {


### PR DESCRIPTION
Hello 👋,

Typesense offers semantic search capabilities using embeddings. However, the `prefix` search option is not compatible with `vector` (embedding-based) search. This PR enables users to set the `prefix` option to `false` when performing a `vector` search.

Relevant documentation: https://typesense.org/docs/29.0/api/search.html#query-parameters:~:text=Indicates%20that%20the,for%20all%20fields).

Current error when using `vector` search with `prefix` set to `true`:

```txt
Prefix search is not supported for remote embedders. Please set `prefix=false` as an additional search parameter to disable prefix searching.
```
