### PR TITLE
[10.x] Sort Stan faliure

### DIFF
--- a/phpstan.src.neon.dist
+++ b/phpstan.src.neon.dist
@@ -8,9 +8,6 @@ parameters:
   ignoreErrors:
     - identifier: new.static
     - "#\\(void\\) is used.#"
-    -
-      identifier: property.notFound
-      path: src/Traits/ConfiguresJob.php
 
   excludePaths:
     - src/Engines/Algolia3Engine.php

--- a/src/Traits/ConfiguresJobOptions.php
+++ b/src/Traits/ConfiguresJobOptions.php
@@ -4,7 +4,6 @@ namespace Laravel\Scout\Traits;
 
 trait ConfiguresJobOptions
 {
-
     /**
      * The number of times the job may be attempted.
      *

--- a/src/Traits/ConfiguresJobOptions.php
+++ b/src/Traits/ConfiguresJobOptions.php
@@ -4,6 +4,28 @@ namespace Laravel\Scout\Traits;
 
 trait ConfiguresJobOptions
 {
+
+    /**
+     * The number of times the job may be attempted.
+     *
+     * @var int|null
+     */
+    public $tries;
+
+    /**
+     * The number of seconds to wait before retrying the job when encountering an uncaught exception.
+     *
+     * @var int|null
+     */
+    public $backoff;
+
+    /**
+     * The maximum number of unhandled exceptions to allow before failing.
+     *
+     * @var int|null
+     */
+    public $maxExceptions;
+
     /**
      * Configure the job.
      *

--- a/tests/Feature/Jobs/MakeSearchableTest.php
+++ b/tests/Feature/Jobs/MakeSearchableTest.php
@@ -52,9 +52,9 @@ class MakeSearchableTest extends TestCase
 
         $job = new MakeSearchable(Collection::make([$model]));
 
-        $this->assertObjectNotHasProperty('tries', $job);
-        $this->assertObjectNotHasProperty('backoff', $job);
-        $this->assertObjectNotHasProperty('maxExceptions', $job);
+        $this->assertNull($job->tries);
+        $this->assertNull($job->backoff);
+        $this->assertNull($job->maxExceptions);
     }
 
     #[WithConfig('scout.jobs.tries', 1)]

--- a/tests/Feature/Jobs/RemoveFromSearchTest.php
+++ b/tests/Feature/Jobs/RemoveFromSearchTest.php
@@ -87,9 +87,9 @@ class RemoveFromSearchTest extends TestCase
 
         $job = new RemoveFromSearch(Collection::make([$model]));
 
-        $this->assertObjectNotHasProperty('tries', $job);
-        $this->assertObjectNotHasProperty('backoff', $job);
-        $this->assertObjectNotHasProperty('maxExceptions', $job);
+        $this->assertNull($job->tries);
+        $this->assertNull($job->backoff);
+        $this->assertNull($job->maxExceptions);
     }
 
     #[WithConfig('scout.jobs.tries', 1)]


### PR DESCRIPTION
Noticed it's failing here: https://github.com/laravel/scout/actions/runs/21730790703/job/62684599282

Rather than ignore it in the config, we can just declare the properties on the trait. 

This follows the same pattern as Laravel's Bus/Queueable trait which also declares public properties.

The isset() checks ensure that if someone extends the job classes and sets their own values, those won't be overridden.

Have adjusted the tests to assert null values rather than property existence.

You may see a better way, so open to your opinion too! 🫡 