### PR TITLE
[10.x] Separate scout key name from database column name

### DIFF
--- a/src/Console/QueueImportCommand.php
+++ b/src/Console/QueueImportCommand.php
@@ -48,8 +48,8 @@ class QueueImportCommand extends Command
 
         $query = $model::makeAllSearchableQuery();
 
-        $min = $this->option('min') ?? $query->min($model->getScoutKeyName());
-        $max = $this->option('max') ?? $query->max($model->getScoutKeyName());
+        $min = $this->option('min') ?? $query->min($model->getScoutKeyColumnName());
+        $max = $this->option('max') ?? $query->max($model->getScoutKeyColumnName());
 
         $chunk = max(1, (int) ($this->option('chunk') ?? config('scout.chunk.searchable', 500)));
 

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -81,7 +81,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
                 }
             })
             ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
-                $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
+                $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyColumnName(), 'desc');
             })
             ->when($this->shouldOrderByRelevance($builder), function ($query) use ($builder) {
                 $this->orderByRelevance($builder, $query);
@@ -120,7 +120,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
                 }
             })
             ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
-                $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
+                $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyColumnName(), 'desc');
             })
             ->when($this->shouldOrderByRelevance($builder), function ($query) use ($builder) {
                 $this->orderByRelevance($builder, $query);
@@ -158,7 +158,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
                 }
             })
             ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
-                $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
+                $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyColumnName(), 'desc');
             })
             ->when($this->shouldOrderByRelevance($builder), function ($query) use ($builder) {
                 $this->orderByRelevance($builder, $query);
@@ -213,7 +213,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
             $canSearchPrimaryKey = ctype_digit($builder->query) &&
                                    in_array($builder->model->getKeyType(), ['int', 'integer']) &&
                                    ($connectionType != 'pgsql' || $builder->query <= PHP_INT_MAX) &&
-                                   in_array($builder->model->getScoutKeyName(), $columns);
+                                   in_array($builder->model->getScoutKeyColumnName(), $columns);
 
             if ($canSearchPrimaryKey) {
                 $query->orWhere($builder->model->getQualifiedKeyName(), $builder->query);
@@ -225,7 +225,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
                 if (in_array($column, $fullTextColumns)) {
                     continue;
                 } else {
-                    if ($canSearchPrimaryKey && $column === $builder->model->getScoutKeyName()) {
+                    if ($canSearchPrimaryKey && $column === $builder->model->getScoutKeyColumnName()) {
                         continue;
                     }
 

--- a/src/Jobs/MakeRangeSearchable.php
+++ b/src/Jobs/MakeRangeSearchable.php
@@ -56,7 +56,7 @@ class MakeRangeSearchable implements ShouldQueue
         $model = new $this->class;
 
         $models = $model::makeAllSearchableQuery()
-            ->whereBetween($model->getScoutKeyName(), [$this->start, $this->end])
+            ->whereBetween($model->getScoutKeyColumnName(), [$this->start, $this->end])
             ->get()
             ->filter
             ->shouldBeSearchable();

--- a/src/Jobs/RemoveFromSearch.php
+++ b/src/Jobs/RemoveFromSearch.php
@@ -58,7 +58,7 @@ class RemoveFromSearch implements ShouldQueue
                     $model->setKeyType(
                         is_string($id) ? 'string' : 'int'
                     )->forceFill([
-                        $model->getScoutKeyName() => $id,
+                        $model->getScoutKeyColumnName() => $id,
                     ]);
                 });
             })

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -194,7 +194,7 @@ trait Searchable
                 $query->withTrashed();
             })
             ->orderBy(
-                $self->qualifyColumn($self->getScoutKeyName())
+                $self->qualifyColumn($self->getScoutKeyColumnName())
             );
     }
 
