### PR TITLE
Use model primary key for database queries instead of scout key name

### DIFF
--- a/resources/boost/skills/scout-development/SKILL.blade.php
+++ b/resources/boost/skills/scout-development/SKILL.blade.php
@@ -31,6 +31,19 @@ Effective search patterns:
 
 The docs are organized into these main sections: Installation, Driver Prerequisites, Configuration, Database/Collection Engines, Indexing, Searching, Custom Engines. Use these section names as search anchors.
 
+## When to Apply
+
+Activate this skill when:
+
+- Installing or configuring Scout
+- Choosing a search engine for a Laravel application
+- Making Eloquent models searchable
+- Customizing indexed data or index names
+- Writing search queries, filters, or pagination
+- Importing or flushing search indexes
+- Troubleshooting search results or indexing issues
+- Choosing between search engines
+
 ## Installation
 
 Before installing, check if Scout is already in the project — look for `laravel/scout` in `composer.json` and `config/scout.php`. If already installed, skip to the relevant section (engine configuration, model setup, or searching).

--- a/resources/boost/skills/scout-development/SKILL.blade.php
+++ b/resources/boost/skills/scout-development/SKILL.blade.php
@@ -31,19 +31,6 @@ Effective search patterns:
 
 The docs are organized into these main sections: Installation, Driver Prerequisites, Configuration, Database/Collection Engines, Indexing, Searching, Custom Engines. Use these section names as search anchors.
 
-## When to Apply
-
-Activate this skill when:
-
-- Installing or configuring Scout
-- Choosing a search engine for a Laravel application
-- Making Eloquent models searchable
-- Customizing indexed data or index names
-- Writing search queries, filters, or pagination
-- Importing or flushing search indexes
-- Troubleshooting search results or indexing issues
-- Choosing between search engines
-
 ## Installation
 
 Before installing, check if Scout is already in the project — look for `laravel/scout` in `composer.json` and `config/scout.php`. If already installed, skip to the relevant section (engine configuration, model setup, or searching).

--- a/src/Console/QueueImportCommand.php
+++ b/src/Console/QueueImportCommand.php
@@ -48,8 +48,8 @@ class QueueImportCommand extends Command
 
         $query = $model::makeAllSearchableQuery();
 
-        $min = $this->option('min') ?? $query->min($model->getScoutKeyName());
-        $max = $this->option('max') ?? $query->max($model->getScoutKeyName());
+        $min = $this->option('min') ?? $query->min($model->getKeyName());
+        $max = $this->option('max') ?? $query->max($model->getKeyName());
 
         $chunk = max(1, (int) ($this->option('chunk') ?? config('scout.chunk.searchable', 500)));
 

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -110,7 +110,7 @@ class CollectionEngine extends Engine
                                 $query->orderBy($order['column'], $order['direction']);
                             }
                         }, function ($query) use ($builder) {
-                            $query->orderBy($builder->model->qualifyColumn($builder->model->getScoutKeyName()), 'desc');
+                            $query->orderBy($builder->model->qualifyColumn($builder->model->getKeyName()), 'desc');
                         });
 
         $models = $this->ensureSoftDeletesAreHandled($builder, $query)
@@ -178,7 +178,7 @@ class CollectionEngine extends Engine
         $results = array_values($results['results']);
 
         return count($results) > 0
-            ? collect($results)->pluck($results[0]->getScoutKeyName())
+            ? collect($results)->pluck($results[0]->getKeyName())
             : collect();
     }
 
@@ -199,7 +199,7 @@ class CollectionEngine extends Engine
         }
 
         $objectIds = collect($results)
-            ->pluck($model->getScoutKeyName())
+            ->pluck($model->getKeyName())
             ->values()
             ->all();
 
@@ -228,7 +228,7 @@ class CollectionEngine extends Engine
         }
 
         $objectIds = collect($results)
-            ->pluck($model->getScoutKeyName())
+            ->pluck($model->getKeyName())
             ->values()->all();
 
         $objectIdPositions = array_flip($objectIds);

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -81,7 +81,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
                 }
             })
             ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
-                $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
+                $query->orderBy($builder->model->getTable().'.'.$builder->model->getKeyName(), 'desc');
             })
             ->when($this->shouldOrderByRelevance($builder), function ($query) use ($builder) {
                 $this->orderByRelevance($builder, $query);
@@ -120,7 +120,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
                 }
             })
             ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
