### PR TITLE
[11.x] Fix typesense and meilisearch tests

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -13,7 +13,7 @@ docker-compose up -d
 
 echo "Running tests"
 
-if MEILISEARCH_HOST='http://localhost:7700' MEILISEARCH_KEY='masterKey' TYPESENSE_HOST='localhost' TYPESENSE_PORT=8108 TYPESENSE_API_KEY='xyz' ./vendor/bin/phpunit; then
+if MEILISEARCH_HOST='http://localhost:7700' MEILISEARCH_KEY='masterKey' TYPESENSE_HOST='localhost' TYPESENSE_PORT=8108 TYPESENSE_API_KEY='xyz' ./vendor/bin/phpunit --exclude-group ''; then
     exit 0
 else
     exit 1

--- a/tests/Integration/MeilisearchSearchableTest.php
+++ b/tests/Integration/MeilisearchSearchableTest.php
@@ -246,8 +246,6 @@ class MeilisearchSearchableTest extends TestCase
 
     public function test_it_can_filter_with_where_comparisons()
     {
-        $this->markTestSkipped('Unable to filter using `age`');
-
         $this->itCanMakeWhereComparisons();
     }
 

--- a/tests/Integration/SearchableTests.php
+++ b/tests/Integration/SearchableTests.php
@@ -5,6 +5,7 @@ namespace Laravel\Scout\Tests\Integration;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Support\LazyCollection;
 use Workbench\App\Models\SearchableUser;
+use Workbench\Database\Factories\SearchableUserFactory;
 use Workbench\Database\Factories\UserFactory;
 
 use function Orchestra\Testbench\workbench_path;
@@ -23,6 +24,7 @@ trait SearchableTests
             return [
                 'id' => static::scoutDriver() === 'typesense' ? (string) $model->id : (int) $model->id,
                 'name' => $model->name,
+                'age' => $model->age,
             ];
         };
 
@@ -212,10 +214,10 @@ trait SearchableTests
         $this->importScoutIndexFrom(SearchableUser::class);
 
         $this->assertSame(['Taylor Otwell'], SearchableUser::search('*')->where('age', '>', 30)->get()->pluck('name')->all());
-        $this->assertSame(['Taylor Otwell', 'Abigail Otwell'], SearchableUser::search('*')->where('age', '>=', 30)->get()->pluck('name')->all());
+        $this->assertEqualsCanonicalizing(['Taylor Otwell', 'Abigail Otwell'], SearchableUser::search('*')->where('age', '>=', 30)->get()->pluck('name')->all());
 
         $this->assertSame(['Abigail Otwell'], SearchableUser::search('*')->where('age', '<', 35)->get()->pluck('name')->all());
-        $this->assertSame(['Taylor Otwell', 'Abigail Otwell'], SearchableUser::search('*')->where('age', '<=', 35)->get()->pluck('name')->all());
+        $this->assertEqualsCanonicalizing(['Taylor Otwell', 'Abigail Otwell'], SearchableUser::search('*')->where('age', '<=', 35)->get()->pluck('name')->all());
 
         $this->assertSame(['Abigail Otwell'], SearchableUser::search('*')->where('age', '!=', 35)->get()->pluck('name')->all());
         $this->assertSame(['Taylor Otwell'], SearchableUser::search('*')->where('age', '!=', 30)->get()->pluck('name')->all());

--- a/tests/Integration/SearchableTests.php
+++ b/tests/Integration/SearchableTests.php
@@ -23,7 +23,7 @@ trait SearchableTests
             return [
                 'id' => static::scoutDriver() === 'typesense' ? (string) $model->id : (int) $model->id,
                 'name' => $model->name,
-                'age' => $model->age,
+                'age' => (int) $model->age,
             ];
         };
 

--- a/tests/Integration/SearchableTests.php
+++ b/tests/Integration/SearchableTests.php
@@ -5,7 +5,6 @@ namespace Laravel\Scout\Tests\Integration;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Support\LazyCollection;
 use Workbench\App\Models\SearchableUser;
-use Workbench\Database\Factories\SearchableUserFactory;
 use Workbench\Database\Factories\UserFactory;
 
 use function Orchestra\Testbench\workbench_path;

--- a/tests/Integration/TypesenseSearchableTest.php
+++ b/tests/Integration/TypesenseSearchableTest.php
@@ -42,7 +42,7 @@ class TypesenseSearchableTest extends TestCase
                     ],
                     [
                         'name' => 'age',
-                        'type' => 'auto',
+                        'type' => 'int64',
                     ],
                 ],
             ],

--- a/tests/Integration/TypesenseSearchableTest.php
+++ b/tests/Integration/TypesenseSearchableTest.php
@@ -271,8 +271,6 @@ class TypesenseSearchableTest extends TestCase
 
     public function test_it_can_filter_with_where_comparisons()
     {
-        $this->markTestSkipped('Unable to filter using `age`');
-
         $this->itCanMakeWhereComparisons();
     }
 

--- a/workbench/database/factories/ChirpFactory.php
+++ b/workbench/database/factories/ChirpFactory.php
@@ -28,7 +28,7 @@ class ChirpFactory extends Factory
     {
         return [
             'scout_id' => fake()->uuid(),
-            'content' => fake()->realText(),
+            'content' => fake()->text(),
         ];
     }
 }


### PR DESCRIPTION
I also updated the `bin/test.sh` file to ensure the typesense en meilisearch tests run locally, because currently they were being skipped because the "external-network" group is excluded by default.
I also updated the ChirpFactory because out-of-memory exceptions occured when using `fake()->realText()`.