@@ -326,7 +326,7 @@ trait Searchable
             'whereIn';
 
         return $query->{$whereIn}(
-            $this->qualifyColumn($this->getScoutKeyName()), $ids
+            $this->qualifyColumn($this->getScoutKeyColumnName()), $ids
         );
     }
 
@@ -487,6 +487,16 @@ trait Searchable
      * @return mixed
      */
     public function getScoutKeyName()
+    {
+        return $this->getKeyName();
+    }
+
+    /**
+     * Get the column name used for database queries when indexing the model.
+     *
+     * @return mixed
+     */
+    public function getScoutKeyColumnName()
     {
         return $this->getKeyName();
     }

--- a/src/SearchableScope.php
+++ b/src/SearchableScope.php
@@ -32,23 +32,23 @@ class SearchableScope implements Scope
     public function extend(EloquentBuilder $builder)
     {
         $builder->macro('searchable', function (EloquentBuilder $builder, $chunk = null) {
-            $scoutKeyName = $builder->getModel()->getScoutKeyName();
+            $scoutKeyColumnName = $builder->getModel()->getScoutKeyColumnName();
 
             $builder->chunkById($chunk ?: config('scout.chunk.searchable', 500), function ($models) {
                 $models->filter->shouldBeSearchable()->searchable();
 
                 event(new ModelsImported($models));
-            }, $builder->qualifyColumn($scoutKeyName), $scoutKeyName);
+            }, $builder->qualifyColumn($scoutKeyColumnName), $scoutKeyColumnName);
         });
 
         $builder->macro('unsearchable', function (EloquentBuilder $builder, $chunk = null) {
-            $scoutKeyName = $builder->getModel()->getScoutKeyName();
+            $scoutKeyColumnName = $builder->getModel()->getScoutKeyColumnName();
 
             $builder->chunkById($chunk ?: config('scout.chunk.unsearchable', 500), function ($models) {
                 $models->unsearchable();
 
                 event(new ModelsFlushed($models));
-            }, $builder->qualifyColumn($scoutKeyName), $scoutKeyName);
+            }, $builder->qualifyColumn($scoutKeyColumnName), $scoutKeyColumnName);
         });
 
         HasManyThrough::macro('searchable', function ($chunk = null) {

--- a/tests/Feature/SearchableTest.php
+++ b/tests/Feature/SearchableTest.php
@@ -10,6 +10,7 @@ use Laravel\Scout\Scout;
 use Laravel\Scout\Tests\Fixtures\OverriddenMakeSearchable;
 use Laravel\Scout\Tests\Fixtures\OverriddenRemoveFromSearch;
 use Laravel\Scout\Tests\Fixtures\SearchableModel;
+use Laravel\Scout\Tests\Fixtures\SearchableModelWithDifferentKeyNames;
 use Laravel\Scout\Tests\Fixtures\SearchableModelWithSoftDeletes;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
@@ -142,7 +143,7 @@ class SearchableTest extends TestCase
         $model = M::mock(SearchableModel::class)->makePartial();
         $model->shouldReceive('newQuery')->once()->andReturnSelf();
         $model->shouldReceive('getScoutKeyType')->once()->andReturn('int');
-        $model->shouldReceive('getScoutKeyName')->once()->andReturn('id');
+        $model->shouldReceive('getScoutKeyColumnName')->once()->andReturn('id');
         $model->shouldReceive('qualifyColumn')->with('id')->once()->andReturn('qualified_id');
         $model->shouldReceive('whereIntegerInRaw')->with('qualified_id', [1, 2, 3])->once()->andReturnSelf();
 
@@ -157,7 +158,7 @@ class SearchableTest extends TestCase
         $model = M::mock(SearchableModel::class)->makePartial();
         $model->shouldReceive('newQuery')->once()->andReturnSelf();
         $model->shouldReceive('getScoutKeyType')->once()->andReturn('string');
-        $model->shouldReceive('getScoutKeyName')->once()->andReturn('id');
+        $model->shouldReceive('getScoutKeyColumnName')->once()->andReturn('id');
         $model->shouldReceive('qualifyColumn')->with('id')->once()->andReturn('qualified_id');
         $model->shouldReceive('whereIn')->with('qualified_id', [1, 2, 3])->once()->andReturnSelf();
 
@@ -165,6 +166,42 @@ class SearchableTest extends TestCase
         $scoutBuilder->queryCallback = null;
 
         $model->queryScoutModelsByIds($scoutBuilder, [1, 2, 3]);
+    }
+
+    public function test_get_scout_key_column_name_defaults_to_key_name()
+    {
+        $model = new SearchableModel;
+
+        $this->assertEquals($model->getKeyName(), $model->getScoutKeyColumnName());
+    }
+
+    public function test_scout_key_column_name_uses_primary_key_not_scout_key_name()
+    {
+        $model = new SearchableModelWithDifferentKeyNames;
+
+        $this->assertEquals('id', $model->getScoutKeyName());
+        $this->assertEquals('uuid', $model->getScoutKeyColumnName());
+        $this->assertEquals($model->getKeyName(), $model->getScoutKeyColumnName());
+    }
+
+    public function test_query_scout_models_by_ids_uses_column_name_not_key_name()
+    {
+        $model = M::mock(SearchableModelWithDifferentKeyNames::class)->makePartial();
+        $model->shouldReceive('newQuery')->once()->andReturnSelf();
+        $model->shouldReceive('getScoutKeyType')->once()->andReturn('string');
+        $model->shouldReceive('getScoutKeyColumnName')->once()->andReturn('uuid');
+        $model->shouldReceive('qualifyColumn')->with('uuid')->once()->andReturn('table.uuid');
+        $model->shouldReceive('whereIn')->with('table.uuid', ['uuid-1', 'uuid-2'])->once()->andReturnSelf();
+
+        $scoutBuilder = M::mock(\Laravel\Scout\Builder::class);
+        $scoutBuilder->queryCallback = null;
+
+        $model->queryScoutModelsByIds($scoutBuilder, ['uuid-1', 'uuid-2']);
+    }
+
+    public function test_make_all_searchable_uses_column_name_for_order_by()
+    {
+        ModelStubWithDifferentKeyNames::makeAllSearchable();
     }
 
     public function test_was_searchable_before_update_works_from_true_to_false()
@@ -217,6 +254,35 @@ class ModelStubForMakeAllSearchable extends SearchableModel
 
         $mock->shouldReceive('orderBy')
             ->with('model_stub_for_make_all_searchables.id')
+            ->once()
+            ->andReturnSelf();
+
+        $mock->shouldReceive('searchable')
+            ->once();
+
+        $mock->shouldReceive('when')->andReturnSelf();
+
+        return $mock;
+    }
+}
+
+class ModelStubWithDifferentKeyNames extends SearchableModelWithDifferentKeyNames
+{
+    public function newQuery()
+    {
+        $mock = m::spy(Builder::class);
+
+        $mock->shouldReceive('when')
+            ->with(true, m::type('Closure'))
+            ->once()
+            ->andReturnUsing(function ($condition, $callback) use ($mock) {
+                $callback($mock);
+
+                return $mock;
+            });
+
+        $mock->shouldReceive('orderBy')
+            ->with('model_stub_with_different_key_names.uuid')
             ->once()
             ->andReturnSelf();
 

--- a/tests/Fixtures/SearchableModelWithDifferentKeyNames.php
+++ b/tests/Fixtures/SearchableModelWithDifferentKeyNames.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Laravel\Scout\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Scout\Searchable;
+
+class SearchableModelWithDifferentKeyNames extends Model
+{
+    use Searchable;
+
+    protected $primaryKey = 'uuid';
+
+    protected $keyType = 'string';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = ['uuid', 'name'];
+
+    public function searchableAs()
+    {
+        return 'table';
+    }
+
+    public function getScoutKeyName()
+    {
+        return 'id';
+    }
+
+    public function getScoutKey()
+    {
+        return $this->uuid;
+    }
+}

--- a/tests/Unit/SearchableScopeTest.php
+++ b/tests/Unit/SearchableScopeTest.php
@@ -23,7 +23,7 @@ class SearchableScopeTest extends TestCase
 
         $builder->shouldReceive('macro')->with('searchable', m::on(function ($callback) use ($builder) {
             $model = m::mock(Model::class);
-            $model->shouldReceive('getScoutKeyName')->once()->andReturn('id');
+            $model->shouldReceive('getScoutKeyColumnName')->once()->andReturn('id');
 
             $builder->shouldReceive('chunkById')->with(500, m::type(\Closure::class), 'users.id', 'id')->once();
             $builder->shouldReceive('getModel')->once()->andReturn($model);
@@ -36,7 +36,7 @@ class SearchableScopeTest extends TestCase
 
         $builder->shouldReceive('macro')->with('unsearchable', m::on(function ($callback) use ($builder) {
             $model = m::mock(Model::class);
-            $model->shouldReceive('getScoutKeyName')->once()->andReturn('id');
+            $model->shouldReceive('getScoutKeyColumnName')->once()->andReturn('id');
 
             $builder->shouldReceive('chunkById')->with(500, m::type(\Closure::class), 'users.id', 'id')->once();
             $builder->shouldReceive('getModel')->once()->andReturn($model);

--- a/workbench/app/Models/Chirp.php
+++ b/workbench/app/Models/Chirp.php
@@ -34,6 +34,12 @@ class Chirp extends Model
         return 'scout_id';
     }
 
+    /** {@inheritDoc} */
+    public function getScoutKeyColumnName()
+    {
+        return 'scout_id';
+    }
+
     public function toSearchableArray()
     {
         if (isset($_ENV['chirp.toSearchableArray'])) {


### PR DESCRIPTION
Fixes #960

## Problem

When a model overrides `getScoutKeyName()` to return a value different from `getKeyName()` (the primary key), database queries break. This is because `getScoutKeyName()` was used both as the key name sent to the search engine **and** as the column name in database queries (`orderBy`, `whereBetween`, `chunkById`, etc.).

For example, a model with `uuid` as the primary key (`getKeyName()`) but `id` as the scout key (`getScoutKeyName()`) would generate invalid SQL queries referencing a non-existent `id` column.

### Before
```php
// Model with uuid primary key and custom scout key
public function getKeyName() { return 'uuid'; }
public function getScoutKeyName() { return 'id'; }

// Queries incorrectly use 'id' column instead of 'uuid':
// SELECT * FROM models ORDER BY models.id  ← fails
```

### After
```php
// New method separates the database column from the scout key:
public function getScoutKeyColumnName() { return $this->getKeyName(); } // 'uuid'
public function getScoutKeyName() { return 'id'; } // sent to search engine

// Queries correctly use 'uuid' column:
// SELECT * FROM models ORDER BY models.uuid  ← works
```

## Solution

Introduce `getScoutKeyColumnName()` method on the `Searchable` trait that defaults to `getKeyName()`. All internal database queries now use `getScoutKeyColumnName()` instead of `getScoutKeyName()`, keeping the two concerns separated:

- `getScoutKeyName()` → key name for the search engine index
- `getScoutKeyColumnName()` → column name for database queries

Updated locations: `Searchable`, `SearchableScope`, `DatabaseEngine`, `QueueImportCommand`, `MakeRangeSearchable`, `RemoveFromSearch`.

## Tests

- Verifies `getScoutKeyColumnName()` defaults to `getKeyName()`
- Verifies a model with different key names returns correct values from each method
- Verifies `queryScoutModelsByIds` uses column name, not scout key name
- Verifies `makeAllSearchable` orders by column name