### PR TITLE
Escape double quotes in Meilisearch filter strings

### DIFF
--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -191,7 +191,7 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
 
                 return is_numeric($value)
                     ? sprintf('%s=%s', $key, $value)
-                    : sprintf('%s="%s"', $key, $value);
+                    : sprintf('%s="%s"', $key, addcslashes((string) $value, '"\\'));
             });
 
         $whereInOperators = [


### PR DESCRIPTION
Currently, when filtering for a value containing double quotes, the quotes are not escaped properly, leading to empty (or wrong) result sets.
This pull request contains escaping of double quotes in filter strings according to the [Meilisearch specs](https://specs.meilisearch.dev/specifications/text/0118-search-api.html#_3-1-2-1-1-grammar).

The key `foo` and value `bar'"\` is rendered as `foo="bar'\"\\"`.
Note that the escaping of backslashes is not documented as such in the Meilisearch docs, but works as expected and is necessary for strings ending in a backslash.