### PR TITLE
[11.x] Prepare for fulltext support when using SQLite and SQL Server

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,10 @@
 
 ## Upgrading To 11.0 From 10.x
 
+### No LIKE search for primary keys
+
+Returning the primary key column in toSearchableArray() is considered an error now because a LIKE search isn't possible on integer values and doesn't make sense on UUID values (if possible at all). Searching for IDs should be done using whereIn().
+
 ### Builder `wheres` Property and Custom Engines
 
 In previous Scout releases, the `wheres` property on the `Builder` instance was a simple key / value associative array. In Scout 11.x, the `wheres` property is now an array of arrays, with each entry containing `field`, `operator`, and `value` keys. This change was made to support comparison operators such as `>`, `<`, `>=`, `<=`, and `!=` via the `where` method:

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -165,11 +165,17 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
      */
     protected function buildSearchQuery(Builder $builder)
     {
+        $prefixColumns = $this->getPrefixColumns($builder);
+        $fullTextColumns = $this->getFullTextColumns($builder);
+
+        $allColumns = array_keys($builder->model->toSearchableArray());
+        $likeColumns = array_diff($allColumns, $prefixColumns, $fullTextColumns);
+
         $query = $this->initializeSearchQuery(
             $builder,
-            array_keys($builder->model->toSearchableArray()),
-            $this->getPrefixColumns($builder),
-            $this->getFullTextColumns($builder)
+            $likeColumns,
+            $prefixColumns,
+            $fullTextColumns
         );
 
         return $this->constrainForSoftDeletes(
@@ -188,42 +194,36 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
      */
     protected function initializeSearchQuery(Builder $builder, array $columns, array $prefixColumns = [], array $fullTextColumns = [])
     {
-        if (blank($builder->query)) {
+        if (empty($builder->query)) {
             return $builder->model->newQuery();
         }
 
         return $builder->model->newQuery()->where(function ($query) use ($builder, $columns, $prefixColumns, $fullTextColumns) {
             $connectionType = $builder->model->getConnection()->getDriverName();
-
-            $canSearchPrimaryKey = ctype_digit($builder->query) &&
-                                   in_array($builder->model->getKeyType(), ['int', 'integer']) &&
-                                   ($connectionType != 'pgsql' || $builder->query <= PHP_INT_MAX) &&
-                                   in_array($builder->model->getScoutKeyName(), $columns);
-
-            if ($canSearchPrimaryKey) {
-                $query->orWhere($builder->model->getQualifiedKeyName(), $builder->query);
-            }
-
             $likeOperator = $connectionType == 'pgsql' ? 'ilike' : 'like';
 
             foreach ($columns as $column) {
-                if (in_array($column, $fullTextColumns)) {
-                    $query->orWhereFullText(
-                        $builder->model->qualifyColumn($column),
-                        $builder->query,
-                        $this->getFullTextOptions($builder)
-                    );
-                } else {
-                    if ($canSearchPrimaryKey && $column === $builder->model->getScoutKeyName()) {
-                        continue;
-                    }
+                $query->orWhere(
+                    $builder->model->qualifyColumn($column),
+                    $likeOperator,
+                    '%'.$builder->query.'%'
+                );
+            }
 
-                    $query->orWhere(
-                        $builder->model->qualifyColumn($column),
-                        $likeOperator,
-                        in_array($column, $prefixColumns) ? $builder->query.'%' : '%'.$builder->query.'%',
-                    );
-                }
+            foreach ($prefixColumns as $column) {
+                $query->orWhere(
+                    $builder->model->qualifyColumn($column),
+                    $likeOperator,
+                    $builder->query.'%'
+                );
+            }
+
+            if (! empty($fullTextColumns)) {
+                $query->orWhereFullText(
+                    $fullTextColumns,
+                    $builder->query,
+                    $this->getFullTextOptions($builder)
+                );
             }
         });
     }


### PR DESCRIPTION
Removes special handling of primary key columns returned by toSearchableArray() in database engine to avoid errors in SQLite and SQL Server (https://github.com/laravel/framework/pull/58921, https://github.com/laravel/framework/pull/58924).

Breaking changes:
Returning the primary key column in toSearchableArray() is considered an error now because a LIKE search isn't possible on integer values and doesn't make sense on UUID values (if possible at all). Searching for IDs should be done using whereIn().