### PR TITLE
[11.x] Add support for `where($field, $operator, $value)` on `Builder` class

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,29 @@
 
 ## Upgrading To 11.0 From 10.x
 
+### Builder `wheres` Property and Custom Engines
+
+In previous Scout releases, the `wheres` property on the `Builder` instance was a simple key / value associative array. In Scout 11.x, the `wheres` property is now an array of arrays, with each entry containing `field`, `operator`, and `value` keys. This change was made to support comparison operators such as `>`, `<`, `>=`, `<=`, and `!=` via the `where` method:
+
+```php
+User::search('*')->where('age', '>', 30)->get();
+```
+
+If you are directly accessing the `wheres` property within a custom engine, you should update your code to handle the new format:
+
+```diff
+- foreach ($builder->wheres as $field => $value) {
+-     // ...
+- }
++ foreach ($builder->wheres as $where) {
++     $field = $where['field'];
++     $operator = $where['operator'];
++     $value = $where['value'];
++
++     // ...
++ }
+```
+
 ### Algolia Engine `filters`
 
 PR: https://github.com/laravel/scout/pull/839

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -111,7 +111,11 @@ class Builder
         $this->callback = $callback;
 
         if ($softDelete) {
-            $this->wheres['__soft_deleted'] = 0;
+            $this->wheres[] = [
+                'field' => '__soft_deleted',
+                'operator' => '=',
+                'value' => 0,
+            ];
         }
     }
 
@@ -132,12 +136,17 @@ class Builder
      * Add a constraint to the search query.
      *
      * @param  string  $field
-     * @param  mixed  $value
+     * @param  mixed  $operator
+     * @param  mixed|null  $value
      * @return $this
      */
-    public function where($field, $value)
+    public function where($field, $operator, $value = null)
     {
-        $this->wheres[$field] = $value;
+        $this->wheres[] = [
+            'field' => $field,
+            'operator' => $value === null ? '=' : $operator,
+            'value' => $value === null ? $operator : $value,
+        ];
 
         return $this;
     }
@@ -177,7 +186,7 @@ class Builder
      */
     public function withTrashed()
     {
-        unset($this->wheres['__soft_deleted']);
+        $this->wheres = collect($this->wheres)->where('field', '!=', '__soft_deleted')->values()->all();
 
         return $this;
     }
