### PR TITLE
[10.x] Ensure MakeSearchable is only dispatched when required

### DIFF
--- a/src/ModelObserver.php
+++ b/src/ModelObserver.php
@@ -106,6 +106,10 @@ class ModelObserver
             return;
         }
 
+        if (! $model->wasRecentlyCreated && ! $model->wasChanged(array_keys($model->toSearchableArray()))) {
+            return;
+        }
+
         $model->searchable();
     }
 

--- a/tests/Feature/ModelObserverTest.php
+++ b/tests/Feature/ModelObserverTest.php
@@ -221,4 +221,49 @@ class ModelObserverTest extends TestCase
 
         unset($_ENV['user.searchIndexShouldBeUpdated']);
     }
+
+    public function test_created_model_is_made_searchable()
+    {
+        tap($this->app->make('scout.spied'), function ($scout) {
+            $scout->shouldReceive('update')->once();
+        });
+
+        SearchableUserFactory::new()->create([
+            'name' => 'Taylor Otwell',
+        ]);
+    }
+
+    public function test_update_to_non_searchable_field_doesnt_make_model_searchable()
+    {
+        $model = SearchableUserFactory::new()->createQuietly([
+            'name' => 'Taylor Otwell',
+            'remember_token' => 123,
+            'password' => 'secret',
+        ]);
+
+        // Force a fresh instance to ensure wasRecentlyCreated is false...
+        $model = $model->fresh();
+
+        tap($this->app->make('scout.spied'), function ($scout) {
+            $scout->shouldNotReceive('update');
+        });
+
+        $model->remember_token = 456;
+        $model->save();
+    }
+
+    public function test_update_to_searchable_field_makes_model_searchable()
+    {
+        $model = SearchableUserFactory::new()->createQuietly([
+            'name' => 'Taylor Otwell',
+            'remember_token' => 123,
+        ]);
+
+        tap($this->app->make('scout.spied'), function ($scout) {
+            $scout->shouldReceive('update')->once();
+        });
+
+        $model->name = 'Taylor';
+        $model->save();
+    }
 }


### PR DESCRIPTION
Currently the `MakeSearchable` Job is dispatched regardless of what attributes were updated.

This means, if we're only indexing certain attributes via the `toSearchableArray()`, updating anything outside of those still triggers a reindex.

This becomes extremely inefficient and also costly when doing large bulk updates of other attributes, as it can re-index thousands of items for no reason.

This PR ensures:
- Newly created items are still indexed as expected
- We only dispatch the job if we need to  / only index on the engine if its required

All other tests and new tests pass as expected. 


No breaking change as the default `toSearchableArray()` returns `toArray()`, so `wasChanged()` will work as expected for models that haven't customized it. The behavior only changes for models that have explicitly narrowed their `toSearchableArray()`, which is what I would expect.

There is `searchIndexShouldBeUpdated` but, this is not documented - and this PR feels (to me) like it's a sensible default behavior. 

Let me know if you need any changes!