### PR TITLE
Change Typesense action mode to emplace when import documents

### DIFF
--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -111,7 +111,7 @@ class TypesenseEngine extends Engine
      * @throws \Typesense\Exceptions\TypesenseClientError
      * @throws \Http\Client\Exception
      */
-    protected function importDocuments(TypesenseCollection $collectionIndex, array $documents, string $action = 'upsert'): Collection
+    protected function importDocuments(TypesenseCollection $collectionIndex, array $documents, string $action = 'emplace'): Collection
     {
         $importedDocuments = $collectionIndex->getDocuments()->import($documents, ['action' => $action]);
 

--- a/tests/Unit/TypesenseEngineTest.php
+++ b/tests/Unit/TypesenseEngineTest.php
@@ -133,7 +133,7 @@ class TypesenseEngineTest extends TestCase
         $documents->expects($this->once())
             ->method('import')
             ->with(
-                [['id' => 1, 'name' => 'Model 1']], ['action' => 'upsert'],
+                [['id' => 1, 'name' => 'Model 1']], ['action' => 'emplace'],
             )
             ->willReturn([[
                 'success' => true,


### PR DESCRIPTION
This PR changes the action mode to emplace when importing documents to Typesense. This is useful to make sure data will not be overwritten when user have other fields in Typesense that is managed seperately (like externally generated embeddings).

Related documentation:
https://typesense.org/docs/29.0/api/documents.html#action-modes-create-upsert-update-emplace

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
