### PR TITLE
Skip deleted handler during force delete on SoftDeletes models

### DIFF
--- a/src/ModelObserver.php
+++ b/src/ModelObserver.php
@@ -125,6 +125,10 @@ class ModelObserver
             return;
         }
 
+        if ($this->usesSoftDelete($model) && $model->isForceDeleting()) {
+            return;
+        }
+
         if ($this->usingSoftDeletes && $this->usesSoftDelete($model)) {
             $this->whileForcingUpdate(function () use ($model) {
                 $this->saved($model);

--- a/tests/Feature/ModelObserverTest.php
+++ b/tests/Feature/ModelObserverTest.php
@@ -139,6 +139,17 @@ class ModelObserverTest extends TestCase
         $model->delete();
     }
 
+    public function test_force_delete_on_soft_delete_model_dispatches_unsearchable_once()
+    {
+        $model = ChirpFactory::new()->createQuietly();
+
+        tap($this->app->make('scout.spied'), function ($scout) {
+            $scout->shouldReceive('delete')->once();
+        });
+
+        $model->forceDelete();
+    }
+
     public function test_update_on_sensitive_attributes_triggers_search()
     {
         $_ENV['user.searchIndexShouldBeUpdated'] = function ($model) {


### PR DESCRIPTION
Calling `forceDelete()` on a Searchable model that uses `SoftDeletes` currently dispatches `RemoveFromSearch` twice.

`SoftDeletes::forceDelete()` delegates to `Model::delete()`, which always fires the `deleted` event after performing the delete. Scout's `ModelObserver::deleted()` calls `$model->unsearchable()`. Immediately after, `SoftDeletes::forceDelete()` fires `forceDeleted`, and `ModelObserver::forceDeleted()` calls `unsearchable()` again.

For bulk delete operations (for example tenant/account purges with large amounts of records), this doubles the load on the search index queue.

## Event flow on `$model->forceDelete()` (SoftDeletes)

1. `SoftDeletes::forceDelete()` fires `forceDeleting`
2. Sets `$this->forceDeleting = true`
3. Delegates to `Model::delete()`:
   - Fires `deleting`
   - Performs the SQL delete
   - Fires `deleted` → first `unsearchable()`
4. `SoftDeletes::forceDelete()` fires `forceDeleted` → second `unsearchable()`

## Fix

Skip the `deleted` handler when the soft-deletes model is currently being force deleted.

The subsequent `forceDeleted` handler still dispatches `unsearchable()`, so the index is correctly cleaned.

## Unchanged behaviour

- Models without `SoftDeletes` are unaffected (`usesSoftDelete($model)` check)
- Plain `delete()` calls on a SoftDeletes model still behave as before (`isForceDeleting()` returns `false`)
- With `scout.soft_delete = true`, the force delete path still correctly removes the model via `forceDeleted`

This also avoids the unnecessary re-index/removal work in `deleted`, where the model is about to be hard-deleted anyway.

## Reproduction

```php
$model = SearchableSoftDeletesModel::find($id);
$model->forceDelete();

// Before: 2 RemoveFromSearch jobs dispatched
// After:  1 RemoveFromSearch job dispatched