### PR TITLE
[10.x] Add `class-string` type annotations to `ModelObserver`

### DIFF
--- a/src/ModelObserver.php
+++ b/src/ModelObserver.php
@@ -32,7 +32,7 @@ class ModelObserver
     /**
      * The class names that syncing is disabled for.
      *
-     * @var array
+     * @var array<class-string<\Illuminate\Database\Eloquent\Model>, bool>
      */
     protected static $syncingDisabledFor = [];
 
@@ -50,7 +50,7 @@ class ModelObserver
     /**
      * Enable syncing for the given class.
      *
-     * @param  string  $class
+     * @param  class-string<\Illuminate\Database\Eloquent\Model>  $class
      * @return void
      */
     public static function enableSyncingFor($class)
@@ -61,7 +61,7 @@ class ModelObserver
     /**
      * Disable syncing for the given class.
      *
-     * @param  string  $class
+     * @param  class-string<\Illuminate\Database\Eloquent\Model>  $class
      * @return void
      */
     public static function disableSyncingFor($class)
@@ -72,7 +72,7 @@ class ModelObserver
     /**
      * Determine if syncing is disabled for the given class or model.
      *
-     * @param  object|string  $class
+     * @param  object|class-string<\Illuminate\Database\Eloquent\Model>  $class
      * @return bool
      */
     public static function syncingDisabledFor($class)


### PR DESCRIPTION
This update adds explicit class-string type annotations for model-related parameters and properties in the `ModelObserver` class. These annotations enhance static analysis precision and improve IDE autocompletion support.