### PR TITLE
feat: add driver option to sync-index-settings command

### DIFF
--- a/src/Console/SyncIndexSettingsCommand.php
+++ b/src/Console/SyncIndexSettingsCommand.php
@@ -18,7 +18,7 @@ class SyncIndexSettingsCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'scout:sync-index-settings';
+    protected $signature = 'scout:sync-index-settings {--driver= : The name of the search engine driver (Defaults to configuration value: `scout.driver`)}';
 
     /**
      * The console command description.
@@ -35,9 +35,9 @@ class SyncIndexSettingsCommand extends Command
      */
     public function handle(EngineManager $manager)
     {
-        $engine = $manager->engine();
+        $driver = $this->option('driver') ?: config('scout.driver');
 
-        $driver = config('scout.driver');
+        $engine = $manager->engine($driver);
 
         if (! $engine instanceof UpdatesIndexSettings) {
             return $this->error('The "'.$driver.'" engine does not support updating index settings.');


### PR DESCRIPTION
This PR adds the ability to select the driver when we update index settings (`scout:sync-index-settings`).

Currently, we have no choice, the update is made for the default driver, which is not handy when you use multiple drivers (like Algolia and Meilisearch).

I didn't find a test related to this specific command, but the changes are really minimal.

Have a nice day :)