### PR TITLE
Feature: add typesense remote embedding settings

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -204,6 +204,11 @@ return [
             //     ],
             // ],
         ],
+        'remote-embedding-settings' => [
+            'remote_embedding_batch_size' => env('TYPESENSE_REMOTE_EMBEDDING_BATCH_SIZE', 200),
+            'remote_embedding_timeout_ms' => env('TYPESENSE_REMOTE_EMBEDDING_TIMEOUT_MS', 60000),
+            'remote_embedding_num_tries' => env('TYPESENSE_REMOTE_EMBEDDING_NUM_TRIES', 2),
+        ],
     ],
 
 ];

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -113,7 +113,8 @@ class TypesenseEngine extends Engine
      */
     protected function importDocuments(TypesenseCollection $collectionIndex, array $documents, string $action = 'upsert'): Collection
     {
-        $importedDocuments = $collectionIndex->getDocuments()->import($documents, ['action' => $action]);
+        $remoteEmbeddingIndex = $this->getRemoteEmbeddingSettings();
+        $importedDocuments = $collectionIndex->getDocuments()->import($documents, ['action' => $action, ...$remoteEmbeddingIndex]);
 
         $results = [];
 
@@ -688,5 +689,19 @@ class TypesenseEngine extends Engine
     public function __call($method, $parameters)
     {
         return $this->typesense->$method(...$parameters);
+    }
+
+    /**
+     * Get the remote embedding settings from the configuration.
+     *
+     * @return array
+     */
+    protected function getRemoteEmbeddingSettings(): array
+    {
+        return config('scout.typesense.remote-embedding-settings', [
+            'remote_embedding_batch_size' => env('TYPESENSE_REMOTE_EMBEDDING_BATCH_SIZE', 200),
+            'remote_embedding_timeout_ms' => env('TYPESENSE_REMOTE_EMBEDDING_TIMEOUT_MS', 60000),
+            'remote_embedding_num_tries' => env('TYPESENSE_REMOTE_EMBEDDING_NUM_TRIES', 2),
+        ]);
     }
 }

--- a/tests/Unit/TypesenseEngineTest.php
+++ b/tests/Unit/TypesenseEngineTest.php
@@ -28,7 +28,7 @@ class TypesenseEngineTest extends TestCase
         $typesenseClient = $this->createMock(TypesenseClient::class);
         $this->engine = $this->getMockBuilder(TypesenseEngine::class)
             ->setConstructorArgs([$typesenseClient, 1000])
-            ->onlyMethods(['getOrCreateCollectionFromModel', 'buildSearchParameters'])
+            ->onlyMethods(['getOrCreateCollectionFromModel', 'buildSearchParameters', 'getRemoteEmbeddingSettings'])
             ->getMock();
     }
 
@@ -142,6 +142,11 @@ class TypesenseEngineTest extends TestCase
         $this->engine->expects($this->once())
             ->method('getOrCreateCollectionFromModel')
             ->willReturn($collection);
+
+        // Mock the getRemoteEmbeddingSettings method
+        $this->engine->expects($this->once())
+            ->method('getRemoteEmbeddingSettings')
+            ->willReturn([]);
 
         // Call the update method
         $this->engine->update(collect($models));


### PR DESCRIPTION
This PR adds the capability of customizing the behavior of typesense performing remote embedding through specifying parameters in config/scout.php file.

Related documentation:
https://typesense.org/docs/29.0/api/vector-search.html#remote-embedding-api-parameters

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
