### PR TITLE
[11.x] Fix Typesense and Meilisearch filtering `where($field, $operator, $value)`

### DIFF
--- a/tests/Integration/MeilisearchSearchableTest.php
+++ b/tests/Integration/MeilisearchSearchableTest.php
@@ -246,8 +246,6 @@ class MeilisearchSearchableTest extends TestCase
 
     public function test_it_can_filter_with_where_comparisons()
     {
-        $this->markTestSkipped('Unable to filter using `age`');
-
         $this->itCanMakeWhereComparisons();
     }
 

--- a/tests/Integration/TypesenseSearchableTest.php
+++ b/tests/Integration/TypesenseSearchableTest.php
@@ -47,7 +47,7 @@ class TypesenseSearchableTest extends TestCase
                 ],
             ],
             'search-parameters' => [
-                'query_by' => 'name',
+                'query_by' => 'name,age',
             ],
         ]);
     }
@@ -271,8 +271,6 @@ class TypesenseSearchableTest extends TestCase
 
     public function test_it_can_filter_with_where_comparisons()
     {
-        $this->markTestSkipped('Unable to filter using `age`');
-
         $this->itCanMakeWhereComparisons();
     }
 

--- a/tests/Integration/TypesenseSearchableTest.php
+++ b/tests/Integration/TypesenseSearchableTest.php
@@ -47,7 +47,8 @@ class TypesenseSearchableTest extends TestCase
                 ],
             ],
             'search-parameters' => [
-                'query_by' => 'name,age',
+                'query_by' => 'name',
+                'filter_by' => 'age',
             ],
         ]);
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
