### PR TITLE
Remove redundant "When to Apply" section from skill body

### DIFF
--- a/resources/boost/skills/scout-development/SKILL.blade.php
+++ b/resources/boost/skills/scout-development/SKILL.blade.php
@@ -31,19 +31,6 @@ Effective search patterns:
 
 The docs are organized into these main sections: Installation, Driver Prerequisites, Configuration, Database/Collection Engines, Indexing, Searching, Custom Engines. Use these section names as search anchors.
 
-## When to Apply
-
-Activate this skill when:
-
-- Installing or configuring Scout
-- Choosing a search engine for a Laravel application
-- Making Eloquent models searchable
-- Customizing indexed data or index names
-- Writing search queries, filters, or pagination
-- Importing or flushing search indexes
-- Troubleshooting search results or indexing issues
-- Choosing between search engines
-
 ## Installation
 
 Before installing, check if Scout is already in the project — look for `laravel/scout` in `composer.json` and `config/scout.php`. If already installed, skip to the relevant section (engine configuration, model setup, or searching).


### PR DESCRIPTION
## Summary

- Removes the `## When to Apply` section from the Scout skill file
- This section was already fully covered by the skill's `description` frontmatter — removing it doesn't affect skill triggering behavior

See laravel/boost#669 for the corresponding change in the Boost monorepo.