### PR TITLE
[10.x] Make `$limit` and `$index` properties nullable in `Builder`

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -57,7 +57,7 @@ class Builder
     /**
      * The custom index specified for the search.
      *
-     * @var string
+     * @var string|null
      */
     public $index;
 
@@ -85,7 +85,7 @@ class Builder
     /**
      * The "limit" that should be applied to the search.
      *
-     * @var int
+     * @var int|null
      */
     public $limit;
 


### PR DESCRIPTION
Clarify that `$limit` and `$index` properties in the `Builder` class can be null.