### PR TITLE
[10.x] Run Typesense integration tests in github action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,3 +105,47 @@ jobs:
           MEILISEARCH_HOST: "http://localhost:7700"
           MEILISEARCH_KEY: 'masterKey'
           DB_CONNECTION: 'testing'
+
+  tests-using-typesense:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: true
+      matrix:
+          php: ['8.0', 8.1, 8.2, 8.3, 8.4]
+
+    name: PHP ${{ matrix.php }} using Typesense
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Start Typesense
+        uses: jirevwe/typesense-github-action@v1.0.1
+        with:
+          typesense-version: 30.1
+          typesense-api-key: masterKey
+
+      - name: Curl Typesense
+        run: sleep 10 && curl http://localhost:8108/health
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip
+          ini-values: error_reporting=E_ALL
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer update --prefer-dist --no-interaction --no-progress
+
+      - name: Execute tests
+        run: vendor/bin/phpunit --no-configuration --no-coverage --color --bootstrap vendor/autoload.php --group typesense tests/Integration
+        env:
+          TYPESENSE_HOST: 'localhost'
+          TYPESENSE_PORT: 8108
+          TYPESENSE_API_KEY: 'masterKey'
+          DB_CONNECTION: 'testing'

--- a/tests/Integration/AlgoliaSearchableTest.php
+++ b/tests/Integration/AlgoliaSearchableTest.php
@@ -4,12 +4,11 @@ namespace Laravel\Scout\Tests\Integration;
 
 use Orchestra\Sidekick\Env;
 use Orchestra\Testbench\Attributes\RequiresEnv;
+use PHPUnit\Framework\Attributes\Group;
 use Workbench\App\Models\SearchableUser;
 
