### PR TITLE
Full-text improvements

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -579,4 +579,12 @@ class Builder
     {
         return $this->model->searchableUsing();
     }
+
+    /**
+     * Get the connection type for the underlying model.
+     */
+    public function modelConnectionType(): string
+    {
+        return $this->model->getConnection()->getDriverName();
+    }
 }

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -260,7 +260,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
 
         return $query->orderByRaw(
             sprintf(
-                "ts_rank(".$vectors.", %s(?)) desc",
+                'ts_rank('.$vectors.', %s(?)) desc',
                 match ($this->getFullTextOptions($builder)['mode'] ?? 'plainto_tsquery') {
                     'phrase' => 'phraseto_tsquery',
                     'websearch' => 'websearch_to_tsquery',

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -256,11 +256,11 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
 
         $vectors = collect($fullTextColumns)->map(function ($column) use ($builder, $language) {
             return sprintf("to_tsvector('%s', %s)", $language, $builder->model->qualifyColumn($column));
-        });
+        })->implode(' || ');
 
         return $query->orderByRaw(
             sprintf(
-                "ts_rank(".$vectors->implode(' || ').", %s(?)) desc",
+                "ts_rank(".$vectors.", %s(?)) desc",
                 match ($this->getFullTextOptions($builder)['mode'] ?? 'plainto_tsquery') {
                     'phrase' => 'phraseto_tsquery',
                     'websearch' => 'websearch_to_tsquery',

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -252,6 +252,9 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
      */
     protected function shouldOrderByRelevance(Builder $builder): bool
     {
+        // MySQL orders by relevance by default, so we will only order by relevance on
+        // Postgres with no developer-defined orders. If there is developer defined
+        // order by clauses we will let those take precedence over the relevance.
         return $builder->modelConnectionType() === 'pgsql' &&
             count($this->getFullTextColumns($builder)) > 0 &&
             empty($builder->orders);

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -228,11 +228,13 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
                 }
             }
 
-            $query->orWhereFullText(
-                array_map(fn ($column) => $builder->model->qualifyColumn($column), $fullTextColumns),
-                $builder->query,
-                $this->getFullTextOptions($builder)
-            );
+            if (count($fullTextColumns) > 0) {
+                $query->orWhereFullText(
+                    array_map(fn ($column) => $builder->model->qualifyColumn($column), $fullTextColumns),
+                    $builder->query,
+                    $this->getFullTextOptions($builder)
+                );
+            }
         });
 
         if ($connectionType === 'pgsql' && empty($builder->orders)) {

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -206,7 +206,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
         }
 
         [$connectionType] = [
-            $builder->model->getConnection()->getDriverName(),
+            $builder->modelConnectionType(),
         ];
 
         return $query->where(function ($query) use ($connectionType, $builder, $columns, $prefixColumns, $fullTextColumns) {

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -196,9 +196,11 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
             return $query;
         }
 
-        return $query->where(function ($query) use ($builder, $columns, $prefixColumns, $fullTextColumns) {
-            $connectionType = $builder->model->getConnection()->getDriverName();
+        [$connectionType] = [
+            $builder->model->getConnection()->getDriverName(),
+        ];
 
+        $query->where(function ($query) use ($connectionType, $builder, $columns, $prefixColumns, $fullTextColumns) {
             $canSearchPrimaryKey = ctype_digit($builder->query) &&
                                    in_array($builder->model->getKeyType(), ['int', 'integer']) &&
                                    ($connectionType != 'pgsql' || $builder->query <= PHP_INT_MAX) &&
@@ -212,11 +214,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
 
             foreach ($columns as $column) {
                 if (in_array($column, $fullTextColumns)) {
-                    $query->orWhereFullText(
-                        $builder->model->qualifyColumn($column),
-                        $builder->query,
-                        $this->getFullTextOptions($builder)
-                    );
+                    continue;
                 } else {
                     if ($canSearchPrimaryKey && $column === $builder->model->getScoutKeyName()) {
                         continue;
@@ -229,7 +227,48 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
                     );
                 }
             }
+
+            $query->orWhereFullText(
+                array_map(fn ($column) => $builder->model->qualifyColumn($column), $fullTextColumns),
+                $builder->query,
+                $this->getFullTextOptions($builder)
+            );
         });
+
+        if ($connectionType === 'pgsql' && empty($builder->orders)) {
+            $query = $this->addOrderByRelevance($query, $builder, $fullTextColumns);
+        }
+
+        return $query;
+    }
+
+    /**
+     * Add an "order by" clause that orders by relevance (Postgres only).
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  array  $fullTextColumns
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function addOrderByRelevance($query, Builder $builder, array $fullTextColumns)
+    {
+        $language = $this->getFullTextOptions($builder)['language'] ?? 'english';
+
+        $vectors = collect($fullTextColumns)->map(function ($column) use ($builder, $language) {
+            return sprintf("to_tsvector('%s', %s)", $language, $builder->model->qualifyColumn($column));
+        });
+
+        return $query->orderByRaw(
+            sprintf(
+                "ts_rank(".$vectors->implode(' || ').", %s(?)) desc",
+                match ($this->getFullTextOptions($builder)['mode'] ?? 'plainto_tsquery') {
+                    'phrase' => 'phraseto_tsquery',
+                    'websearch' => 'websearch_to_tsquery',
+                    default => 'plainto_tsquery',
+                },
+            ),
+            [$builder->query]
+        );
     }
 
     /**

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -62,6 +62,34 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
     }
 
     /**
+     * Get the Eloquent models for the given builder.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  int|null  $page
+     * @param  int|null  $perPage
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    protected function searchModels(Builder $builder, $page = null, $perPage = null)
+    {
+        return $this->buildSearchQuery($builder)
+            ->when(! is_null($page) && ! is_null($perPage), function ($query) use ($page, $perPage) {
+                $query->forPage($page, $perPage);
+            })
+            ->when($builder->orders, function ($query) use ($builder) {
+                foreach ($builder->orders as $order) {
+                    $query->orderBy($order['column'], $order['direction']);
+                }
+            })
+            ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
+                $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
+            })
+            ->when($this->shouldOrderByRelevance($builder), function ($query) use ($builder) {
+                $this->orderByRelevance($builder, $query);
+            })
+            ->get();
+    }
+
+    /**
      * Paginate the given search on the engine.
      *
      * @param  \Laravel\Scout\Builder  $builder
@@ -93,6 +121,9 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
             })
             ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
                 $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
+            })
+            ->when($this->shouldOrderByRelevance($builder), function ($query) use ($builder) {
+                $this->orderByRelevance($builder, $query);
             })
             ->paginate($perPage, ['*'], $pageName, $page);
     }
@@ -129,32 +160,10 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
             ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
                 $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
             })
+            ->when($this->shouldOrderByRelevance($builder), function ($query) use ($builder) {
+                $this->orderByRelevance($builder, $query);
+            })
             ->simplePaginate($perPage, ['*'], $pageName, $page);
-    }
-
-    /**
-     * Get the Eloquent models for the given builder.
-     *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @param  int|null  $page
-     * @param  int|null  $perPage
-     * @return \Illuminate\Database\Eloquent\Collection
-     */
-    protected function searchModels(Builder $builder, $page = null, $perPage = null)
-    {
-        return $this->buildSearchQuery($builder)
-            ->when(! is_null($page) && ! is_null($perPage), function ($query) use ($page, $perPage) {
-                $query->forPage($page, $perPage);
-            })
-            ->when($builder->orders, function ($query) use ($builder) {
-                foreach ($builder->orders as $order) {
-                    $query->orderBy($order['column'], $order['direction']);
-                }
-            })
-            ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
-                $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
-            })
-            ->get();
     }
 
     /**
@@ -200,7 +209,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
             $builder->model->getConnection()->getDriverName(),
         ];
 
-        $query->where(function ($query) use ($connectionType, $builder, $columns, $prefixColumns, $fullTextColumns) {
+        return $query->where(function ($query) use ($connectionType, $builder, $columns, $prefixColumns, $fullTextColumns) {
             $canSearchPrimaryKey = ctype_digit($builder->query) &&
                                    in_array($builder->model->getKeyType(), ['int', 'integer']) &&
                                    ($connectionType != 'pgsql' || $builder->query <= PHP_INT_MAX) &&
@@ -236,26 +245,29 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
                 );
             }
         });
+    }
 
-        if ($connectionType === 'pgsql' &&
-            count($fullTextColumns) > 0 &&
-            empty($builder->orders)) {
-            $query = $this->orderByRelevance($query, $builder, $fullTextColumns);
-        }
-
-        return $query;
+    /**
+     * Determine if the query should be ordered by relevance.
+     */
+    protected function shouldOrderByRelevance(Builder $builder): bool
+    {
+        return $builder->modelConnectionType() === 'pgsql' &&
+            count($this->getFullTextColumns($builder)) > 0 &&
+            empty($builder->orders);
     }
 
     /**
      * Add an "order by" clause that orders by relevance (Postgres only).
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @param  \Laravel\Scout\Builder  $builder
-     * @param  array  $fullTextColumns
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    protected function orderByRelevance($query, Builder $builder, array $fullTextColumns)
+    protected function orderByRelevance(Builder $builder, $query)
     {
+        $fullTextColumns = $this->getFullTextColumns($builder);
+
         $language = $this->getFullTextOptions($builder)['language'] ?? 'english';
 
         $vectors = collect($fullTextColumns)->map(function ($column) use ($builder, $language) {

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -238,7 +238,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
         });
 
         if ($connectionType === 'pgsql' && empty($builder->orders)) {
-            $query = $this->addOrderByRelevance($query, $builder, $fullTextColumns);
+            $query = $this->orderByRelevance($query, $builder, $fullTextColumns);
         }
 
         return $query;
@@ -252,7 +252,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
      * @param  array  $fullTextColumns
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    protected function addOrderByRelevance($query, Builder $builder, array $fullTextColumns)
+    protected function orderByRelevance($query, Builder $builder, array $fullTextColumns)
     {
         $language = $this->getFullTextOptions($builder)['language'] ?? 'english';
 

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -237,7 +237,9 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
             }
         });
 
-        if ($connectionType === 'pgsql' && empty($builder->orders)) {
+        if ($connectionType === 'pgsql' &&
+            count($fullTextColumns) > 0 &&
+            empty($builder->orders)) {
             $query = $this->orderByRelevance($query, $builder, $fullTextColumns);
         }
 

--- a/src/Scout.php
+++ b/src/Scout.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Scout;
 
-use Laravel\Scout\EngineManager;
 use Laravel\Scout\Engines\Engine;
 use Laravel\Scout\Jobs\MakeSearchable;
 use Laravel\Scout\Jobs\RemoveFromSearch;

--- a/src/Scout.php
+++ b/src/Scout.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Scout;
 
+use Laravel\Scout\EngineManager;
+use Laravel\Scout\Engines\Engine;
 use Laravel\Scout\Jobs\MakeSearchable;
 use Laravel\Scout\Jobs\RemoveFromSearch;
 
@@ -27,6 +29,14 @@ class Scout
      * @var string
      */
     public static $removeFromSearchJob = RemoveFromSearch::class;
+
+    /**
+     * Get a Scout engine instance.
+     */
+    public static function engine(string $engine): Engine
+    {
+        return app(EngineManager::class)->engine($engine);
+    }
 
     /**
      * Specify the job class that should make models searchable.


### PR DESCRIPTION
This makes a couple of improvements to full-text support when using the `database` engine.

- Just pass multiple columns to `orWhereFullText` in a single call.
- When using Postgres and no other developer provided ordering has been defined, automatically add relevance based ordering by default to match MySQL's built-in ordering behavior.