### PR TITLE
Change SCOUT_DRIVER default from 'algolia' to 'collection'

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -16,7 +16,7 @@ return [
     |
     */
 
-    'driver' => env('SCOUT_DRIVER', 'algolia'),
+    'driver' => env('SCOUT_DRIVER', 'collection'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Using a default driver that isn't available out of the box and requires installing additional packages and configuration is a problem when a package requires laravel/scout. In that case, the package can't configure laravel/scout automatically and exceptions will be thrown making the user think that the package doesn't work. There should be a working default for a successful start for those developers who don't read documentation well.
