### PR TITLE
Add support for `--queue` option to `scout:queue-import`

### DIFF
--- a/src/Console/QueueImportCommand.php
+++ b/src/Console/QueueImportCommand.php
@@ -19,7 +19,7 @@ class QueueImportCommand extends Command
             {--min= : The minimum ID to start queuing from}
             {--max= : The maximum ID to queue up to}
             {--c|chunk= : The number of records to queue in a single job (Defaults to configuration value: `scout.chunk.searchable`)}
-            {--q|queue= : The queue to use for the jobs (Defaults to configuration value: `scout.queue.queue`)}';
+            {--queue= : The queue to use for the jobs (Defaults to configuration value: `scout.queue.queue`)}';
 
     /**
      * The console command description.

--- a/src/Console/QueueImportCommand.php
+++ b/src/Console/QueueImportCommand.php
@@ -18,7 +18,8 @@ class QueueImportCommand extends Command
             {model : Class name of model to bulk queue}
             {--min= : The minimum ID to start queuing from}
             {--max= : The maximum ID to queue up to}
-            {--c|chunk= : The number of records to queue in a single job (Defaults to configuration value: `scout.chunk.searchable`)}';
+            {--c|chunk= : The number of records to queue in a single job (Defaults to configuration value: `scout.chunk.searchable`)}
+            {--queue= : The queue to use for the jobs (Defaults to configuration value: `scout.queue.queue`)}';
 
     /**
      * The console command description.
@@ -39,6 +40,8 @@ class QueueImportCommand extends Command
         $model = new $class;
 
         $query = $model::makeAllSearchableQuery();
+
+        $queue = $this->option('queue') ?? $model->syncWithSearchUsingQueue();
 
         $min = $this->option('min') ?? $query->min($model->getScoutKeyName());
         $max = $this->option('max') ?? $query->max($model->getScoutKeyName());
@@ -61,7 +64,7 @@ class QueueImportCommand extends Command
             $end = min($start + $chunk - 1, $max);
 
             dispatch(new MakeRangeSearchable($class, $start, $end))
-                ->onQueue($model->syncWithSearchUsingQueue())
+                ->onQueue($queue)
                 ->onConnection($model->syncWithSearchUsing());
 
             $this->line('<comment>Queued ['.$class.'] models up to ID:</comment> '.$end);

--- a/src/Console/QueueImportCommand.php
+++ b/src/Console/QueueImportCommand.php
@@ -19,7 +19,7 @@ class QueueImportCommand extends Command
             {--min= : The minimum ID to start queuing from}
             {--max= : The maximum ID to queue up to}
             {--c|chunk= : The number of records to queue in a single job (Defaults to configuration value: `scout.chunk.searchable`)}
-            {--queue= : The queue to use for the jobs (Defaults to configuration value: `scout.queue.queue`)}';
+            {--q|queue= : The queue to use for the jobs (Defaults to configuration value: `scout.queue.queue`)}';
 
     /**
      * The console command description.

--- a/src/Console/QueueImportCommand.php
+++ b/src/Console/QueueImportCommand.php
@@ -19,7 +19,7 @@ class QueueImportCommand extends Command
             {--min= : The minimum ID to start queuing from}
             {--max= : The maximum ID to queue up to}
             {--c|chunk= : The number of records to queue in a single job (Defaults to configuration value: `scout.chunk.searchable`)}
-            {--queue= : The queue to use for the jobs (Defaults to configuration value: `scout.queue.queue`)}';
+            {--queue= : The queue that should be used (Defaults to configuration value: `scout.queue.queue`)}';
 
     /**
      * The console command description.
@@ -40,8 +40,6 @@ class QueueImportCommand extends Command
         $model = new $class;
 
         $query = $model::makeAllSearchableQuery();
-
-        $queue = $this->option('queue') ?? $model->syncWithSearchUsingQueue();
 
         $min = $this->option('min') ?? $query->min($model->getScoutKeyName());
         $max = $this->option('max') ?? $query->max($model->getScoutKeyName());
@@ -64,7 +62,7 @@ class QueueImportCommand extends Command
             $end = min($start + $chunk - 1, $max);
 
             dispatch(new MakeRangeSearchable($class, $start, $end))
-                ->onQueue($queue)
+                ->onQueue($this->option('queue') ?? $model->syncWithSearchUsingQueue())
                 ->onConnection($model->syncWithSearchUsing());
 
             $this->line('<comment>Queued ['.$class.'] models up to ID:</comment> '.$end);

--- a/tests/Feature/Commands/QueueImportCommandTest.php
+++ b/tests/Feature/Commands/QueueImportCommandTest.php
@@ -399,6 +399,25 @@ class QueueImportCommandTest extends TestCase
         });
     }
 
+    public function test_it_accepts_custom_queue_option()
+    {
+        Queue::fake();
+
+        SearchableUserFactory::new()->count(10)->create();
+
+        $this->artisan('scout:queue-import', [
+            'model' => SearchableUser::class,
+            '--queue' => 'custom-queue',
+        ])
+            ->expectsOutputToContain('models up to ID: 10')
+            ->expectsOutputToContain('records have been queued')
+            ->assertSuccessful();
+
+        Queue::assertPushedOn('custom-queue', MakeRangeSearchable::class, function ($job) {
+            return $job->start == 1 && $job->end == 10;
+        });
+    }
+
     public function test_it_can_accept_all_options()
     {
         Queue::fake();
@@ -410,6 +429,7 @@ class QueueImportCommandTest extends TestCase
             '--min' => 5,
             '--max' => 15,
             '--chunk' => 4,
+            '--queue' => 'custom-queue',
         ])
             ->expectsOutputToContain('models up to ID: 8')
             ->expectsOutputToContain('models up to ID: 12')
@@ -419,5 +439,17 @@ class QueueImportCommandTest extends TestCase
 
         // Should dispatch 3 jobs: [5-8], [9-12], [13-15]
         Queue::assertPushed(MakeRangeSearchable::class, 3);
+
+        Queue::assertPushedOn('custom-queue', MakeRangeSearchable::class, function ($job) {
+            return $job->start == 5 && $job->end == 8;
+        });
+
+        Queue::assertPushedOn('custom-queue', MakeRangeSearchable::class, function ($job) {
+            return $job->start == 9 && $job->end == 12;
+        });
+
+        Queue::assertPushedOn('custom-queue', MakeRangeSearchable::class, function ($job) {
+            return $job->start == 13 && $job->end == 15;
+        });
     }
 }


### PR DESCRIPTION
This PR adds a `--queue` option to the newly added `scout:queue-import` command. 
This option is useful for performing huge re-indexes where we do not want to disrupt the normal scout queue with thousands of jobs before new items are indexed.

**Usage**
```sh
php artisan scout:queue "App\Models\Post" --queue=scout-reindex
```