### PR TITLE
[10.x] Use try-finally to ensure forceSaving flag is always reset

### DIFF
--- a/src/ModelObserver.php
+++ b/src/ModelObserver.php
@@ -172,11 +172,11 @@ class ModelObserver
     {
         $this->forceSaving = true;
 
-        $result = $callback();
-
-        $this->forceSaving = false;
-
-        return $result;
+        try {
+            return $callback();
+        } finally {
+            $this->forceSaving = false;
+        }
     }
 
     /**


### PR DESCRIPTION
This PR updates the `whileForcingUpdate` method to use a try...finally block.
Previously, if the provided callback threw an exception, the `$forceSaving` flag could remain true