### PR TITLE
Add scout:import-all command to import all Searchable models

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -18,6 +18,10 @@ return [
 
     'driver' => env('SCOUT_DRIVER', 'algolia'),
 
+    'models' => [
+        // App\Models\User::class,
+    ],
+
     /*
     |--------------------------------------------------------------------------
     | Index Prefix

--- a/config/scout.php
+++ b/config/scout.php
@@ -18,6 +18,17 @@ return [
 
     'driver' => env('SCOUT_DRIVER', 'algolia'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Models
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the models that will be imported into the search engine
+    | when running the `scout:import-all` command. These models will be flushed
+    | first. If empty then models with the Searchable trait will be imported.
+    |
+    */
+    
     'models' => [
         // App\Models\User::class,
     ],

--- a/src/Console/ImportAllModelsCommand.php
+++ b/src/Console/ImportAllModelsCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Laravel\Scout\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'scout:import-all')]
+class ImportAllModelsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'scout:import-all';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Import all models to scout index';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        // $this->info('Importing all models to scout index...');
+
+
+        $models = config('scout.models') ?? [];
+
+        if (empty($models)) {
+            $this->error('No models found in config/scout.php');
+
+            return;
+        }
+
+        // $this->info('Found ' . count($models) . ' models to import');
+
+        foreach ($models as $model) {
+            // $this->info("Flushing $model...");
+            $this->call('scout:flush', ['model' => $model]);
+        }
+        $this->line('');
+
+        foreach ($models as $model) {
+            // $this->info("Syncing $model...");
+            $this->call('scout:import', ['model' => $model]);
+        }
+
+        $this->line('');
+
+
+        $this->info('Scout index synced');
+    }
+}

--- a/src/Console/ImportAllModelsCommand.php
+++ b/src/Console/ImportAllModelsCommand.php
@@ -3,6 +3,7 @@
 namespace Laravel\Scout\Console;
 
 use Illuminate\Console\Command;
+use Laravel\Scout\Searchable;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'scout:import-all')]
@@ -27,33 +28,94 @@ class ImportAllModelsCommand extends Command
      */
     public function handle()
     {
-        // $this->info('Importing all models to scout index...');
+        $configModels = config('scout.models') ?? [];
 
+        // This flag is deteermines if we are auto discovering models.
+        // It will be set to true if the config('scout.models') is empty.
+        $autoDiscoveringModels = empty($configModels);
 
-        $models = config('scout.models') ?? [];
+        if ($autoDiscoveringModels) {
+            $models = $this->getSearchableModels();
+        } else {
+            $this->validateModelsAreSearchable($configModels);
+            $models = $configModels;
+        }
 
         if (empty($models)) {
-            $this->error('No models found in config/scout.php');
-
+            $this->error('No searchable models found.');
             return;
         }
 
-        // $this->info('Found ' . count($models) . ' models to import');
-
+        // Flush all models first
         foreach ($models as $model) {
-            // $this->info("Flushing $model...");
             $this->call('scout:flush', ['model' => $model]);
         }
         $this->line('');
 
+        // Import all models
         foreach ($models as $model) {
-            // $this->info("Syncing $model...");
             $this->call('scout:import', ['model' => $model]);
         }
 
         $this->line('');
+        $this->info('All models have been imported successfully.');
+    }
 
+    /**
+     * Get models from config.
+     *
+     * @return array
+     */
+    protected function validateModelsAreSearchable(array $models): void
+    {
+        foreach ($models as $model) {
+            if (!in_array(Searchable::class, class_uses_recursive($model))) {
+                $this->error('Model ' . $model . ' is not searchable.');
+                exit(1);
+            }
+        }
+    }
 
-        $this->info('Scout index synced');
+    /**
+     * Get all models that use the Searchable trait.
+     *
+     * @return array
+     */
+    protected function getSearchableModels(): array
+    {
+        $searchableModels = [];
+        $modelPath = app_path('Models');
+
+        // Fallback to app/ for older Laravel versions
+        if (!is_dir($modelPath)) {
+            $modelPath = app_path();
+        }
+
+        foreach (glob($modelPath . '/*.php') as $file) {
+            $class = $this->getClassFromFile($file);
+
+            if (
+                $class && class_exists($class) &&
+                in_array(Searchable::class, class_uses_recursive($class))
+            ) {
+                $searchableModels[] = $class;
+            }
+        }
+
+        return $searchableModels;
+    }
+
+    /**
+     * Get class name from file.
+     *
+     * @param string $file
+     * @return string|null
+     */
+    protected function getClassFromFile(string $file): ?string
+    {
+        $class = basename($file, '.php');
+        $fullClass = 'App\\Models\\' . $class;
+
+        return class_exists($fullClass) ? $fullClass : null;
     }
 }

--- a/src/ScoutServiceProvider.php
+++ b/src/ScoutServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Support\ServiceProvider;
 use Laravel\Scout\Console\DeleteAllIndexesCommand;
 use Laravel\Scout\Console\DeleteIndexCommand;
 use Laravel\Scout\Console\FlushCommand;
+use Laravel\Scout\Console\ImportAllModelsCommand;
 use Laravel\Scout\Console\ImportCommand;
 use Laravel\Scout\Console\IndexCommand;
 use Laravel\Scout\Console\QueueImportCommand;
@@ -21,7 +22,7 @@ class ScoutServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->mergeConfigFrom(__DIR__.'/../config/scout.php', 'scout');
+        $this->mergeConfigFrom(__DIR__ . '/../config/scout.php', 'scout');
 
         if (class_exists(Meilisearch::class)) {
             $this->app->singleton(Meilisearch::class, function ($app) {
@@ -56,10 +57,11 @@ class ScoutServiceProvider extends ServiceProvider
                 SyncIndexSettingsCommand::class,
                 DeleteIndexCommand::class,
                 DeleteAllIndexesCommand::class,
+                ImportAllModelsCommand::class,
             ]);
 
             $this->publishes([
-                __DIR__.'/../config/scout.php' => $this->app['path.config'].DIRECTORY_SEPARATOR.'scout.php',
+                __DIR__ . '/../config/scout.php' => $this->app['path.config'] . DIRECTORY_SEPARATOR . 'scout.php',
             ]);
         }
     }


### PR DESCRIPTION
This PR implements a new `scout:import-all` command to automatically import all models that contain the Searchable trait, or all the models that were specified in the scout.php config file.

I've worked in multiple projects where I've had to re-import all models, and run the php artisan scout:import command per each model. This PR resolves this, by automatically discovering the models that have the Searchable trait.
If you want to specify which models should be imported when running the command, then in the scout.php config file there is a models key with an empty array where you can specify the models you want this command to import.

Let me know your thoughts!
Thanks



## Summary
This PR adds a new `scout:import-all` command that automatically discovers and imports all searchable models to the search index, eliminating the need to run `scout:import` individually for each model.

## Problem
In projects with multiple searchable models, developers currently need to run `php artisan scout:import` for each model individually when re-indexing data.

## Solution
The new command provides two ways to import models:

1. **Auto-discovery** (default): Automatically finds all models using the `Searchable` trait
2. **Configuration-based**: Specify models in `config/scout.php`

## Usage
```bash
php artisan scout:import-all

```

## Configuration (Optional)
```php
// config/scout.php
'models' => [
    App\Models\User::class,
    App\Models\Post::class,
    App\Models\Product::class,
],
```