### PR TITLE
Add option to wait for task

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -144,6 +144,7 @@ return [
             //     'filterableAttributes'=> ['id', 'name', 'email'],
             // ],
         ],
+        'wait_for_task' => false,
     ],
 
     /*

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -81,7 +81,7 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
 
         if (! empty($objects)) {
             $response = $index->addDocuments($objects, $models->first()->getScoutKeyName());
-            if (Config::get('scout.meilisearch.wait_for_task', false) && isset($result['taskUid'])) {
+            if (Config::get('scout.meilisearch.wait_for_task', false) && isset($response['taskUid'])) {
                 $index->waitForTask($response['taskUid']);
             }
         }
@@ -106,7 +106,7 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
             : $models->map->getScoutKey();
 
         $response = $index->deleteDocuments($keys->values()->all());
-        if (Config::get('scout.meilisearch.wait_for_task', false) && isset($result['taskUid'])) {
+        if (Config::get('scout.meilisearch.wait_for_task', false) && isset($response['taskUid'])) {
             $index->waitForTask($response['taskUid']);
         }
     }

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -80,7 +80,10 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
             ->all();
 
         if (! empty($objects)) {
-            $index->addDocuments($objects, $models->first()->getScoutKeyName());
+            $response = $index->addDocuments($objects, $models->first()->getScoutKeyName());
+            if (Config::get('scout.meilisearch.wait_for_task', false) && isset($result['taskUid'])) {
+                $index->waitForTask($response['taskUid']);
+            }
         }
     }
 
@@ -102,7 +105,10 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
             ? $models->pluck($models->first()->getScoutKeyName())
             : $models->map->getScoutKey();
 
-        $index->deleteDocuments($keys->values()->all());
+        $response = $index->deleteDocuments($keys->values()->all());
+        if (Config::get('scout.meilisearch.wait_for_task', false) && isset($result['taskUid'])) {
+            $index->waitForTask($response['taskUid']);
+        }
     }
 
     /**


### PR DESCRIPTION
This pull request adds an option in the Scout configuration to wait for a Meilisearch task to be finished. This was needed, because even with `searchableSync`, Meilisearch updates their index asynchronously, giving me inconsistant results.