### PR TITLE
[10.x][Algolia] Support numeric 'whereNotIn' to prevent silent failures

### DIFF
--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -133,7 +133,7 @@ abstract class AlgoliaEngine extends Engine implements UpdatesIndexSettings
             ->map(fn ($value, $key) => $key.'='.$value)
             ->values();
 
-        return $wheres->merge(collect($builder->whereIns)->map(function ($values, $key) {
+        $whereIns = collect($builder->whereIns)->map(function ($values, $key) {
             if (empty($values)) {
                 return '0=1';
             }
@@ -141,7 +141,19 @@ abstract class AlgoliaEngine extends Engine implements UpdatesIndexSettings
             return collect($values)
                 ->map(fn ($value) => $key.'='.$value)
                 ->all();
-        })->values())->values()->all();
+        })->values();
+
+        $whereNotIns = collect($builder->whereNotIns)->map(function ($values, $key) {
+            if (empty($values)) {
+                return [];
+            }
+
+            return collect($values)
+                ->map(fn ($value) => $key.'!='.$value)
+                ->all();
+        })->values()->filter();
+
+        return $wheres->merge($whereIns)->merge($whereNotIns)->values()->all();
     }
 
     /**

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -143,7 +143,7 @@ abstract class AlgoliaEngine extends Engine implements UpdatesIndexSettings
                 ->all();
         })->values();
 
-        $whereNotIns = collect($builder->whereNotIns)->map(function ($values, $key) {
+        $whereNotIns = collect($builder->whereNotIns)->flatMap(function ($values, $key) {
             if (empty($values)) {
                 return [];
             }
@@ -151,7 +151,7 @@ abstract class AlgoliaEngine extends Engine implements UpdatesIndexSettings
             return collect($values)
                 ->map(fn ($value) => $key.'!='.$value)
                 ->all();
-        })->values()->filter();
+        });
 
         return $wheres->merge($whereIns)->merge($whereNotIns)->values()->all();
     }

--- a/tests/Feature/Engines/Algolia3EngineTest.php
+++ b/tests/Feature/Engines/Algolia3EngineTest.php
@@ -150,36 +150,6 @@ class Algolia3EngineTest extends TestCase
         $engine->search($builder);
     }
 
-    public function test_search_sends_correct_parameters_to_algolia_for_where_not_in_search()
-    {
-        $engine = $this->app->make(EngineManager::class)->engine();
-
-        $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
-        $index->shouldReceive('search')->once()->with('zonda', [
-            'numericFilters' => ['foo=1', ['bar!=1', 'bar!=2']],
-        ]);
-
-        $builder = new Builder(new SearchableUser, 'zonda');
-        $builder->where('foo', 1)->whereNotIn('bar', [1, 2]);
-
-        $engine->search($builder);
-    }
-
-    public function test_search_sends_correct_parameters_to_algolia_for_empty_where_not_in_search()
-    {
-        $engine = $this->app->make(EngineManager::class)->engine();
-
-        $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
-        $index->shouldReceive('search')->once()->with('zonda', [
-            'numericFilters' => ['foo=1'],
-        ]);
-
-        $builder = new Builder(new SearchableUser, 'zonda');
-        $builder->where('foo', 1)->whereNotIn('bar', []);
-
-        $engine->search($builder);
-    }
-
     public function test_map_correctly_maps_results_to_models()
     {
         $model = SearchableUserFactory::new()->createQuietly(['name' => 'zonda']);
@@ -272,5 +242,58 @@ class Algolia3EngineTest extends TestCase
         $engine->update(Collection::make([new Chirp]));
 
         unset($_ENV['chirp.toSearchableArray']);
+    }
+
+    public function test_search_sends_correct_parameters_to_algolia_for_where_not_in_search()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+        $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
+
+        $index->shouldReceive('search')->once()->with('zonda', [
+            'numericFilters' => [
+                'foo!=1',
+                'foo!=2',
+            ],
+        ]);
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->whereNotIn('foo', [1, 2]);
+
+        $engine->search($builder);
+    }
+
+    public function test_search_ignores_empty_where_not_in_search()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+        $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
+
+        $index->shouldReceive('search')->once()->with('zonda', []);
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->whereNotIn('foo', []);
+
+        $engine->search($builder);
+    }
+
+    public function test_search_sends_correct_parameters_to_algolia_for_mixed_search()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+        $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
+
+        $index->shouldReceive('search')->once()->with('zonda', [
+            'numericFilters' => [
+                'foo=1',
+                ['bar=1', 'bar=2'],
+                'baz!=1',
+                'baz!=2',
+            ],
+        ]);
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->where('foo', 1)
+                ->whereIn('bar', [1, 2])
+                ->whereNotIn('baz', [1, 2]);
+
+        $engine->search($builder);
     }
 }

--- a/tests/Feature/Engines/Algolia3EngineTest.php
+++ b/tests/Feature/Engines/Algolia3EngineTest.php
@@ -150,6 +150,36 @@ class Algolia3EngineTest extends TestCase
         $engine->search($builder);
     }
 
+    public function test_search_sends_correct_parameters_to_algolia_for_where_not_in_search()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+
+        $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
+        $index->shouldReceive('search')->once()->with('zonda', [
+            'numericFilters' => ['foo=1', ['bar!=1', 'bar!=2']],
+        ]);
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->where('foo', 1)->whereNotIn('bar', [1, 2]);
+
+        $engine->search($builder);
+    }
+
+    public function test_search_sends_correct_parameters_to_algolia_for_empty_where_not_in_search()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+
+        $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
+        $index->shouldReceive('search')->once()->with('zonda', [
+            'numericFilters' => ['foo=1'],
+        ]);
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->where('foo', 1)->whereNotIn('bar', []);
+
+        $engine->search($builder);
+    }
+
     public function test_map_correctly_maps_results_to_models()
     {
         $model = SearchableUserFactory::new()->createQuietly(['name' => 'zonda']);

--- a/tests/Feature/Engines/Algolia4EngineTest.php
+++ b/tests/Feature/Engines/Algolia4EngineTest.php
@@ -146,6 +146,36 @@ class Algolia4EngineTest extends TestCase
         $engine->search($builder);
     }
 
+    public function test_search_sends_correct_parameters_to_algolia_for_where_not_in_search()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+
+        $this->client->shouldReceive('searchSingleIndex')->once()->with(
+            'users',
+            ['query' => 'zonda', 'numericFilters' => ['foo=1', ['bar!=1', 'bar!=2']]],
+        );
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->where('foo', 1)->whereNotIn('bar', [1, 2]);
+
+        $engine->search($builder);
+    }
+
+    public function test_search_sends_correct_parameters_to_algolia_for_empty_where_not_in_search()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+
+        $this->client->shouldReceive('searchSingleIndex')->once()->with(
+            'users',
+            ['query' => 'zonda', 'numericFilters' => ['foo=1']],
+        );
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->where('foo', 1)->whereNotIn('bar', []);
+
+        $engine->search($builder);
+    }
+
     public function test_map_correctly_maps_results_to_models()
     {
         $model = SearchableUserFactory::new()->createQuietly(['name' => 'zonda']);

--- a/tests/Feature/Engines/Algolia4EngineTest.php
+++ b/tests/Feature/Engines/Algolia4EngineTest.php
@@ -146,36 +146,6 @@ class Algolia4EngineTest extends TestCase
         $engine->search($builder);
     }
 
-    public function test_search_sends_correct_parameters_to_algolia_for_where_not_in_search()
-    {
-        $engine = $this->app->make(EngineManager::class)->engine();
-
-        $this->client->shouldReceive('searchSingleIndex')->once()->with(
-            'users',
-            ['query' => 'zonda', 'numericFilters' => ['foo=1', ['bar!=1', 'bar!=2']]],
-        );
-
-        $builder = new Builder(new SearchableUser, 'zonda');
-        $builder->where('foo', 1)->whereNotIn('bar', [1, 2]);
-
-        $engine->search($builder);
-    }
-
-    public function test_search_sends_correct_parameters_to_algolia_for_empty_where_not_in_search()
-    {
-        $engine = $this->app->make(EngineManager::class)->engine();
-
-        $this->client->shouldReceive('searchSingleIndex')->once()->with(
-            'users',
-            ['query' => 'zonda', 'numericFilters' => ['foo=1']],
-        );
-
-        $builder = new Builder(new SearchableUser, 'zonda');
-        $builder->where('foo', 1)->whereNotIn('bar', []);
-
-        $engine->search($builder);
-    }
-
     public function test_map_correctly_maps_results_to_models()
     {
         $model = SearchableUserFactory::new()->createQuietly(['name' => 'zonda']);
@@ -263,5 +233,66 @@ class Algolia4EngineTest extends TestCase
         $engine->update(Collection::make([new Chirp]));
 
         unset($_ENV['searchable.chirp']);
+    }
+
+    public function test_search_sends_correct_parameters_to_algolia_for_where_not_in_search()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+
+        $this->client->shouldReceive('searchSingleIndex')->once()->with(
+            'users',
+            [
+                'query' => 'zonda',
+                'numericFilters' => [
+                    'foo!=1',
+                    'foo!=2',
+                ],
+            ]
+        );
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->whereNotIn('foo', [1, 2]);
+
+        $engine->search($builder);
+    }
+
+    public function test_search_ignores_empty_where_not_in_search()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+
+        $this->client->shouldReceive('searchSingleIndex')->once()->with(
+            'users',
+            ['query' => 'zonda']
+        );
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->whereNotIn('foo', []);
+
+        $engine->search($builder);
+    }
+
+    public function test_search_sends_correct_parameters_to_algolia_for_mixed_search()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+
+        $this->client->shouldReceive('searchSingleIndex')->once()->with(
+            'users',
+            [
+                'query' => 'zonda',
+                'numericFilters' => [
+                    'foo=1',
+                    ['bar=1', 'bar=2'],
+                    'baz!=1',
+                    'baz!=2',
+                ],
+            ]
+        );
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->where('foo', 1)
+                ->whereIn('bar', [1, 2])
+                ->whereNotIn('baz', [1, 2]);
+
+        $engine->search($builder);
     }
 }


### PR DESCRIPTION
# [Algolia] Support numeric `whereNotIn` to prevent silent failures

## Description
Currently, the Algolia engine **silently fails** when `whereNotIn` is used. The Builder accepts the method call, but `AlgoliaEngine` completely ignores the exclusion list, returning records that the developer explicitly intended to hide.

This PR implements `whereNotIn` support using Algolia's `numericFilters`, bringing parity with `where` and `whereIn`.

### Before
```php
// Returns invoices with status_code 7 (Cancelled) and 0 (Draft) (Silent Failure)
Invoice::search('ACME Corp')->whereNotIn('status_code', [0, 7])->get();
```

### After
```php
// Correctly excludes Cancelled and Draft invoices
Invoice::search('ACME Corp')->whereNotIn('status_code', [0, 7])->get();
```

### Technical Implementation
Since Algolia's `numericFilters` lacks a native "NOT IN" operator, we simulate it using `AND` logic:
*   `whereIn` (Existing): Maps to a nested array `[['id=1', 'id=2']]` (interpreted as **OR**).
*   `whereNotIn` (New): Uses `flatMap` to generate a top-level list `['id!=1', 'id!=2']` (interpreted as **AND**).

*Note: Consistent with the existing engine implementation, this supports numeric values only.*

### Tests
Comprehensive tests were added to `Algolia3EngineTest` and `Algolia4EngineTest` to verify:
*   **Correct Logic:** `whereNotIn('foo', [1, 2])` generates `['foo!=1', 'foo!=2']`.
*   **Empty Arrays:** Passing an empty array is safely ignored.
*   **Mixed Queries:** Validated that `where`, `whereIn`, and `whereNotIn` work correctly when combined in a single query.

## Benefit to end users
Developers can now reliably use `whereNotIn` to exclude specific numeric records (e.g., status codes, IDs) from their search results without needing manual post-processing. It eliminates a dangerous silent failure where sensitive or unwanted data could be exposed.

## Reasons it does not break any existing features
This change is purely additive. It processes `whereNotIn` constraints which were previously ignored. Existing `where` and `whereIn` functionality remains untouched, and applications not using `whereNotIn` will experience no change in behavior.