-/**
- * @group algolia
- * @group external-network
- */
+#[Group('algolia')]
+#[Group('external-network')]
 #[RequiresEnv('ALGOLIA_APP_ID')]
 class AlgoliaSearchableTest extends TestCase
 {

--- a/tests/Integration/MeilisearchSearchableTest.php
+++ b/tests/Integration/MeilisearchSearchableTest.php
@@ -10,12 +10,11 @@ use Meilisearch\Client;
 use Meilisearch\Endpoints\Indexes;
 use Mockery as m;
 use Orchestra\Testbench\Attributes\RequiresEnv;
+use PHPUnit\Framework\Attributes\Group;
 use Workbench\App\Models\SearchableUser;
 
-/**
- * @group meilisearch
- * @group external-network
- */
+#[Group('meilisearch')]
+#[Group('external-network')]
 #[RequiresEnv('MEILISEARCH_HOST')]
 class MeilisearchSearchableTest extends TestCase
 {

--- a/tests/Integration/SearchableTests.php
+++ b/tests/Integration/SearchableTests.php
@@ -19,7 +19,7 @@ trait SearchableTests
     {
         $_ENV['user.toSearchableArray'] = function ($model) {
             return [
-                'id' => (int) $model->id,
+                'id' => static::scoutDriver() === 'typesense' ? (string) $model->id : (int) $model->id,
                 'name' => $model->name,
             ];
         };

--- a/tests/Integration/TypesenseSearchableTest.php
+++ b/tests/Integration/TypesenseSearchableTest.php
@@ -3,12 +3,11 @@
 namespace Laravel\Scout\Tests\Integration;
 
 use Orchestra\Testbench\Attributes\RequiresEnv;
+use PHPUnit\Framework\Attributes\Group;
 use Workbench\App\Models\SearchableUser;
 
-/**
- * @group typesense
- * @group external-network
- */
+#[Group('typesense')]
+#[Group('external-network')]
 #[RequiresEnv('TYPESENSE_API_KEY')]
 class TypesenseSearchableTest extends TestCase
 {

--- a/tests/Integration/TypesenseSearchableTest.php
+++ b/tests/Integration/TypesenseSearchableTest.php
@@ -246,12 +246,19 @@ class TypesenseSearchableTest extends TestCase
         $overflowPage = 4294967296; // max int + 1
         $expectedPage = floor($maxInt / $perPage);
 
+        $rawSearchResult = null;
+
         $results = SearchableUser::search('lar')
+            ->withRawResults(function ($result) use (&$rawSearchResult) {
+                $rawSearchResult = $result;
+            })
             ->paginate($perPage, null, $overflowPage);
 
         // Verify the page was adjusted correctly
-        $this->assertEquals($expectedPage, $results->currentPage());
+        $this->assertEquals($overflowPage, $results->currentPage());
         $this->assertEquals($perPage, $results->perPage());
+        $this->assertEquals($expectedPage, $rawSearchResult['page']);
+        $this->assertEquals($perPage, $rawSearchResult['request_params']['per_page']);
     }
 
     protected static function scoutDriver(): string

--- a/tests/Integration/TypesenseSearchableTest.php
+++ b/tests/Integration/TypesenseSearchableTest.php
@@ -12,7 +12,9 @@ use Workbench\App\Models\SearchableUser;
 #[RequiresEnv('TYPESENSE_API_KEY')]
 class TypesenseSearchableTest extends TestCase
 {
-    use SearchableTests;
+    use SearchableTests {
+        defineScoutDatabaseMigrations as baseDefineScoutDatabaseMigrations;
+    }
 
     /**
      * Define environment setup.
@@ -23,6 +25,24 @@ class TypesenseSearchableTest extends TestCase
     protected function defineEnvironment($app)
     {
         $this->defineScoutEnvironment($app);
+
+        $app['config']->set('scout.typesense.model-settings.' . SearchableUser::class, [
+            'collection-schema' => [
+                'fields' => [
+                    [
+                        'name' => 'id',
+                        'type' => 'string',
+                    ],
+                    [
+                        'name' => 'name',
+                        'type' => 'string',
+                    ],
+                ],
+            ],
+            'search-parameters' => [
+                'query_by' => 'name'
+            ],
+        ]);
     }
 
     /**
@@ -35,13 +55,10 @@ class TypesenseSearchableTest extends TestCase
         $this->defineScoutDatabaseMigrations();
     }
 
-    /**
-     * Perform any work that should take place once the database has finished refreshing.
-     *
-     * @return void
-     */
-    protected function afterRefreshingDatabase()
+    protected function defineScoutDatabaseMigrations()
     {
+        $this->baseDefineScoutDatabaseMigrations();
+
         $this->importScoutIndexFrom(SearchableUser::class);
     }
 
@@ -50,8 +67,6 @@ class TypesenseSearchableTest extends TestCase
         $results = $this->itCanUseBasicSearch();
 
         $this->assertSame([
-            11 => 'Larry Casper',
-            1 => 'Laravel Framework',
             44 => 'Amos Larson Sr.',
             43 => 'Dana Larson Sr.',
             42 => 'Dax Larkin',
@@ -60,6 +75,8 @@ class TypesenseSearchableTest extends TestCase
             39 => 'Linkwood Larkin',
             20 => 'Prof. Larry Prosacco DVM',
             12 => 'Reta Larkin',
+            11 => 'Larry Casper',
+            1 => 'Laravel Framework',
         ], $results->pluck('name', 'id')->all());
     }
 
@@ -68,13 +85,13 @@ class TypesenseSearchableTest extends TestCase
         $results = $this->itCanUseBasicSearchWithQueryCallback();
 
         $this->assertSame([
-            1 => 'Laravel Framework',
             44 => 'Amos Larson Sr.',
             43 => 'Dana Larson Sr.',
             42 => 'Dax Larkin',
             41 => 'Gudrun Larkin',
             40 => 'Otis Larson MD',
             12 => 'Reta Larkin',
+            1 => 'Laravel Framework',
         ], $results->pluck('name', 'id')->all());
     }
 
@@ -83,8 +100,6 @@ class TypesenseSearchableTest extends TestCase
         $results = $this->itCanUseBasicSearchToFetchKeys();
 
         $this->assertSame([
-            '11',
-            '1',
             '44',
             '43',
             '42',
@@ -93,6 +108,8 @@ class TypesenseSearchableTest extends TestCase
             '39',
             '20',
             '12',
+            '11',
+            '1',
         ], $results->all());
     }
 
@@ -101,8 +118,6 @@ class TypesenseSearchableTest extends TestCase
         $results = $this->itCanUseBasicSearchWithQueryCallbackToFetchKeys();
 
         $this->assertSame([
-            '11',
-            '1',
             '44',
             '43',
             '42',
@@ -111,6 +126,8 @@ class TypesenseSearchableTest extends TestCase
             '39',
             '20',
             '12',
+            '11',
+            '1',
         ], $results->all());
     }
 
