### PR TITLE
[10.x] Make it easy to run Typesense en Meilisearch integration tests locally

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+echo "Ensuring docker is running"
+
+if ! docker info > /dev/null 2>&1; then
+  echo "Please start docker first."
+  exit 1
+fi
+
+echo "Ensuring services are running"
+
+docker-compose up -d
+
+echo "Running tests"
+
+if MEILISEARCH_HOST='http://localhost:7700' MEILISEARCH_KEY='masterKey' TYPESENSE_HOST='localhost' TYPESENSE_PORT=8108 TYPESENSE_API_KEY='xyz' ./vendor/bin/phpunit; then
+    exit 0
+else
+    exit 1
+fi

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-echo "Ensuring docker is running"
+echo "Ensuring Docker is running"
 
 if ! docker info > /dev/null 2>&1; then
   echo "Please start docker first."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3'
+services:
+    typesense:
+        image: 'typesense/typesense:30.1'
+        ports:
+            - '8108:8108'
+        environment:
+            TYPESENSE_DATA_DIR: '/typesense-data'
+            TYPESENSE_API_KEY: 'xyz'
+            TYPESENSE_ENABLE_CORS: true
+        volumes:
+            - 'typesense-data:/typesense-data'
+        healthcheck:
+            test:
+                - CMD
+                - wget
+                - '--no-verbose'
+                - '--spider'
+                - 'http://localhost:8108/health'
+            retries: 5
+            timeout: 7s
+    meilisearch:
+      image: 'getmeili/meilisearch:latest'
+      ports:
+          - '7700:7700'
+      healthcheck:
+          test: ["CMD", "wget", "--no-verbose", "--spider",  "http://localhost:7700/health"]
+          retries: 3
+          timeout: 5s
+volumes:
+    typesense-data:
+        driver: local


### PR DESCRIPTION
Currently, there is no easy way to quickly run the Typesense and Meilisearch integration tests when you are making changes to this package: either you already have Typesense and Meilisearch instances on your machine, or you have to trigger the GitHub actions.

This PR fixes that by adding a docker-compose file and a script to run the tests using those Docker containers on your local machine.
```bash
sh ./bin/test.sh
```