### PR TITLE
Add `--flush` option to ImportCommand

### DIFF
--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -17,7 +17,7 @@ class ImportCommand extends Command
      */
     protected $signature = 'scout:import
             {model : Class name of model to bulk import}
-            {--flush : Flush the index before importing}
+            {--fresh : Flush the index before importing}
             {--c|chunk= : The number of records to import at a time (Defaults to configuration value: `scout.chunk.searchable`)}';
 
     /**
@@ -45,7 +45,7 @@ class ImportCommand extends Command
             $this->line('<comment>Imported ['.$class.'] models up to ID:</comment> '.$key);
         });
 
-        if ($this->option('flush')) {
+        if ($this->option('fresh')) {
             $model::removeAllFromSearch();
         }
 

--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -17,6 +17,7 @@ class ImportCommand extends Command
      */
     protected $signature = 'scout:import
             {model : Class name of model to bulk import}
+            {--flush : Flush the index before importing}
             {--c|chunk= : The number of records to import at a time (Defaults to configuration value: `scout.chunk.searchable`)}';
 
     /**
@@ -43,6 +44,10 @@ class ImportCommand extends Command
 
             $this->line('<comment>Imported ['.$class.'] models up to ID:</comment> '.$key);
         });
+
+        if ($this->option('flush')) {
+            $model::removeAllFromSearch();
+        }
 
         $model::makeAllSearchable($this->option('chunk'));
 


### PR DESCRIPTION
Adds the `--flush` flag to `artisan scout:import` which if passed in, will flush the index out before importing

I just spent a few hours trying to figure out why pagination result numbers were not matching up. 
The issue was that the index had old records that were missing form the database (due to manual database changes). I had run the import command but assumed it flushed the index out first - turns out it doesn't.

This change makes it a bit more apparent that it does not flush by default (maybe it should?) and gives and easy option to do so (why wouldn't you?).