### PR TITLE
Use Algolia's filters parameter instead of numericFilters for string filter support

### DIFF
--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -99,7 +99,7 @@ abstract class AlgoliaEngine extends Engine implements UpdatesIndexSettings
     public function search(Builder $builder)
     {
         return $this->performSearch($builder, array_filter([
-            'numericFilters' => $this->filters($builder),
+            'filters' => $this->filters($builder),
             'hitsPerPage' => $builder->limit,
         ]));
     }
@@ -114,11 +114,11 @@ abstract class AlgoliaEngine extends Engine implements UpdatesIndexSettings
      */
     public function paginate(Builder $builder, $perPage, $page)
     {
-        return $this->performSearch($builder, [
-            'numericFilters' => $this->filters($builder),
+        return $this->performSearch($builder, array_filter([
+            'filters' => $this->filters($builder),
             'hitsPerPage' => $perPage,
             'page' => $page - 1,
-        ]);
+        ]));
     }
 
     /**
@@ -129,31 +129,56 @@ abstract class AlgoliaEngine extends Engine implements UpdatesIndexSettings
      */
     protected function filters(Builder $builder)
     {
-        $wheres = collect($builder->wheres)
-            ->map(fn ($value, $key) => $key.'='.$value)
-            ->values();
+        $parts = [];
 
-        $whereIns = collect($builder->whereIns)->map(function ($values, $key) {
+        foreach ($builder->wheres as $key => $value) {
+            $parts[] = $this->formatFilterExpression($key, '=', $value);
+        }
+
+        foreach ($builder->whereIns as $key => $values) {
             if (empty($values)) {
-                return '0=1';
+                $parts[] = '0=1';
+                continue;
             }
 
-            return collect($values)
-                ->map(fn ($value) => $key.'='.$value)
-                ->all();
-        })->values();
+            $orGroup = array_map(
+                fn ($value) => $this->formatFilterExpression($key, '=', $value),
+                $values
+            );
 
-        $whereNotIns = collect($builder->whereNotIns)->flatMap(function ($values, $key) {
-            if (empty($values)) {
-                return [];
+            $parts[] = count($orGroup) === 1 ? $orGroup[0] : '('.implode(' OR ', $orGroup).')';
+        }
+
+        foreach ($builder->whereNotIns as $key => $values) {
+            foreach ($values as $value) {
+                $parts[] = $this->formatFilterExpression($key, '!=', $value);
             }
+        }
 
-            return collect($values)
-                ->map(fn ($value) => $key.'!='.$value)
-                ->all();
-        });
+        return implode(' AND ', $parts) ?: null;
+    }
 
-        return $wheres->merge($whereIns)->merge($whereNotIns)->values()->all();
+    /**
+     * Format a single filter expression for Algolia's filters parameter.
+     *
+     * @param  string  $key
+     * @param  string  $operator
+     * @param  mixed  $value
+     * @return string
+     */
+    protected function formatFilterExpression($key, $operator, $value)
+    {
+        if (is_int($value) || is_float($value)) {
+            return $key.$operator.$value;
+        }
+
+        $escaped = str_replace('"', '\\"', (string) $value);
+
+        if ($operator === '!=') {
+            return 'NOT '.$key.':"'.$escaped.'"';
+        }
+
+        return $key.':"'.$escaped.'"';
     }
 
     /**

--- a/tests/Feature/Engines/Algolia3EngineTest.php
+++ b/tests/Feature/Engines/Algolia3EngineTest.php
@@ -112,7 +112,7 @@ class Algolia3EngineTest extends TestCase
 
         $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
         $index->shouldReceive('search')->once()->with('zonda', [
-            'numericFilters' => ['foo=1'],
+            'filters' => 'foo=1',
         ])->once();
 
         $builder = new Builder(new SearchableUser, 'zonda');
@@ -127,7 +127,7 @@ class Algolia3EngineTest extends TestCase
 
         $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
         $index->shouldReceive('search')->once()->with('zonda', [
-            'numericFilters' => ['foo=1', ['bar=1', 'bar=2']],
+            'filters' => 'foo=1 AND (bar=1 OR bar=2)',
         ]);
 
         $builder = new Builder(new SearchableUser, 'zonda');
@@ -142,7 +142,7 @@ class Algolia3EngineTest extends TestCase
 
         $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
         $index->shouldReceive('search')->once()->with('zonda', [
-            'numericFilters' => ['foo=1', '0=1'],
+            'filters' => 'foo=1 AND 0=1',
         ]);
 
         $builder = new Builder(new SearchableUser, 'zonda');
@@ -250,10 +250,7 @@ class Algolia3EngineTest extends TestCase
         $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
 
         $index->shouldReceive('search')->once()->with('zonda', [
-            'numericFilters' => [
-                'foo!=1',
-                'foo!=2',
-            ],
+            'filters' => 'foo!=1 AND foo!=2',
         ]);
 
         $builder = new Builder(new SearchableUser, 'zonda');
@@ -281,18 +278,162 @@ class Algolia3EngineTest extends TestCase
         $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
 
         $index->shouldReceive('search')->once()->with('zonda', [
-            'numericFilters' => [
-                'foo=1',
-                ['bar=1', 'bar=2'],
-                'baz!=1',
-                'baz!=2',
-            ],
+            'filters' => 'foo=1 AND (bar=1 OR bar=2) AND baz!=1 AND baz!=2',
         ]);
 
         $builder = new Builder(new SearchableUser, 'zonda');
         $builder->where('foo', 1)
                 ->whereIn('bar', [1, 2])
                 ->whereNotIn('baz', [1, 2]);
+
+        $engine->search($builder);
+    }
+
+    public function test_search_sends_correct_parameters_to_algolia_for_string_where_not_in_search()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+        $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
+
+        $index->shouldReceive('search')->once()->with('zonda', [
+            'filters' => 'NOT status:"draft" AND NOT status:"archived"',
+        ]);
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->whereNotIn('status', ['draft', 'archived']);
+
+        $engine->search($builder);
+    }
+
+    public function test_search_sends_correct_parameters_to_algolia_for_mixed_numeric_and_string_filters()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+        $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
+
+        $index->shouldReceive('search')->once()->with('zonda', [
+            'filters' => 'foo=1 AND (bar=1 OR bar=2) AND NOT status:"draft"',
+        ]);
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->where('foo', 1)
+                ->whereIn('bar', [1, 2])
+                ->whereNotIn('status', ['draft']);
+
+        $engine->search($builder);
+    }
+
+    public function test_search_sends_correct_parameters_to_algolia_for_string_where()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+        $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
+
+        $index->shouldReceive('search')->once()->with('zonda', [
+            'filters' => 'status:"active"',
+        ]);
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->where('status', 'active');
+
+        $engine->search($builder);
+    }
+
+    public function test_search_sends_correct_parameters_to_algolia_for_string_where_in()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+        $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
+
+        $index->shouldReceive('search')->once()->with('zonda', [
+            'filters' => '(status:"draft" OR status:"archived")',
+        ]);
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->whereIn('status', ['draft', 'archived']);
+
+        $engine->search($builder);
+    }
+
+    public function test_search_sends_no_filters_when_none_are_set()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+        $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
+
+        $index->shouldReceive('search')->once()->with('zonda', []);
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+
+        $engine->search($builder);
+    }
+
+    public function test_search_sends_correct_parameters_for_single_value_where_in()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+        $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
+
+        $index->shouldReceive('search')->once()->with('zonda', [
+            'filters' => 'foo=1',
+        ]);
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->whereIn('foo', [1]);
+
+        $engine->search($builder);
+    }
+
+    public function test_search_sends_correct_parameters_for_single_string_where_not_in()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+        $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
+
+        $index->shouldReceive('search')->once()->with('zonda', [
+            'filters' => 'NOT status:"deleted"',
+        ]);
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->whereNotIn('status', ['deleted']);
+
+        $engine->search($builder);
+    }
+
+    public function test_search_escapes_double_quotes_in_string_values()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+        $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
+
+        $index->shouldReceive('search')->once()->with('zonda', [
+            'filters' => 'name:"John \\"Doc\\" Smith"',
+        ]);
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->where('name', 'John "Doc" Smith');
+
+        $engine->search($builder);
+    }
+
+    public function test_search_sends_correct_parameters_for_float_values()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+        $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
+
+        $index->shouldReceive('search')->once()->with('zonda', [
+            'filters' => 'price=99.99',
+        ]);
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->where('price', 99.99);
+
+        $engine->search($builder);
+    }
+
+    public function test_search_sends_correct_parameters_for_zero_value()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+        $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
+
+        $index->shouldReceive('search')->once()->with('zonda', [
+            'filters' => '__soft_deleted=0',
+        ]);
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->where('__soft_deleted', 0);
 
         $engine->search($builder);
     }

--- a/tests/Feature/Engines/Algolia4EngineTest.php
+++ b/tests/Feature/Engines/Algolia4EngineTest.php
@@ -108,7 +108,7 @@ class Algolia4EngineTest extends TestCase
 
         $this->client->shouldReceive('searchSingleIndex')->once()->with(
             'users',
-            ['query' => 'zonda', 'numericFilters' => ['foo=1']],
+            ['query' => 'zonda', 'filters' => 'foo=1'],
         );
 
         $builder = new Builder(new SearchableUser, 'zonda');
@@ -123,7 +123,7 @@ class Algolia4EngineTest extends TestCase
 
         $this->client->shouldReceive('searchSingleIndex')->once()->with(
             'users',
-            ['query' => 'zonda', 'numericFilters' => ['foo=1', ['bar=1', 'bar=2']]],
+            ['query' => 'zonda', 'filters' => 'foo=1 AND (bar=1 OR bar=2)'],
         );
 
         $builder = new Builder(new SearchableUser, 'zonda');
@@ -138,7 +138,7 @@ class Algolia4EngineTest extends TestCase
 
         $this->client->shouldReceive('searchSingleIndex')->once()->with(
             'users',
-            ['query' => 'zonda', 'numericFilters' => ['foo=1', '0=1']],
+            ['query' => 'zonda', 'filters' => 'foo=1 AND 0=1'],
         );
 
         $builder = new Builder(new SearchableUser, 'zonda');
@@ -243,10 +243,7 @@ class Algolia4EngineTest extends TestCase
             'users',
             [
                 'query' => 'zonda',
-                'numericFilters' => [
-                    'foo!=1',
-                    'foo!=2',
-                ],
+                'filters' => 'foo!=1 AND foo!=2',
             ]
         );
 
@@ -279,12 +276,7 @@ class Algolia4EngineTest extends TestCase
             'users',
             [
                 'query' => 'zonda',
-                'numericFilters' => [
-                    'foo=1',
-                    ['bar=1', 'bar=2'],
-                    'baz!=1',
-                    'baz!=2',
-                ],
+                'filters' => 'foo=1 AND (bar=1 OR bar=2) AND baz!=1 AND baz!=2',
             ]
         );
 
@@ -292,6 +284,184 @@ class Algolia4EngineTest extends TestCase
         $builder->where('foo', 1)
                 ->whereIn('bar', [1, 2])
                 ->whereNotIn('baz', [1, 2]);
+
+        $engine->search($builder);
+    }
+
+    public function test_search_sends_correct_parameters_to_algolia_for_string_where_not_in_search()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+
+        $this->client->shouldReceive('searchSingleIndex')->once()->with(
+            'users',
+            [
+                'query' => 'zonda',
+                'filters' => 'NOT status:"draft" AND NOT status:"archived"',
+            ]
+        );
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->whereNotIn('status', ['draft', 'archived']);
+
+        $engine->search($builder);
+    }
+
+    public function test_search_sends_correct_parameters_to_algolia_for_mixed_numeric_and_string_filters()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+
+        $this->client->shouldReceive('searchSingleIndex')->once()->with(
+            'users',
+            [
+                'query' => 'zonda',
+                'filters' => 'foo=1 AND (bar=1 OR bar=2) AND NOT status:"draft"',
+            ]
+        );
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->where('foo', 1)
+                ->whereIn('bar', [1, 2])
+                ->whereNotIn('status', ['draft']);
+
+        $engine->search($builder);
+    }
+
+    public function test_search_sends_correct_parameters_to_algolia_for_string_where()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+
+        $this->client->shouldReceive('searchSingleIndex')->once()->with(
+            'users',
+            [
+                'query' => 'zonda',
+                'filters' => 'status:"active"',
+            ]
+        );
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->where('status', 'active');
+
+        $engine->search($builder);
+    }
+
+    public function test_search_sends_correct_parameters_to_algolia_for_string_where_in()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+
+        $this->client->shouldReceive('searchSingleIndex')->once()->with(
+            'users',
+            [
+                'query' => 'zonda',
+                'filters' => '(status:"draft" OR status:"archived")',
+            ]
+        );
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->whereIn('status', ['draft', 'archived']);
+
+        $engine->search($builder);
+    }
+
+    public function test_search_sends_no_filters_when_none_are_set()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+
+        $this->client->shouldReceive('searchSingleIndex')->once()->with(
+            'users',
+            ['query' => 'zonda']
+        );
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+
+        $engine->search($builder);
+    }
+
+    public function test_search_sends_correct_parameters_for_single_value_where_in()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+
+        $this->client->shouldReceive('searchSingleIndex')->once()->with(
+            'users',
+            [
+                'query' => 'zonda',
+                'filters' => 'foo=1',
+            ]
+        );
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->whereIn('foo', [1]);
+
+        $engine->search($builder);
+    }
+
+    public function test_search_sends_correct_parameters_for_single_string_where_not_in()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+
+        $this->client->shouldReceive('searchSingleIndex')->once()->with(
+            'users',
+            [
+                'query' => 'zonda',
+                'filters' => 'NOT status:"deleted"',
+            ]
+        );
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->whereNotIn('status', ['deleted']);
+
+        $engine->search($builder);
+    }
+
+    public function test_search_escapes_double_quotes_in_string_values()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+
+        $this->client->shouldReceive('searchSingleIndex')->once()->with(
+            'users',
+            [
+                'query' => 'zonda',
+                'filters' => 'name:"John \\"Doc\\" Smith"',
+            ]
+        );
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->where('name', 'John "Doc" Smith');
+
+        $engine->search($builder);
+    }
+
+    public function test_search_sends_correct_parameters_for_float_values()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+
+        $this->client->shouldReceive('searchSingleIndex')->once()->with(
+            'users',
+            [
+                'query' => 'zonda',
+                'filters' => 'price=99.99',
+            ]
+        );
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->where('price', 99.99);
+
+        $engine->search($builder);
+    }
+
+    public function test_search_sends_correct_parameters_for_zero_value()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+
+        $this->client->shouldReceive('searchSingleIndex')->once()->with(
+            'users',
+            [
+                'query' => 'zonda',
+                'filters' => '__soft_deleted=0',
+            ]
+        );
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->where('__soft_deleted', 0);
 
         $engine->search($builder);
     }


### PR DESCRIPTION
## Summary

- Migrates Algolia filter generation from the `numericFilters` parameter to the unified `filters` parameter, which supports both numeric comparisons and facet/string matching
- Fixes string-based filters (e.g. `whereNotIn('status', ['deleted'])`) which previously failed because `numericFilters` only accepts numeric values
- Uses proper Algolia filter syntax: `key=value` for numeric, `key:"value"` for strings, `NOT key:"value"` for string negation, `(... OR ...)` for whereIn groups, joined with `AND`
- Adds comprehensive test coverage for string where/whereIn/whereNotIn, mixed numeric+string filters, quote escaping, floats, zero values, and single-value whereIn

## Test plan

- [x] All existing Algolia v3 and v4 feature tests updated and passing
- [x] New tests added for: string where, string whereIn, string whereNotIn, single-value whereIn, quote escaping, float values, zero/soft-delete values, no-filter search
- [x] Full test suite passes (206 tests)
- [x] Verified filter string format against live Algolia API


Made with [Cursor](https://cursor.com)