### PR TITLE
Typesense Import Action - default to upsert

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -204,6 +204,7 @@ return [
             //     ],
             // ],
         ],
+        'import_action' => env('TYPESENSE_IMPORT_ACTION', 'upsert'),
     ],
 
 ];

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Exceptions\NotSupportedException;
@@ -107,15 +108,17 @@ class TypesenseEngine extends Engine
      *
      * @param  TypesenseCollection  $collectionIndex
      * @param  array  $documents
-     * @param  string  $action
+     * @param  string|null  $action
      * @return \Illuminate\Support\Collection
      *
      * @throws \JsonException
      * @throws \Typesense\Exceptions\TypesenseClientError
      * @throws \Http\Client\Exception
      */
-    protected function importDocuments(TypesenseCollection $collectionIndex, array $documents, string $action = 'emplace'): Collection
+    protected function importDocuments(TypesenseCollection $collectionIndex, array $documents, ?string $action = null): Collection
     {
+        $action = $action ?? Config::get('scout.typesense.import_action', 'upsert');
+
         $importedDocuments = $collectionIndex->getDocuments()->import($documents, ['action' => $action]);
 
         $results = [];

--- a/tests/Unit/TypesenseEngineTest.php
+++ b/tests/Unit/TypesenseEngineTest.php
@@ -46,7 +46,6 @@ class TypesenseEngineTest extends TestCase
         Container::getInstance()->flush();
 
         $this->tearDownTheTestEnvironmentUsingMockery();
-
     }
 
     /**

--- a/tests/Unit/TypesenseEngineTest.php
+++ b/tests/Unit/TypesenseEngineTest.php
@@ -6,10 +6,13 @@ use Http\Client\Exception;
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Facade;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\TypesenseEngine;
 use Laravel\Scout\Tests\Fixtures\SearchableModel;
 use Mockery as m;
+use Orchestra\Testbench\Concerns\InteractsWithMockery;
 use PHPUnit\Framework\TestCase;
 use Typesense\Client as TypesenseClient;
 use Typesense\Collection as TypesenseCollection;
@@ -18,11 +21,17 @@ use Typesense\Exceptions\TypesenseClientError;
 
 class TypesenseEngineTest extends TestCase
 {
+    use InteractsWithMockery;
+
     protected TypesenseEngine $engine;
 
     protected function setUp(): void
     {
         parent::setUp();
+
+        Facade::clearResolvedInstances();
+        Config::shouldReceive('get')->with('scout.after_commit', m::any())->andReturn(false);
+        Config::shouldReceive('get')->with('scout.soft_delete', m::any())->andReturn(false);
 
         // Mock the Typesense client and pass it to the engine constructor
         $typesenseClient = $this->createMock(TypesenseClient::class);
@@ -35,7 +44,9 @@ class TypesenseEngineTest extends TestCase
     protected function tearDown(): void
     {
         Container::getInstance()->flush();
-        m::close();
+
+        $this->tearDownTheTestEnvironmentUsingMockery();
+
     }
 
     /**
@@ -111,6 +122,49 @@ class TypesenseEngineTest extends TestCase
 
     public function test_update_method(): void
     {
+        Config::shouldReceive('get')->with('scout.typesense.import_action', m::any())->andReturn('upsert');
+
+        // Mock models and their methods
+        $models = [
+            $this->createMock(SearchableModel::class),
+        ];
+
+        $models[0]->expects($this->once())
+            ->method('toSearchableArray')
+            ->willReturn(['id' => 1, 'name' => 'Model 1']);
+
+        $models[0]->expects($this->once())
+            ->method('scoutMetadata')
+            ->willReturn([]);
+
+        // Mock the getOrCreateCollectionFromModel method
+        $collection = $this->createMock(TypesenseCollection::class);
+        $documents = $this->createMock(Documents::class);
+        $collection->expects($this->once())
+            ->method('getDocuments')
+            ->willReturn($documents);
+        $documents->expects($this->once())
+            ->method('import')
+            ->with(
+                [['id' => 1, 'name' => 'Model 1']], ['action' => 'upsert'],
+            )
+            ->willReturn([[
+                'success' => true,
+            ]]);
+
+        $this->engine->expects($this->once())
+            ->method('getOrCreateCollectionFromModel')
+            ->willReturn($collection);
+
+        // Call the update method
+        $this->engine->update(collect($models));
+    }
+
+    public function test_update_method_with_emplace_action(): void
+    {
+        // Override config for this specific test
+        Config::shouldReceive('get')->with('scout.typesense.import_action', m::any())->andReturn('emplace');
+
         // Mock models and their methods
         $models = [
             $this->createMock(SearchableModel::class),


### PR DESCRIPTION
## Problem

The default action was changed from `upsert` to `emplace` in https://github.com/laravel/scout/pull/936

According to the Typesense docs (https://typesense.org/docs/29.0/api/documents.html#index-multiple-documents):
> Creates a new document or updates an existing document if a document with the same id already exists. You can send either the whole document or a partial document for update.

While `emplace` supports partial updates, this causes a critical issue: **when removing optional fields from a document, those fields are not deleted from the index**. Instead, they retain their old values and remain searchable.

### Example

Initial document:
```php
[
   'id' => 1,
   'a' => 'a',
   'b' => 'b',
]
```

After update (removing field `b`):
```php
[
   'id' => 1,
   'a' => 'a',
]
```

I even experienced some cases that even sending the field with null values would still not update it, when using `enable_nested_fields`.

```php
[
   'id' => 1,
   'a' => 'a',
   'b' => null,
]
```

**Expected:** Field `b` should be removed from the index
**Actual:** Field `b` still contains `'b'` and remains searchable

## Solution

This PR adds a config option to change the action, but reverts the default back to `upsert` to prevent this issue.