@@ -190,7 +199,11 @@ class Builder
     public function onlyTrashed()
     {
         return tap($this->withTrashed(), function () {
-            $this->wheres['__soft_deleted'] = 1;
+            $this->wheres[] = [
+                'field' => '__soft_deleted',
+                'operator' => '=',
+                'value' => 1,
+            ];
         });
     }
 

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -144,8 +144,8 @@ class Builder
     {
         $this->wheres[] = [
             'field' => $field,
-            'operator' => $value === null ? '=' : $operator,
-            'value' => $value === null ? $operator : $value,
+            'operator' => func_num_args() === 2 ? '=' : $operator,
+            'value' => func_num_args() === 2 ? $operator : $value,
         ];
 
         return $this;

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -162,9 +162,20 @@ class AlgoliaEngine extends Engine
      */
     protected function filters(Builder $builder)
     {
-        $wheres = collect($builder->wheres)->map(function ($value, $key) {
-            return $key.":'{$value}'";
-        })->values();
+        $wheres = collect($builder->wheres)
+            ->map(function ($where) {
+                $field = $where['field'];
+                $operator = $where['operator'];
+                $value = $where['value'];
+
+                if (is_string($value) || $operator === '=') {
+                    $operator = ':';
+                    $value = "'{$value}'";
+                }
+
+                return $field.$operator.$value;
+            })
+            ->values();
 
         return $wheres->merge(collect($builder->whereIns)->map(function ($values, $key) {
             if (empty($values)) {

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -3,7 +3,6 @@
 namespace Laravel\Scout\Engines;
 
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Support\Arr;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
 use Laravel\Scout\Builder;

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -89,9 +89,9 @@ class CollectionEngine extends Engine
                             call_user_func($builder->callback, $query, $builder, $builder->query);
                         })
                         ->when(! $builder->callback && count($builder->wheres) > 0, function ($query) use ($builder) {
-                            foreach ($builder->wheres as $key => $value) {
-                                if ($key !== '__soft_deleted') {
-                                    $query->where($key, $value);
+                            foreach ($builder->wheres as $where) {
+                                if ($where['field'] !== '__soft_deleted') {
+                                    $query->where($where['field'], $where['operator'], $where['value']);
                                 }
                             }
                         })
@@ -155,9 +155,11 @@ class CollectionEngine extends Engine
      */
     protected function ensureSoftDeletesAreHandled($builder, $query)
     {
-        if (Arr::get($builder->wheres, '__soft_deleted') === 0) {
+        $softDeleteWhere = collect($builder->wheres)->firstWhere('field', '__soft_deleted');
+
+        if ($softDeleteWhere && $softDeleteWhere['value'] === 0) {
             return $query->withoutTrashed();
-        } elseif (Arr::get($builder->wheres, '__soft_deleted') === 1) {
+        } elseif ($softDeleteWhere && $softDeleteWhere['value'] === 1) {
             return $query->onlyTrashed();
         } elseif (in_array(SoftDeletes::class, class_uses_recursive(get_class($builder->model))) &&
                   config('scout.soft_delete', false)) {

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -240,9 +240,9 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
         return $query->when(! is_null($builder->callback), function ($query) use ($builder) {
             call_user_func($builder->callback, $query, $builder, $builder->query);
         })->when(! $builder->callback && count($builder->wheres) > 0, function ($query) use ($builder) {
-            foreach ($builder->wheres as $key => $value) {
-                if ($key !== '__soft_deleted') {
-                    $query->where($key, '=', $value);
+            foreach ($builder->wheres as $where) {
+                if ($where['field'] !== '__soft_deleted') {
+                    $query->where($where['field'], $where['operator'], $where['value']);
                 }
             }
         })->when(! $builder->callback && count($builder->whereIns) > 0, function ($query) use ($builder) {
@@ -267,9 +267,11 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
      */
     protected function constrainForSoftDeletes($builder, $query)
     {
-        if (Arr::get($builder->wheres, '__soft_deleted') === 0) {
+        $softDeleteWhere = collect($builder->wheres)->firstWhere('field', '__soft_deleted');
+
+        if ($softDeleteWhere && $softDeleteWhere['value'] === 0) {
             return $query->withoutTrashed();
-        } elseif (Arr::get($builder->wheres, '__soft_deleted') === 1) {
+        } elseif ($softDeleteWhere && $softDeleteWhere['value'] === 1) {
             return $query->onlyTrashed();
         } elseif (in_array(SoftDeletes::class, class_uses_recursive(get_class($builder->model))) &&
                   config('scout.soft_delete', false)) {

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -178,18 +178,22 @@ class MeilisearchEngine extends Engine
      */
     protected function filters(Builder $builder)
     {
-        $filters = collect($builder->wheres)->map(function ($value, $key) {
+        $filters = collect($builder->wheres)->map(function ($where) {
+            $field = $where['field'];
+            $value = $where['value'];
+            $operator = $where['operator'];
+
             if (is_bool($value)) {
-                return sprintf('%s=%s', $key, $value ? 'true' : 'false');
+                return sprintf('%s%s%s', $field, $operator, $value ? 'true' : 'false');
             }
 
             if ($value instanceof BackedEnum) {
-                return sprintf('%s=%s', $key, $value->value);
+                return sprintf('%s%s%s', $field, $operator, $value->value);
             }
 
             return is_numeric($value)
-                ? sprintf('%s=%s', $key, $value)
-                : sprintf('%s="%s"', $key, $value);
+                ? sprintf('%s%s%s', $field, $operator, $value)
+                : sprintf('%s%s"%s"', $field, $operator, $value);
         });
 
         $whereInOperators = [

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -291,7 +291,7 @@ class TypesenseEngine extends Engine
     protected function filters(Builder $builder): string
     {
         $whereFilter = collect($builder->wheres)
-            ->map(fn ($value, $key) => $this->parseWhereFilter($value, $key))
+            ->map(fn ($where) => $this->parseWhereFilter($this->parseFilterValue($where['value']), $where['field'], $where['operator']))
             ->values()
             ->implode(' && ');
 
@@ -310,13 +310,26 @@ class TypesenseEngine extends Engine
      *
      * @param  array|string  $value
      * @param  string  $key
+     * @param  string  $operator
      * @return string
      */
-    protected function parseWhereFilter(array|string $value, string $key): string
+    protected function parseWhereFilter(array|string $value, string $key, string $operator = '='): string
     {
-        return is_array($value)
-            ? sprintf('%s:%s', $key, implode('', $value))
-            : sprintf('%s:=%s', $key, $value);
+        if (is_array($value)) {
+            return sprintf('%s:%s', $key, implode('', $value));
+        }
+
+        $operator = match ($operator) {
+            '=' => ':=',
+            '!=' => ':!=',
+            '<' => ':<',
+            '>' => ':>',
+            '<=' => ':<=',
+            '>=' => ':>=',
+            default => ':=',
+        };
+
+        return sprintf('%s%s%s', $key, $operator, $value);
     }
 
     /**

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -242,7 +242,7 @@ class TypesenseEngine extends Engine
      * @param  int|null  $perPage
      * @return array
      */
-    public function buildSearchParameters(Builder $builder, int $page, int|null $perPage): array
+    public function buildSearchParameters(Builder $builder, int $page, ?int $perPage): array
     {
         $parameters = [
             'q' => $builder->query,

--- a/tests/Feature/CollectionEngineTest.php
+++ b/tests/Feature/CollectionEngineTest.php
@@ -159,4 +159,70 @@ class CollectionEngineTest extends TestCase
 
         $this->assertCount(2, $models);
     }
+
+    public function test_it_can_filter_with_greater_than()
+    {
+        $models = SearchableUserModel::search()->where('name', '>', 'B')->get();
+
+        $this->assertCount(1, $models);
+        $this->assertEquals('Taylor Otwell', $models[0]->name);
+    }
+
+    public function test_it_can_filter_with_less_than()
+    {
+        $models = SearchableUserModel::search()->where('name', '<', 'B')->get();
+
+        $this->assertCount(1, $models);
+        $this->assertEquals('Abigail Otwell', $models[0]->name);
+    }
+
+    public function test_it_can_filter_with_greater_than_or_equal()
+    {
+        $models = SearchableUserModel::search()->where('name', '>=', 'T')->get();
+
+        $this->assertCount(1, $models);
+        $this->assertEquals('Taylor Otwell', $models[0]->name);
+
+        $models = SearchableUserModel::search()->where('name', '>=', 'A')->get();
+
+        $this->assertCount(2, $models);
+    }
+
+    public function test_it_can_filter_with_less_than_or_equal()
+    {
+        $models = SearchableUserModel::search()->where('name', '<=', 'Abigail Otwell')->get();
+
+        $this->assertCount(1, $models);
+        $this->assertEquals('Abigail Otwell', $models[0]->name);
+
+        $models = SearchableUserModel::search()->where('name', '<=', 'Taylor Otwell')->get();
+
+        $this->assertCount(2, $models);
+    }
+
+    public function test_it_can_filter_with_not_equal()
+    {
+        $models = SearchableUserModel::search()->where('name', '!=', 'Abigail Otwell')->get();
+
+        $this->assertCount(1, $models);
+        $this->assertEquals('Taylor Otwell', $models[0]->name);
+
+        $models = SearchableUserModel::search()->where('name', '!=', 'Taylor Otwell')->get();
+
+        $this->assertCount(1, $models);
+        $this->assertEquals('Abigail Otwell', $models[0]->name);
+    }
+
+    public function test_it_can_filter_with_multiple_where_comparisons()
+    {
+        $models = SearchableUserModel::search()->where('name', '>', 'S')->where('name', '<', 'Z')->get();
+
+        $this->assertCount(1, $models);
+        $this->assertEquals('Taylor Otwell', $models[0]->name);
+
+        $models = SearchableUserModel::search()->where('name', '>', 'A')->where('name', '<', 'S')->get();
+
+        $this->assertCount(1, $models);
+        $this->assertEquals('Abigail Otwell', $models[0]->name);
+    }
 }

--- a/tests/Feature/DatabaseEngineTest.php
+++ b/tests/Feature/DatabaseEngineTest.php
@@ -174,4 +174,70 @@ class DatabaseEngineTest extends TestCase
         $this->assertCount(1, $modelsSimplePaginate);
         $this->assertEquals('Taylor Otwell', $modelsSimplePaginate[0]->name);
     }
+
+    public function test_it_can_filter_with_greater_than()
+    {
+        $models = SearchableUserDatabaseModel::search()->where('name', '>', 'B')->get();
+
+        $this->assertCount(1, $models);
+        $this->assertEquals('Taylor Otwell', $models[0]->name);
+    }
+
+    public function test_it_can_filter_with_less_than()
+    {
+        $models = SearchableUserDatabaseModel::search()->where('name', '<', 'B')->get();
+
+        $this->assertCount(1, $models);
+        $this->assertEquals('Abigail Otwell', $models[0]->name);
+    }
+
+    public function test_it_can_filter_with_greater_than_or_equal()
+    {
+        $models = SearchableUserDatabaseModel::search()->where('name', '>=', 'T')->get();
+
+        $this->assertCount(1, $models);
+        $this->assertEquals('Taylor Otwell', $models[0]->name);
+
+        $models = SearchableUserDatabaseModel::search()->where('name', '>=', 'A')->get();
+
+        $this->assertCount(2, $models);
+    }
+
+    public function test_it_can_filter_with_less_than_or_equal()
+    {
+        $models = SearchableUserDatabaseModel::search()->where('name', '<=', 'Abigail Otwell')->get();
+
+        $this->assertCount(1, $models);
+        $this->assertEquals('Abigail Otwell', $models[0]->name);
+
+        $models = SearchableUserDatabaseModel::search()->where('name', '<=', 'Taylor Otwell')->get();
+
+        $this->assertCount(2, $models);
+    }
+
+    public function test_it_can_filter_with_not_equal()
+    {
+        $models = SearchableUserDatabaseModel::search()->where('name', '!=', 'Abigail Otwell')->get();
+
+        $this->assertCount(1, $models);
+        $this->assertEquals('Taylor Otwell', $models[0]->name);
+
+        $models = SearchableUserDatabaseModel::search()->where('name', '!=', 'Taylor Otwell')->get();
+
+        $this->assertCount(1, $models);
+        $this->assertEquals('Abigail Otwell', $models[0]->name);
+    }
+
+    public function test_it_can_filter_with_multiple_where_comparisons()
+    {
+        $models = SearchableUserDatabaseModel::search()->where('name', '>', 'S')->where('name', '<', 'Z')->get();
+
+        $this->assertCount(1, $models);
+        $this->assertEquals('Taylor Otwell', $models[0]->name);
+
+        $models = SearchableUserDatabaseModel::search()->where('name', '>', 'A')->where('name', '<', 'S')->get();
+
+        $this->assertCount(1, $models);
+        $this->assertEquals('Abigail Otwell', $models[0]->name);
+    }
 }

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -19,6 +19,7 @@ class User extends Authenticatable
         return [
             'id' => (int) $this->id,
             'name' => $this->name,
+            'age' => $this->age,
         ];
     }
 }

--- a/tests/Fixtures/migrations/add_age_to_users_table.php
+++ b/tests/Fixtures/migrations/add_age_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->integer('age')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('age');
+        });
+    }
+};

--- a/tests/Integration/AlgoliaSearchableTest.php
+++ b/tests/Integration/AlgoliaSearchableTest.php
@@ -2,13 +2,14 @@
 
 namespace Laravel\Scout\Tests\Integration;
 
-use Illuminate\Support\Env;
 use Laravel\Scout\Tests\Fixtures\User;
+use Orchestra\Testbench\Attributes\RequiresEnv;
 
 /**
  * @group algolia
  * @group external-network
  */
+#[RequiresEnv('ALGOLIA_APP_ID')]
 class AlgoliaSearchableTest extends TestCase
 {
     use SearchableTests;
@@ -21,10 +22,6 @@ class AlgoliaSearchableTest extends TestCase
      */
     protected function defineEnvironment($app)
     {
-        if (is_null(Env::get('ALGOLIA_APP_ID'))) {
-            $this->markTestSkipped();
-        }
-
         $this->defineScoutEnvironment($app);
     }
 
@@ -162,6 +159,11 @@ class AlgoliaSearchableTest extends TestCase
             40 => 'Otis Larson MD',
             12 => 'Reta Larkin',
         ], $page2->pluck('name', 'id')->all());
+    }
+
+    public function test_it_can_filter_with_where_comparisons()
+    {
+        $this->itCanMakeWhereComparisons();
     }
 
     protected static function scoutDriver(): string

--- a/tests/Integration/MeilisearchSearchableTest.php
+++ b/tests/Integration/MeilisearchSearchableTest.php
@@ -3,7 +3,6 @@
 namespace Laravel\Scout\Tests\Integration;
 
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Support\Env;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\MeilisearchEngine;
 use Laravel\Scout\Tests\Fixtures\User;
@@ -11,11 +10,13 @@ use Laravel\Scout\Tests\Fixtures\VersionableModel;
 use Meilisearch\Client;
 use Meilisearch\Endpoints\Indexes;
 use Mockery as m;
+use Orchestra\Testbench\Attributes\RequiresEnv;
 
 /**
  * @group meilisearch
  * @group external-network
  */
+#[RequiresEnv('MEILISEARCH_HOST')]
 class MeilisearchSearchableTest extends TestCase
 {
     use SearchableTests {
@@ -30,13 +31,9 @@ class MeilisearchSearchableTest extends TestCase
      */
     protected function defineEnvironment($app)
     {
-        if (is_null(Env::get('MEILISEARCH_HOST'))) {
-            $this->markTestSkipped();
-
-            return;
-        }
-
         $this->defineScoutEnvironment($app);
+
+        $app['config']->set('scout.meilisearch.index-settings.'.User::class.'.filterableAttributes', ['age']);
     }
 
     /**
@@ -188,6 +185,11 @@ class MeilisearchSearchableTest extends TestCase
             43 => 'Dana Larson Sr.',
             44 => 'Amos Larson Sr.',
         ], $page2->pluck('name', 'id')->all());
+    }
+
+    public function test_it_can_filter_with_where_comparisons()
+    {
+        $this->itCanMakeWhereComparisons();
     }
 
     protected static function scoutDriver(): string

--- a/tests/Integration/SearchableTests.php
+++ b/tests/Integration/SearchableTests.php
@@ -26,6 +26,7 @@ trait SearchableTests
     protected function defineScoutDatabaseMigrations(): void
     {
         $this->loadLaravelMigrations();
+        $this->loadMigrationsFrom(__DIR__.'/../Fixtures/migrations');
 
         $collect = LazyCollection::make(function () {
             yield ['name' => 'Laravel Framework'];
@@ -103,5 +104,27 @@ trait SearchableTests
             User::search('lar')->take(10)->query($queryCallback)->paginate(5, 'page', 1),
             User::search('lar')->take(10)->query($queryCallback)->paginate(5, 'page', 2),
         ];
+    }
+
+    public function itCanMakeWhereComparisons()
+    {
+        User::all()->each->delete();
+
+        UserFactory::new()->create(['name' => 'Taylor Otwell', 'age' => 35]);
+        UserFactory::new()->create(['name' => 'Abigail Otwell', 'age' => 30]);
+
+        $this->importScoutIndexFrom(User::class);
+
+        $this->assertSame(['Taylor Otwell'], User::search('*')->where('age', '>', 30)->get()->pluck('name')->all());
+        $this->assertSame(['Taylor Otwell', 'Abigail Otwell'], User::search('*')->where('age', '>=', 30)->get()->pluck('name')->all());
+
+        $this->assertSame(['Abigail Otwell'], User::search('*')->where('age', '<', 35)->get()->pluck('name')->all());
+        $this->assertSame(['Taylor Otwell', 'Abigail Otwell'], User::search('*')->where('age', '<=', 35)->get()->pluck('name')->all());
+
+        $this->assertSame(['Abigail Otwell'], User::search('*')->where('age', '!=', 35)->get()->pluck('name')->all());
+        $this->assertSame(['Taylor Otwell'], User::search('*')->where('age', '!=', 30)->get()->pluck('name')->all());
+
+        $this->assertSame(['Taylor Otwell'], User::search('*')->where('age', '>', 30)->where('age', '<', 40)->get()->pluck('name')->all());
+        $this->assertSame(['Abigail Otwell'], User::search('*')->where('age', '>', 25)->where('age', '<', 35)->get()->pluck('name')->all());
     }
 }

--- a/tests/Integration/TypesenseSearchableTest.php
+++ b/tests/Integration/TypesenseSearchableTest.php
@@ -2,13 +2,14 @@
 
 namespace Laravel\Scout\Tests\Integration;
 
-use Illuminate\Support\Env;
 use Laravel\Scout\Tests\Fixtures\User;
+use Orchestra\Testbench\Attributes\RequiresEnv;
 
 /**
  * @group typesense
  * @group external-network
  */
+#[RequiresEnv('TYPESENSE_API_KEY')]
 class TypesenseSearchableTest extends TestCase
 {
     use SearchableTests;
@@ -21,10 +22,6 @@ class TypesenseSearchableTest extends TestCase
      */
     protected function defineEnvironment($app)
     {
-        if (is_null(Env::get('TYPESENSE_API_KEY'))) {
-            $this->markTestSkipped();
-        }
-
         $this->defineScoutEnvironment($app);
     }
 
@@ -162,6 +159,11 @@ class TypesenseSearchableTest extends TestCase
             40 => 'Otis Larson MD',
             12 => 'Reta Larkin',
         ], $page2->pluck('name', 'id')->all());
+    }
+
+    public function test_it_can_filter_with_where_comparisons()
+    {
+        $this->itCanMakeWhereComparisons();
     }
 
     protected static function scoutDriver(): string

--- a/tests/Unit/BuilderTest.php
+++ b/tests/Unit/BuilderTest.php
@@ -130,14 +130,20 @@ class BuilderTest extends TestCase
     public function test_hard_delete_doesnt_set_wheres()
     {
         $builder = new Builder($model = m::mock(), 'zonda', null, false);
+        $builder->where('foo', 'bar');
 
-        $this->assertArrayNotHasKey('__soft_deleted', $builder->wheres);
+        $this->assertSame([['field' => 'foo', 'operator' => '=', 'value' => 'bar']], $builder->wheres);
+
+        $builder = new Builder($model = m::mock(), 'zonda', null, true);
+        $builder->where('foo', 'bar');
+
+        $this->assertSame([['field' => '__soft_deleted', 'operator' => '=', 'value' => 0], ['field' => 'foo', 'operator' => '=', 'value' => 'bar']], $builder->wheres);
     }
 
     public function test_soft_delete_sets_wheres()
     {
         $builder = new Builder($model = m::mock(), 'zonda', null, true);
 
-        $this->assertSame(0, $builder->wheres['__soft_deleted']);
+        $this->assertSame([['field' => '__soft_deleted', 'operator' => '=', 'value' => 0]], $builder->wheres);
     }
 }


### PR DESCRIPTION
Currently, there is no easy way to, for example, search the models that were created after a certain date. 
```php
// Before
User::search('foo', function ($engine, $query, options) {
	// You have to try to manipulate the $options to add where statements with operators (<, >, <=, >=, !=).
	// The $options variable is also very different for each engine, so you have to write an engine-specific implementation
})->get();
```
This is because the `where()` method on the Scout `Builder` class only accepts 2 parameters: a field and a value. This PR fixes that by allowing you to use an operator.
```php
// After
User::search('foo')->where('created_at', '>', now()->timestamp)->get();
```