### PR TITLE
[10.x] Drop ignores

### DIFF
--- a/src/Traits/ConfiguresJobOptions.php
+++ b/src/Traits/ConfiguresJobOptions.php
@@ -33,20 +33,17 @@ trait ConfiguresJobOptions
     protected function configureJob(): void
     {
         if (! isset($this->tries) && ! is_null($tries = config('scout.jobs.tries'))) {
-            /** @phpstan-ignore property.notFound */
             $this->tries = $tries;
         }
 
         if (! isset($this->backoff) &&
             ! method_exists($this, 'backoff') &&
             ! is_null($backoff = config('scout.jobs.backoff'))) {
-            /** @phpstan-ignore property.notFound */
             $this->backoff = $backoff;
         }
 
         if (! isset($this->maxExceptions) &&
             ! is_null($maxExceptions = config('scout.jobs.max_exceptions'))) {
-            /** @phpstan-ignore property.notFound */
             $this->maxExceptions = $maxExceptions;
         }
     }


### PR DESCRIPTION
We don't need to ignore these anymore, as the properties are on the trait. 

Just a bit of cleanup.. 

Tests all pass.