-                $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
+                $query->orderBy($builder->model->getTable().'.'.$builder->model->getKeyName(), 'desc');
             })
             ->when($this->shouldOrderByRelevance($builder), function ($query) use ($builder) {
                 $this->orderByRelevance($builder, $query);
@@ -158,7 +158,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
                 }
             })
             ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
-                $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
+                $query->orderBy($builder->model->getTable().'.'.$builder->model->getKeyName(), 'desc');
             })
             ->when($this->shouldOrderByRelevance($builder), function ($query) use ($builder) {
                 $this->orderByRelevance($builder, $query);
@@ -213,7 +213,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
             $canSearchPrimaryKey = ctype_digit($builder->query) &&
                                    in_array($builder->model->getKeyType(), ['int', 'integer']) &&
                                    ($connectionType != 'pgsql' || $builder->query <= PHP_INT_MAX) &&
-                                   in_array($builder->model->getScoutKeyName(), $columns);
+                                   in_array($builder->model->getKeyName(), $columns);
 
             if ($canSearchPrimaryKey) {
                 $query->orWhere($builder->model->getQualifiedKeyName(), $builder->query);
@@ -225,7 +225,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
                 if (in_array($column, $fullTextColumns)) {
                     continue;
                 } else {
-                    if ($canSearchPrimaryKey && $column === $builder->model->getScoutKeyName()) {
+                    if ($canSearchPrimaryKey && $column === $builder->model->getKeyName()) {
                         continue;
                     }
 

--- a/src/Jobs/MakeRangeSearchable.php
+++ b/src/Jobs/MakeRangeSearchable.php
@@ -56,7 +56,7 @@ class MakeRangeSearchable implements ShouldQueue
         $model = new $this->class;
 
         $models = $model::makeAllSearchableQuery()
-            ->whereBetween($model->getScoutKeyName(), [$this->start, $this->end])
+            ->whereBetween($model->getKeyName(), [$this->start, $this->end])
             ->get()
             ->filter
             ->shouldBeSearchable();

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -202,7 +202,7 @@ trait Searchable
                 $query->withTrashed();
             })
             ->orderBy(
-                $self->qualifyColumn($self->getScoutKeyName())
+                $self->qualifyColumn($self->getKeyName())
             );
     }
 
@@ -334,7 +334,7 @@ trait Searchable
             'whereIn';
 
         return $query->{$whereIn}(
-            $this->qualifyColumn($this->getScoutKeyName()), $ids
+            $this->qualifyColumn($this->getKeyName()), $ids
         );
     }
 

--- a/src/SearchableScope.php
+++ b/src/SearchableScope.php
@@ -32,23 +32,23 @@ class SearchableScope implements Scope
     public function extend(EloquentBuilder $builder)
     {
         $builder->macro('searchable', function (EloquentBuilder $builder, $chunk = null) {
-            $scoutKeyName = $builder->getModel()->getScoutKeyName();
+            $keyName = $builder->getModel()->getKeyName();
 
             $builder->chunkById($chunk ?: config('scout.chunk.searchable', 500), function ($models) {
                 $models->filter->shouldBeSearchable()->searchable();
 
                 event(new ModelsImported($models));
-            }, $builder->qualifyColumn($scoutKeyName), $scoutKeyName);
+            }, $builder->qualifyColumn($keyName), $keyName);
         });
 
         $builder->macro('unsearchable', function (EloquentBuilder $builder, $chunk = null) {
-            $scoutKeyName = $builder->getModel()->getScoutKeyName();
+            $keyName = $builder->getModel()->getKeyName();
 
             $builder->chunkById($chunk ?: config('scout.chunk.unsearchable', 500), function ($models) {
                 $models->unsearchable();
 
                 event(new ModelsFlushed($models));
-            }, $builder->qualifyColumn($scoutKeyName), $scoutKeyName);
+            }, $builder->qualifyColumn($keyName), $keyName);
         });
 
         HasManyThrough::macro('searchable', function ($chunk = null) {

--- a/tests/Feature/SearchableTest.php
+++ b/tests/Feature/SearchableTest.php
@@ -142,7 +142,7 @@ class SearchableTest extends TestCase
         $model = M::mock(SearchableModel::class)->makePartial();
         $model->shouldReceive('newQuery')->once()->andReturnSelf();
         $model->shouldReceive('getScoutKeyType')->once()->andReturn('int');
-        $model->shouldReceive('getScoutKeyName')->once()->andReturn('id');
+        $model->shouldReceive('getKeyName')->once()->andReturn('id');
         $model->shouldReceive('qualifyColumn')->with('id')->once()->andReturn('qualified_id');
         $model->shouldReceive('whereIntegerInRaw')->with('qualified_id', [1, 2, 3])->once()->andReturnSelf();
 
@@ -157,7 +157,7 @@ class SearchableTest extends TestCase
         $model = M::mock(SearchableModel::class)->makePartial();
         $model->shouldReceive('newQuery')->once()->andReturnSelf();
         $model->shouldReceive('getScoutKeyType')->once()->andReturn('string');
-        $model->shouldReceive('getScoutKeyName')->once()->andReturn('id');
+        $model->shouldReceive('getKeyName')->once()->andReturn('id');
         $model->shouldReceive('qualifyColumn')->with('id')->once()->andReturn('qualified_id');
         $model->shouldReceive('whereIn')->with('qualified_id', [1, 2, 3])->once()->andReturnSelf();
 

--- a/tests/Unit/SearchableScopeTest.php
+++ b/tests/Unit/SearchableScopeTest.php
@@ -23,7 +23,7 @@ class SearchableScopeTest extends TestCase
 
         $builder->shouldReceive('macro')->with('searchable', m::on(function ($callback) use ($builder) {
             $model = m::mock(Model::class);
-            $model->shouldReceive('getScoutKeyName')->once()->andReturn('id');
+            $model->shouldReceive('getKeyName')->once()->andReturn('id');
 
             $builder->shouldReceive('chunkById')->with(500, m::type(\Closure::class), 'users.id', 'id')->once();
             $builder->shouldReceive('getModel')->once()->andReturn($model);
@@ -36,7 +36,7 @@ class SearchableScopeTest extends TestCase
 
         $builder->shouldReceive('macro')->with('unsearchable', m::on(function ($callback) use ($builder) {
             $model = m::mock(Model::class);
-            $model->shouldReceive('getScoutKeyName')->once()->andReturn('id');
+            $model->shouldReceive('getKeyName')->once()->andReturn('id');
 
             $builder->shouldReceive('chunkById')->with(500, m::type(\Closure::class), 'users.id', 'id')->once();
             $builder->shouldReceive('getModel')->once()->andReturn($model);


### PR DESCRIPTION
## Summary

Fixes database query failures when `getScoutKeyName()` is overridden to return a different field name than the model's actual primary key. Database operations (chunking, ordering, whereIn) were incorrectly using the Scout key name instead of the database primary key.

Fixes laravel/scout#960

## Problem

When a model overrides `getScoutKeyName()` to return a search-engine-specific field name that differs from the database primary key, all database operations break:

```php
class Product extends Model
{
    protected $primaryKey = 'uuid';

    public function getScoutKeyName(): string
    {
        return 'id'; // Meilisearch document ID field
    }
}

// scout:import fails:
// SQLSTATE: Column not found: 1054 Unknown column 'id' in 'order clause'
// Because chunkById() uses getScoutKeyName() ('id') instead of getKeyName() ('uuid')
```

## Solution

Separate the two concerns across all affected files (SearchableScope, Searchable trait, QueueImportCommand, MakeRangeSearchable, DatabaseEngine, CollectionEngine):

- **Search engine operations** (indexing, deleting documents, extracting IDs from search results): continue using `getScoutKeyName()`
- **Database operations** (chunking, ordering, whereIn, min/max): now use `getKeyName()`

## Before/After

**Before:** `scout:import` with a custom `getScoutKeyName()` fails with "Column not found" because database queries use the Scout key name.

**After:** Database queries use the model's actual primary key. Search engine operations continue using the Scout key name. Both work independently.

## Test Plan

- Verify `scout:import` works with default configuration (getScoutKeyName == getKeyName)
- Verify `scout:import` works when getScoutKeyName differs from getKeyName
- Verify DatabaseEngine and CollectionEngine search results are correctly ordered
- Run existing test suite