@@ -127,19 +144,19 @@ class TypesenseSearchableTest extends TestCase
         [$page1, $page2] = $this->itCanUsePaginatedSearch();
 
         $this->assertSame([
-            11 => 'Larry Casper',
-            1 => 'Laravel Framework',
             44 => 'Amos Larson Sr.',
             43 => 'Dana Larson Sr.',
             42 => 'Dax Larkin',
+            41 => 'Gudrun Larkin',
+            40 => 'Otis Larson MD',
         ], $page1->pluck('name', 'id')->all());
 
         $this->assertSame([
-            41 => 'Gudrun Larkin',
-            40 => 'Otis Larson MD',
             39 => 'Linkwood Larkin',
             20 => 'Prof. Larry Prosacco DVM',
             12 => 'Reta Larkin',
+            11 => 'Larry Casper',
+            1 => 'Laravel Framework',
         ], $page2->pluck('name', 'id')->all());
     }
 
@@ -148,16 +165,16 @@ class TypesenseSearchableTest extends TestCase
         [$page1, $page2] = $this->itCanUsePaginatedSearchWithQueryCallback();
 
         $this->assertSame([
-            1 => 'Laravel Framework',
             44 => 'Amos Larson Sr.',
             43 => 'Dana Larson Sr.',
             42 => 'Dax Larkin',
+            41 => 'Gudrun Larkin',
+            40 => 'Otis Larson MD',
         ], $page1->pluck('name', 'id')->all());
 
         $this->assertSame([
-            41 => 'Gudrun Larkin',
-            40 => 'Otis Larson MD',
             12 => 'Reta Larkin',
+            1 => 'Laravel Framework',
         ], $page2->pluck('name', 'id')->all());
     }
 

--- a/tests/Integration/TypesenseSearchableTest.php
+++ b/tests/Integration/TypesenseSearchableTest.php
@@ -247,7 +247,7 @@ class TypesenseSearchableTest extends TestCase
         $expectedPage = floor($maxInt / $perPage);
 
         $results = SearchableUser::search('lar')
-            ->paginate($perPage, $overflowPage);
+            ->paginate($perPage, null, $overflowPage);
 
         // Verify the page was adjusted correctly
         $this->assertEquals($expectedPage, $results->currentPage());

--- a/tests/Integration/TypesenseSearchableTest.php
+++ b/tests/Integration/TypesenseSearchableTest.php
@@ -26,7 +26,7 @@ class TypesenseSearchableTest extends TestCase
     {
         $this->defineScoutEnvironment($app);
 
-        $app['config']->set('scout.typesense.model-settings.' . SearchableUser::class, [
+        $app['config']->set('scout.typesense.model-settings.'.SearchableUser::class, [
             'collection-schema' => [
                 'fields' => [
                     [
@@ -40,7 +40,7 @@ class TypesenseSearchableTest extends TestCase
                 ],
             ],
             'search-parameters' => [
-                'query_by' => 'name'
+                'query_by' => 'name',
             ],
         ]);
     }


### PR DESCRIPTION
Based on https://typesense.org/docs/guide/github-actions.html, I updated the GitHub action to run the Typesense integration tests.

I also replaced the `@group ...` docblocks with PHPUnit attributes, since no Meilisearch or Typesense integration tests ran on PHP 8.3/8.4 due to the usage of docblocks. 
<img width="993" height="131" alt="Screenshot 2026-02-10 at 10 18 57" src="https://github.com/user-attachments/assets/588dbcc8-775b-4d13-bd32-b997aa22ad8d" />