### PR TITLE
Add failOnTimeout to Scout job classes

### DIFF
--- a/src/Jobs/MakeRangeSearchable.php
+++ b/src/Jobs/MakeRangeSearchable.php
@@ -11,6 +11,13 @@ class MakeRangeSearchable implements ShouldQueue
     use Queueable;
 
     /**
+     * Indicate if the job should be marked as failed on timeout.
+     *
+     * @var bool
+     */
+    public bool $failOnTimeout = true;
+
+    /**
      * The model to be made searchable.
      *
      * @var string

--- a/src/Traits/ConfiguresJobOptions.php
+++ b/src/Traits/ConfiguresJobOptions.php
@@ -26,6 +26,13 @@ trait ConfiguresJobOptions
     public $maxExceptions;
 
     /**
+     * Indicate if the job should be marked as failed on timeout.
+     *
+     * @var bool
+     */
+    public bool $failOnTimeout = true;
+
+    /**
      * Configure the job.
      *
      * @return void


### PR DESCRIPTION
## Summary

Scout jobs that exceed their timeout silently return to the queue and retry instead of being marked as failed. This makes it difficult to detect and diagnose indexing issues. Adds `failOnTimeout = true` to Scout job classes so timed-out jobs are properly recorded as failures.

Fixes laravel/scout#957

## Problem

Scout's `ConfiguresJobOptions` trait and `MakeRangeSearchable` job do not set `$failOnTimeout`. When a search indexing job times out (e.g., due to a slow Meilisearch/Algolia API call), Laravel's default behavior is to release the job back to the queue for retry rather than marking it as failed.

This means:
- Timed-out jobs silently retry without appearing in `failed_jobs`
- `Queue::failing()` callbacks are never triggered
- Monitoring tools cannot detect persistent timeout issues
- Jobs can loop indefinitely between retry and timeout

## Solution

Add `public bool $failOnTimeout = true` to the `ConfiguresJobOptions` trait and `MakeRangeSearchable` job class, matching the pattern used in other Laravel first-party packages.

## Test Plan

- Verify Scout import/flush jobs that exceed their timeout are marked as failed
- Verify the failed job handler is triggered on timeout
- Verify no regression for jobs that complete within timeout