### PR TITLE
Fix: meilisearch `not null` condition

### DIFF
--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -196,7 +196,7 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
                 }
 
                 if (is_null($value)) {
-                    return sprintf('%s %s', $field, 'IS NULL');
+                    return sprintf('%s %s', $field, $operator === '!=' ? 'IS NOT NULL' : 'IS NULL');
                 }
 
                 return is_numeric($value)

--- a/tests/Feature/Engines/MeilisearchEngineTest.php
+++ b/tests/Feature/Engines/MeilisearchEngineTest.php
@@ -219,6 +219,22 @@ class MeilisearchEngineTest extends TestCase
         $engine->search($builder);
     }
 
+    public function test_null_inequality_conditions_are_applied()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+
+        $builder = new Builder(new SearchableUser, '');
+        $builder->where('baz', '!=', null);
+
+        $this->client->shouldReceive('index')->once()->with('users')->andReturn($index = m::mock(Indexes::class));
+        $index->shouldReceive('rawSearch')->once()->with($builder->query, array_filter([
+            'filter' => 'baz IS NOT NULL',
+            'hitsPerPage' => $builder->limit,
+        ]))->andReturn([]);
+
+        $engine->search($builder);
+    }
+
     public function test_a_model_is_indexed_with_a_custom_meilisearch_key()
     {
         $model = ChirpFactory::new()->createQuietly(['scout_id' => 'my-meilisearch-key.5']);


### PR DESCRIPTION
Set the condition to `IS NOT NULL` when `value` is `null` and the `operator` is `!=`