### PR TITLE
Add PostgreSQL search engine to Scout

### DIFF
--- a/.github/workflows/pgsql.yml
+++ b/.github/workflows/pgsql.yml
@@ -2,12 +2,18 @@ name: PostgreSQL
 
 on:
   push:
+    branches:
+      - master
+      - '*.x'
   pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   pgsql:
     name: PostgreSQL Scout Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     services:
       postgres:
@@ -25,26 +31,25 @@ jobs:
           --health-retries 5
 
     env:
-      SCOUT_PGSQL_TEST_DATABASE: scout_testing
-      SCOUT_PGSQL_TEST_HOST: 127.0.0.1
-      SCOUT_PGSQL_TEST_PORT: 5432
-      SCOUT_PGSQL_TEST_USERNAME: postgres
-      SCOUT_PGSQL_TEST_PASSWORD: postgres
-      SCOUT_PGSQL_TEST_TRIGRAM: true
+      PGSQL_TEST_DATABASE: scout_testing
+      PGSQL_TEST_PASSWORD: postgres
+      PGSQL_TEST_TRIGRAM: true
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
-          php-version: '8.3'
+          php-version: 8.4
           extensions: pdo_pgsql
           coverage: none
 
       - name: Install Composer dependencies
-        run: composer install --no-interaction --prefer-dist
+        run: composer update --prefer-dist --no-interaction --no-progress
 
       - name: Run PostgreSQL tests
         run: vendor/bin/phpunit --group pgsql

--- a/.github/workflows/pgsql.yml
+++ b/.github/workflows/pgsql.yml
@@ -1,0 +1,50 @@
+name: PostgreSQL
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pgsql:
+    name: PostgreSQL Scout Tests
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_DB: scout_testing
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      SCOUT_PGSQL_TEST_DATABASE: scout_testing
+      SCOUT_PGSQL_TEST_HOST: 127.0.0.1
+      SCOUT_PGSQL_TEST_PORT: 5432
+      SCOUT_PGSQL_TEST_USERNAME: postgres
+      SCOUT_PGSQL_TEST_PASSWORD: postgres
+      SCOUT_PGSQL_TEST_TRIGRAM: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: pdo_pgsql
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run PostgreSQL tests
+        run: vendor/bin/phpunit --group pgsql

--- a/.github/workflows/pgsql.yml
+++ b/.github/workflows/pgsql.yml
@@ -12,8 +12,23 @@ permissions:
 
 jobs:
   pgsql:
-    name: PostgreSQL Scout Tests
-    runs-on: ubuntu-24.04
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} PostgreSQL
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - php: 8.0
+            laravel: 9
+          - php: 8.1
+            laravel: 10
+          - php: 8.2
+            laravel: 11
+          - php: 8.2
+            laravel: 12
+          - php: 8.3
+            laravel: 13
 
     services:
       postgres:
@@ -37,19 +52,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
-          php-version: 8.4
-          extensions: pdo_pgsql
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pdo_pgsql
+          tools: composer:v2
           coverage: none
 
       - name: Install Composer dependencies
-        run: composer update --prefer-dist --no-interaction --no-progress
+        run: composer update --prefer-dist --no-interaction --no-progress --with="illuminate/contracts:^${{ matrix.laravel }}"
 
       - name: Run PostgreSQL tests
         run: vendor/bin/phpunit --group pgsql

--- a/.github/workflows/pgsql.yml
+++ b/.github/workflows/pgsql.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   pgsql:
     name: PostgreSQL Scout Tests
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
 
     services:
       postgres:

--- a/config/scout.php
+++ b/config/scout.php
@@ -214,25 +214,25 @@ return [
     |
     | Here you may configure Scout's native PostgreSQL search driver. The driver
     | uses PostgreSQL full-text search by default and may optionally blend in
-    | trigram similarity when the pg_trgm extension is available.
+    | trigram similarity scoring when the pg_trgm extension is available.
     |
     */
 
     'pgsql' => [
-        'language' => env('SCOUT_PGSQL_LANGUAGE', 'english'),
-        'vector_column' => env('SCOUT_PGSQL_VECTOR_COLUMN', 'search_vector'),
+        'language' => 'english',
+        'vector_column' => 'search_vector',
         'column_weights' => [],
-        'query_function' => env('SCOUT_PGSQL_QUERY_FUNCTION', 'plainto_tsquery'),
-        'rank_function' => env('SCOUT_PGSQL_RANK_FUNCTION', 'ts_rank'),
+        'query_function' => 'plainto_tsquery',
+        'rank_function' => 'ts_rank',
         'trigram' => [
-            'enabled' => env('SCOUT_PGSQL_TRIGRAM', false),
-            'threshold' => env('SCOUT_PGSQL_TRIGRAM_THRESHOLD', 0.3),
+            'enabled' => env('PGSQL_TRIGRAM', false),
+            'threshold' => env('PGSQL_TRIGRAM_THRESHOLD', 0.3),
             'columns' => [],
-            'create_extension' => env('SCOUT_PGSQL_CREATE_TRIGRAM_EXTENSION', false),
+            'create_extension' => false,
         ],
         'weights' => [
-            'full_text' => env('SCOUT_PGSQL_FULL_TEXT_WEIGHT', 1.0),
-            'trigram' => env('SCOUT_PGSQL_TRIGRAM_WEIGHT', 0.25),
+            'full_text' => 1.0,
+            'trigram' => 0.25,
         ],
     ],
 

--- a/config/scout.php
+++ b/config/scout.php
@@ -227,10 +227,7 @@ return [
         'trigram' => [
             'enabled' => env('SCOUT_PGSQL_TRIGRAM', false),
             'threshold' => env('SCOUT_PGSQL_TRIGRAM_THRESHOLD', 0.3),
-            'extension' => [
-                'enabled' => env('SCOUT_PGSQL_TRIGRAM_EXTENSION', false),
-                'create' => env('SCOUT_PGSQL_CREATE_TRIGRAM_EXTENSION', false),
-            ],
+            'create_extension' => env('SCOUT_PGSQL_CREATE_TRIGRAM_EXTENSION', false),
         ],
         'weights' => [
             'full_text' => env('SCOUT_PGSQL_FULL_TEXT_WEIGHT', 1.0),

--- a/config/scout.php
+++ b/config/scout.php
@@ -221,6 +221,7 @@ return [
     'pgsql' => [
         'language' => env('SCOUT_PGSQL_LANGUAGE', 'english'),
         'vector_column' => env('SCOUT_PGSQL_VECTOR_COLUMN', 'search_vector'),
+        'query_function' => env('SCOUT_PGSQL_QUERY_FUNCTION', 'plainto_tsquery'),
         'rank_function' => env('SCOUT_PGSQL_RANK_FUNCTION', 'ts_rank'),
         'trigram' => [
             'enabled' => env('SCOUT_PGSQL_TRIGRAM', false),

--- a/config/scout.php
+++ b/config/scout.php
@@ -221,6 +221,7 @@ return [
     'pgsql' => [
         'language' => env('SCOUT_PGSQL_LANGUAGE', 'english'),
         'vector_column' => env('SCOUT_PGSQL_VECTOR_COLUMN', 'search_vector'),
+        'column_weights' => [],
         'query_function' => env('SCOUT_PGSQL_QUERY_FUNCTION', 'plainto_tsquery'),
         'rank_function' => env('SCOUT_PGSQL_RANK_FUNCTION', 'ts_rank'),
         'trigram' => [

--- a/config/scout.php
+++ b/config/scout.php
@@ -227,6 +227,7 @@ return [
         'trigram' => [
             'enabled' => env('SCOUT_PGSQL_TRIGRAM', false),
             'threshold' => env('SCOUT_PGSQL_TRIGRAM_THRESHOLD', 0.3),
+            'columns' => [],
             'create_extension' => env('SCOUT_PGSQL_CREATE_TRIGRAM_EXTENSION', false),
         ],
         'weights' => [

--- a/config/scout.php
+++ b/config/scout.php
@@ -11,7 +11,7 @@ return [
     | using Laravel Scout. This connection is used when syncing all models
     | to the search service. You should adjust this based on your needs.
     |
-    | Supported: "algolia", "meilisearch", "typesense",
+    | Supported: "algolia", "meilisearch", "typesense", "pgsql",
     |            "database", "collection", "null"
     |
     */
@@ -205,6 +205,35 @@ return [
             // ],
         ],
         'import_action' => env('TYPESENSE_IMPORT_ACTION', 'upsert'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | PostgreSQL Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure Scout's native PostgreSQL search driver. The driver
+    | uses PostgreSQL full-text search by default and may optionally blend in
+    | trigram similarity when the pg_trgm extension is available.
+    |
+    */
+
+    'pgsql' => [
+        'language' => env('SCOUT_PGSQL_LANGUAGE', 'english'),
+        'vector_column' => env('SCOUT_PGSQL_VECTOR_COLUMN', 'search_vector'),
+        'rank_function' => env('SCOUT_PGSQL_RANK_FUNCTION', 'ts_rank'),
+        'trigram' => [
+            'enabled' => env('SCOUT_PGSQL_TRIGRAM', false),
+            'threshold' => env('SCOUT_PGSQL_TRIGRAM_THRESHOLD', 0.3),
+            'extension' => [
+                'enabled' => env('SCOUT_PGSQL_TRIGRAM_EXTENSION', false),
+                'create' => env('SCOUT_PGSQL_CREATE_TRIGRAM_EXTENSION', false),
+            ],
+        ],
+        'weights' => [
+            'full_text' => env('SCOUT_PGSQL_FULL_TEXT_WEIGHT', 1.0),
+            'trigram' => env('SCOUT_PGSQL_TRIGRAM_WEIGHT', 0.25),
+        ],
     ],
 
 ];

--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -46,6 +46,11 @@ class ImportCommand extends Command
 
         $model = new $class;
 
+        if (config('scout.driver') === 'pgsql') {
+            $this->warn('Setting SCOUT_DRIVER or the Scout driver to [pgsql] does not create PostgreSQL search columns or indexes.');
+            $this->warn('Add the PostgreSQL search vector and any trigram indexes through a migration before importing.');
+        }
+
         $events->listen(ModelsImported::class, function ($event) use ($class) {
             $key = $event->models->last()->getScoutKey();
 

--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -4,7 +4,6 @@ namespace Laravel\Scout\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Support\Facades\Schema;
 use Laravel\Scout\Engines\PgsqlEngine;
 use Laravel\Scout\Events\ModelsImported;
 use Laravel\Scout\Exceptions\ScoutException;
@@ -44,7 +43,9 @@ class ImportCommand extends Command
     {
         $class = $this->argument('model');
 
-        if (! class_exists($class) && ! class_exists($class = app()->getNamespace()."Models\\{$class}")) {
+        $namespace = app()->getNamespace();
+
+        if (! class_exists($class) && ! class_exists($class = "{$namespace}Models\\{$class}")) {
             throw new ScoutException("Model [{$class}] not found.");
         }
 
@@ -63,7 +64,7 @@ class ImportCommand extends Command
         $events->listen(ModelsImported::class, function ($event) use ($class) {
             $key = $event->models->last()->getScoutKey();
 
-            $this->line('<comment>Imported ['.$class.'] models up to ID:</comment> '.$key);
+            $this->line("<comment>Imported [{$class}] models up to ID:</comment> {$key}");
         });
 
         if ($this->option('fresh')) {
@@ -74,7 +75,7 @@ class ImportCommand extends Command
 
         $events->forget(ModelsImported::class);
 
-        $this->info('All ['.$class.'] records have been imported.');
+        $this->info("All [{$class}] records have been imported.");
     }
 
     /**
@@ -86,19 +87,135 @@ class ImportCommand extends Command
      */
     protected function preparePgsqlSearch($model, $class)
     {
-        $schema = Schema::connection($model->getConnectionName());
-        $vectorColumn = (new SearchableSchema(config('scout.pgsql', [])))->vectorColumn();
+        $connection = $model->getConnection();
+        $schema = $connection->getSchemaBuilder();
+        $helper = new SearchableSchema(config('scout.pgsql', []));
+        $table = $model->getTable();
+        $vectorColumn = $helper->vectorColumn();
+        $columns = $this->searchableDatabaseColumns($model, $schema, $vectorColumn, $class);
+        $trigramColumns = $this->trigramDatabaseColumns($helper, $columns);
 
-        if ($schema->hasColumn($model->getTable(), $vectorColumn)) {
-            $this->warn('PostgreSQL search column ['.$vectorColumn.'] already exists for ['.$class.']; skipping preparation.');
+        if (! $schema->hasColumn($table, $vectorColumn)) {
+            $schema->table($table, function ($table) use ($columns, $trigramColumns) {
+                $table->searchable($columns, [
+                    'trigram' => [
+                        'columns' => $trigramColumns,
+                    ],
+                ]);
+            });
+
+            $this->info("Prepared PostgreSQL search columns and indexes for [{$class}].");
 
             return;
         }
 
-        $schema->table($model->getTable(), function ($table) use ($model) {
-            $table->searchable(array_keys($model->toSearchableArray()));
+        $createdExtension = false;
+
+        if ($helper->shouldCreateTrigramExtension() && ! empty($trigramColumns)) {
+            $connection->statement('create extension if not exists "pg_trgm"');
+            $createdExtension = true;
+        }
+
+        if ($this->preparePgsqlIndexes($connection, $schema, $helper, $table, $vectorColumn, $trigramColumns) || $createdExtension) {
+            $this->info("Prepared PostgreSQL search indexes for [{$class}].");
+
+            return;
+        }
+
+        $this->warn("PostgreSQL search schema already exists for [{$class}].");
+    }
+
+    /**
+     * Get searchable payload keys that are backed by real database columns.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Schema\Builder  $schema
+     * @param  string  $vectorColumn
+     * @param  class-string  $class
+     * @return array
+     */
+    protected function searchableDatabaseColumns($model, $schema, $vectorColumn, $class)
+    {
+        $databaseColumns = array_flip($schema->getColumnListing($model->getTable()));
+
+        $columns = array_values(array_filter(array_keys($model->toSearchableArray()), function ($column) use ($databaseColumns, $vectorColumn) {
+            return $column !== $vectorColumn && array_key_exists($column, $databaseColumns);
+        }));
+
+        if (empty($columns)) {
+            $table = $model->getTable();
+
+            throw new ScoutException("No database columns from [{$class}::toSearchableArray()] exist on [{$table}].");
+        }
+
+        return $columns;
+    }
+
+    /**
+     * Get configured trigram columns that can be indexed by the database.
+     *
+     * @param  \Laravel\Scout\Pgsql\SearchableSchema  $helper
+     * @param  array  $columns
+     * @return array
+     */
+    protected function trigramDatabaseColumns(SearchableSchema $helper, array $columns)
+    {
+        $searchableColumns = array_flip($columns);
+
+        return array_values(array_filter($helper->trigramColumns(), fn ($column) => array_key_exists($column, $searchableColumns)));
+    }
+
+    /**
+     * Prepare missing PostgreSQL indexes for an existing vector column.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @param  \Illuminate\Database\Schema\Builder  $schema
+     * @param  \Laravel\Scout\Pgsql\SearchableSchema  $helper
+     * @param  string  $table
+     * @param  string  $vectorColumn
+     * @param  array  $trigramColumns
+     * @return bool
+     */
+    protected function preparePgsqlIndexes($connection, $schema, SearchableSchema $helper, $table, $vectorColumn, array $trigramColumns)
+    {
+        $missingVectorIndex = ! $this->schemaHasIndex($schema, $table, [$vectorColumn], 'gin');
+        $missingTrigramColumns = array_values(array_filter($trigramColumns, function ($column) use ($connection, $schema, $helper, $table) {
+            return ! $this->schemaHasIndex($schema, $table, $helper->indexName($connection, $table, [$column], 'trigram_index'), 'gin');
+        }));
+
+        if (! $missingVectorIndex && empty($missingTrigramColumns)) {
+            return false;
+        }
+
+        $tableName = $table;
+
+        $schema->table($table, function ($table) use ($connection, $helper, $tableName, $vectorColumn, $missingVectorIndex, $missingTrigramColumns) {
+            if ($missingVectorIndex) {
+                $table->index($vectorColumn, null, 'gin');
+            }
+
+            foreach ($missingTrigramColumns as $column) {
+                $table->rawIndex(
+                    sprintf('%s gin_trgm_ops', $connection->getSchemaGrammar()->wrap($column)),
+                    $helper->indexName($connection, $tableName, [$column], 'trigram_index')
+                )->algorithm('gin');
+            }
         });
 
-        $this->info('Prepared PostgreSQL search columns and indexes for ['.$class.'].');
+        return true;
+    }
+
+    /**
+     * Determine if the schema builder can find the given index.
+     *
+     * @param  \Illuminate\Database\Schema\Builder  $schema
+     * @param  string  $table
+     * @param  string|array  $index
+     * @param  string|null  $type
+     * @return bool
+     */
+    protected function schemaHasIndex($schema, $table, $index, $type = null)
+    {
+        return method_exists($schema, 'hasIndex') && $schema->hasIndex($table, $index, $type);
     }
 }

--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -4,8 +4,11 @@ namespace Laravel\Scout\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Scout\Engines\PgsqlEngine;
 use Laravel\Scout\Events\ModelsImported;
 use Laravel\Scout\Exceptions\ScoutException;
+use Laravel\Scout\Pgsql\SearchableSchema;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'scout:import')]
@@ -19,6 +22,7 @@ class ImportCommand extends Command
     protected $signature = 'scout:import
             {model : Class name of model to bulk import}
             {--fresh : Flush the index before importing}
+            {--prepare-pgsql : Create PostgreSQL search columns and indexes before importing}
             {--c|chunk= : The number of records to import at a time (Defaults to configuration value: `scout.chunk.searchable`)}';
 
     /**
@@ -45,10 +49,15 @@ class ImportCommand extends Command
         }
 
         $model = new $class;
+        $usesPgsqlEngine = $model->searchableUsing() instanceof PgsqlEngine;
 
-        if (config('scout.driver') === 'pgsql') {
-            $this->warn('Setting SCOUT_DRIVER or the Scout driver to [pgsql] does not create PostgreSQL search columns or indexes.');
+        if ($usesPgsqlEngine && $this->option('prepare-pgsql')) {
+            $this->preparePgsqlSearch($model, $class);
+        } elseif ($usesPgsqlEngine) {
+            $this->warn('Using the [pgsql] Scout engine does not create PostgreSQL search columns or indexes.');
             $this->warn('Add the PostgreSQL search vector and any trigram indexes through a migration before importing.');
+        } elseif ($this->option('prepare-pgsql')) {
+            $this->warn('The [--prepare-pgsql] option only applies to models using the [pgsql] Scout engine.');
         }
 
         $events->listen(ModelsImported::class, function ($event) use ($class) {
@@ -66,5 +75,30 @@ class ImportCommand extends Command
         $events->forget(ModelsImported::class);
 
         $this->info('All ['.$class.'] records have been imported.');
+    }
+
+    /**
+     * Prepare PostgreSQL search columns and indexes for the model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  class-string  $class
+     * @return void
+     */
+    protected function preparePgsqlSearch($model, $class)
+    {
+        $schema = Schema::connection($model->getConnectionName());
+        $vectorColumn = (new SearchableSchema(config('scout.pgsql', [])))->vectorColumn();
+
+        if ($schema->hasColumn($model->getTable(), $vectorColumn)) {
+            $this->warn('PostgreSQL search column ['.$vectorColumn.'] already exists for ['.$class.']; skipping preparation.');
+
+            return;
+        }
+
+        $schema->table($model->getTable(), function ($table) use ($model) {
+            $table->searchable(array_keys($model->toSearchableArray()));
+        });
+
+        $this->info('Prepared PostgreSQL search columns and indexes for ['.$class.'].');
     }
 }

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -13,6 +13,7 @@ use Laravel\Scout\Engines\CollectionEngine;
 use Laravel\Scout\Engines\DatabaseEngine;
 use Laravel\Scout\Engines\MeilisearchEngine;
 use Laravel\Scout\Engines\NullEngine;
+use Laravel\Scout\Engines\PgsqlEngine;
 use Laravel\Scout\Engines\TypesenseEngine;
 use Meilisearch\Client as MeilisearchClient;
 use Meilisearch\Meilisearch;
@@ -187,6 +188,16 @@ class EngineManager extends Manager
     public function createDatabaseDriver()
     {
         return new DatabaseEngine;
+    }
+
+    /**
+     * Create a PostgreSQL engine instance.
+     *
+     * @return \Laravel\Scout\Engines\PgsqlEngine
+     */
+    public function createPgsqlDriver()
+    {
+        return new PgsqlEngine(config('scout.pgsql'));
     }
 
     /**

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -222,5 +222,4 @@ class DatabaseEngine extends DatabaseModelEngine
 
         return $options;
     }
-
 }

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -2,16 +2,13 @@
 
 namespace Laravel\Scout\Engines;
 
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Arr;
-use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Attributes\SearchUsingFullText;
 use Laravel\Scout\Attributes\SearchUsingPrefix;
 use Laravel\Scout\Builder;
-use Laravel\Scout\Contracts\PaginatesEloquentModelsUsingDatabase;
 use ReflectionMethod;
 
-class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
+class DatabaseEngine extends DatabaseModelEngine
 {
     /**
      * Create a new engine instance.
@@ -21,149 +18,6 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
     public function __construct()
     {
         //
-    }
-
-    /**
-     * Update the given model in the index.
-     *
-     * @param  \Illuminate\Database\Eloquent\Collection  $models
-     * @return void
-     */
-    public function update($models)
-    {
-        //
-    }
-
-    /**
-     * Remove the given model from the index.
-     *
-     * @param  \Illuminate\Database\Eloquent\Collection  $models
-     * @return void
-     */
-    public function delete($models)
-    {
-        //
-    }
-
-    /**
-     * Perform the given search on the engine.
-     *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @return mixed
-     */
-    public function search(Builder $builder)
-    {
-        $models = $this->searchModels($builder);
-
-        return [
-            'results' => $models,
-            'total' => $models->count(),
-        ];
-    }
-
-    /**
-     * Get the Eloquent models for the given builder.
-     *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @param  int|null  $page
-     * @param  int|null  $perPage
-     * @return \Illuminate\Database\Eloquent\Collection
-     */
-    protected function searchModels(Builder $builder, $page = null, $perPage = null)
-    {
-        return $this->buildSearchQuery($builder)
-            ->when(! is_null($page) && ! is_null($perPage), function ($query) use ($page, $perPage) {
-                $query->forPage($page, $perPage);
-            })
-            ->when($builder->orders, function ($query) use ($builder) {
-                foreach ($builder->orders as $order) {
-                    $query->orderBy($order['column'], $order['direction']);
-                }
-            })
-            ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
-                $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
-            })
-            ->when($this->shouldOrderByRelevance($builder), function ($query) use ($builder) {
-                $this->orderByRelevance($builder, $query);
-            })
-            ->get();
-    }
-
-    /**
-     * Paginate the given search on the engine.
-     *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @param  int  $perPage
-     * @param  int  $page
-     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
-     */
-    public function paginate(Builder $builder, $perPage, $page)
-    {
-        return $this->paginateUsingDatabase($builder, $perPage, 'page', $page);
-    }
-
-    /**
-     * Paginate the given search on the engine.
-     *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @param  int  $perPage
-     * @param  string  $pageName
-     * @param  int  $page
-     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
-     */
-    public function paginateUsingDatabase(Builder $builder, $perPage, $pageName, $page)
-    {
-        return $this->buildSearchQuery($builder)
-            ->when($builder->orders, function ($query) use ($builder) {
-                foreach ($builder->orders as $order) {
-                    $query->orderBy($order['column'], $order['direction']);
-                }
-            })
-            ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
-                $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
-            })
-            ->when($this->shouldOrderByRelevance($builder), function ($query) use ($builder) {
-                $this->orderByRelevance($builder, $query);
-            })
-            ->paginate($perPage, ['*'], $pageName, $page);
-    }
-
-    /**
-     * Paginate the given search on the engine using simple pagination.
-     *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @param  int  $perPage
-     * @param  int  $page
-     * @return \Illuminate\Contracts\Pagination\Paginator
-     */
-    public function simplePaginate(Builder $builder, $perPage, $page)
-    {
-        return $this->simplePaginateUsingDatabase($builder, $perPage, 'page', $page);
-    }
-
-    /**
-     * Paginate the given query into a simple paginator.
-     *
-     * @param  int  $perPage
-     * @param  string  $pageName
-     * @param  int|null  $page
-     * @return \Illuminate\Contracts\Pagination\Paginator
-     */
-    public function simplePaginateUsingDatabase(Builder $builder, $perPage, $pageName, $page)
-    {
-        return $this->buildSearchQuery($builder)
-            ->when($builder->orders, function ($query) use ($builder) {
-                foreach ($builder->orders as $order) {
-                    $query->orderBy($order['column'], $order['direction']);
-                }
-            })
-            ->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
-                $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
-            })
-            ->when($this->shouldOrderByRelevance($builder), function ($query) use ($builder) {
-                $this->orderByRelevance($builder, $query);
-            })
-            ->simplePaginate($perPage, ['*'], $pageName, $page);
     }
 
     /**
@@ -181,9 +35,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
             $this->getFullTextColumns($builder)
         );
 
-        return $this->constrainForSoftDeletes(
-            $builder, $this->addAdditionalConstraints($builder, $query->take($builder->limit))
-        );
+        return $this->finalizeSearchQuery($builder, $query);
     }
 
     /**
@@ -197,9 +49,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
      */
     protected function initializeSearchQuery(Builder $builder, array $columns, array $prefixColumns = [], array $fullTextColumns = [])
     {
-        $query = method_exists($builder->model, 'newScoutQuery')
-            ? $builder->model->newScoutQuery($builder)
-            : $builder->model->newQuery();
+        $query = $this->newModelQuery($builder);
 
         if (blank($builder->query)) {
             return $query;
@@ -248,6 +98,26 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
     }
 
     /**
+     * Add ordering to the search query.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function orderSearchQuery(Builder $builder, $query)
+    {
+        return $query->when($builder->orders, function ($query) use ($builder) {
+            foreach ($builder->orders as $order) {
+                $query->orderBy($order['column'], $order['direction']);
+            }
+        })->when(! $this->getFullTextColumns($builder), function ($query) use ($builder) {
+            $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
+        })->when($this->shouldOrderByRelevance($builder), function ($query) use ($builder) {
+            $this->orderByRelevance($builder, $query);
+        });
+    }
+
+    /**
      * Determine if the query should be ordered by relevance.
      */
     protected function shouldOrderByRelevance(Builder $builder): bool
@@ -288,59 +158,6 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
             ),
             [$builder->query]
         );
-    }
-
-    /**
-     * Add additional, developer defined constraints to the search query.
-     *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    protected function addAdditionalConstraints(Builder $builder, $query)
-    {
-        return $query->when(! is_null($builder->callback), function ($query) use ($builder) {
-            call_user_func($builder->callback, $query, $builder, $builder->query);
-        })->when(! $builder->callback && count($builder->wheres) > 0, function ($query) use ($builder) {
-            foreach ($builder->wheres as $where) {
-                if ($where['field'] !== '__soft_deleted') {
-                    $query->where($where['field'], $where['operator'], $where['value']);
-                }
-            }
-        })->when(! $builder->callback && count($builder->whereIns) > 0, function ($query) use ($builder) {
-            foreach ($builder->whereIns as $key => $values) {
-                $query->whereIn($key, $values);
-            }
-        })->when(! $builder->callback && count($builder->whereNotIns) > 0, function ($query) use ($builder) {
-            foreach ($builder->whereNotIns as $key => $values) {
-                $query->whereNotIn($key, $values);
-            }
-        })->when(! is_null($builder->queryCallback), function ($query) use ($builder) {
-            call_user_func($builder->queryCallback, $query);
-        });
-    }
-
-    /**
-     * Ensure that soft delete constraints are properly applied to the query.
-     *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    protected function constrainForSoftDeletes($builder, $query)
-    {
-        $softDeleteWhere = collect($builder->wheres)->firstWhere('field', '__soft_deleted');
-
-        if ($softDeleteWhere && $softDeleteWhere['value'] === 0) {
-            return $query->withoutTrashed();
-        } elseif ($softDeleteWhere && $softDeleteWhere['value'] === 1) {
-            return $query->onlyTrashed();
-        } elseif (in_array(SoftDeletes::class, class_uses_recursive(get_class($builder->model))) &&
-                  config('scout.soft_delete', false)) {
-            return $query->withTrashed();
-        }
-
-        return $query;
     }
 
     /**
@@ -406,91 +223,4 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
         return $options;
     }
 
-    /**
-     * Pluck and return the primary keys of the given results.
-     *
-     * @param  mixed  $results
-     * @return \Illuminate\Support\Collection
-     */
-    public function mapIds($results)
-    {
-        $results = $results['results'];
-
-        return count($results) > 0
-            ? collect($results->modelKeys())
-            : collect();
-    }
-
-    /**
-     * Map the given results to instances of the given model.
-     *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @param  mixed  $results
-     * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return \Illuminate\Database\Eloquent\Collection
-     */
-    public function map(Builder $builder, $results, $model)
-    {
-        return $results['results'];
-    }
-
-    /**
-     * Map the given results to instances of the given model via a lazy collection.
-     *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @param  mixed  $results
-     * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return \Illuminate\Support\LazyCollection
-     */
-    public function lazyMap(Builder $builder, $results, $model)
-    {
-        return new LazyCollection($results['results']->all());
-    }
-
-    /**
-     * Get the total count from a raw result returned by the engine.
-     *
-     * @param  mixed  $results
-     * @return int
-     */
-    public function getTotalCount($results)
-    {
-        return $results['total'];
-    }
-
-    /**
-     * Flush all of the model's records from the engine.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return void
-     */
-    public function flush($model)
-    {
-        //
-    }
-
-    /**
-     * Create a search index.
-     *
-     * @param  string  $name
-     * @param  array  $options
-     * @return mixed
-     *
-     * @throws \Exception
-     */
-    public function createIndex($name, array $options = [])
-    {
-        //
-    }
-
-    /**
-     * Delete a search index.
-     *
-     * @param  string  $name
-     * @return mixed
-     */
-    public function deleteIndex($name)
-    {
-        //
-    }
 }

--- a/src/Engines/DatabaseModelEngine.php
+++ b/src/Engines/DatabaseModelEngine.php
@@ -131,7 +131,7 @@ abstract class DatabaseModelEngine extends Engine implements PaginatesEloquentMo
         $results = $results['results'];
 
         return count($results) > 0
-            ? collect($results->modelKeys())
+            ? $results->map(fn ($model) => $model->getScoutKey())->values()
             : collect();
     }
 

--- a/src/Engines/DatabaseModelEngine.php
+++ b/src/Engines/DatabaseModelEngine.php
@@ -1,0 +1,311 @@
+<?php
+
+namespace Laravel\Scout\Engines;
+
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\LazyCollection;
+use Laravel\Scout\Builder;
+use Laravel\Scout\Contracts\PaginatesEloquentModelsUsingDatabase;
+
+abstract class DatabaseModelEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
+{
+    /**
+     * Update the given model in the index.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @return void
+     */
+    public function update($models)
+    {
+        //
+    }
+
+    /**
+     * Remove the given model from the index.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @return void
+     */
+    public function delete($models)
+    {
+        //
+    }
+
+    /**
+     * Perform the given search on the engine.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return mixed
+     */
+    public function search(Builder $builder)
+    {
+        $models = $this->searchModels($builder);
+
+        return [
+            'results' => $models,
+            'total' => $models->count(),
+        ];
+    }
+
+    /**
+     * Get the Eloquent models for the given builder.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  int|null  $page
+     * @param  int|null  $perPage
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    protected function searchModels(Builder $builder, $page = null, $perPage = null)
+    {
+        $query = $this->buildSearchQuery($builder)
+            ->when(! is_null($page) && ! is_null($perPage), function ($query) use ($page, $perPage) {
+                $query->forPage($page, $perPage);
+            });
+
+        return $this->orderSearchQuery($builder, $query)->get();
+    }
+
+    /**
+     * Paginate the given search on the engine.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  int  $perPage
+     * @param  int  $page
+     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
+     */
+    public function paginate(Builder $builder, $perPage, $page)
+    {
+        return $this->paginateUsingDatabase($builder, $perPage, 'page', $page);
+    }
+
+    /**
+     * Paginate the given search on the engine.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  int  $perPage
+     * @param  string  $pageName
+     * @param  int  $page
+     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
+     */
+    public function paginateUsingDatabase(Builder $builder, $perPage, $pageName, $page)
+    {
+        return $this->orderSearchQuery($builder, $this->buildSearchQuery($builder))
+            ->paginate($perPage, ['*'], $pageName, $page);
+    }
+
+    /**
+     * Paginate the given search on the engine using simple pagination.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  int  $perPage
+     * @param  int  $page
+     * @return \Illuminate\Contracts\Pagination\Paginator
+     */
+    public function simplePaginate(Builder $builder, $perPage, $page)
+    {
+        return $this->simplePaginateUsingDatabase($builder, $perPage, 'page', $page);
+    }
+
+    /**
+     * Paginate the given query into a simple paginator.
+     *
+     * @param  int  $perPage
+     * @param  string  $pageName
+     * @param  int|null  $page
+     * @return \Illuminate\Contracts\Pagination\Paginator
+     */
+    public function simplePaginateUsingDatabase(Builder $builder, $perPage, $pageName, $page)
+    {
+        return $this->orderSearchQuery($builder, $this->buildSearchQuery($builder))
+            ->simplePaginate($perPage, ['*'], $pageName, $page);
+    }
+
+    /**
+     * Pluck and return the primary keys of the given results.
+     *
+     * @param  mixed  $results
+     * @return \Illuminate\Support\Collection
+     */
+    public function mapIds($results)
+    {
+        $results = $results['results'];
+
+        return count($results) > 0
+            ? collect($results->modelKeys())
+            : collect();
+    }
+
+    /**
+     * Map the given results to instances of the given model.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  mixed  $results
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function map(Builder $builder, $results, $model)
+    {
+        return $results['results'];
+    }
+
+    /**
+     * Map the given results to instances of the given model via a lazy collection.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  mixed  $results
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Support\LazyCollection
+     */
+    public function lazyMap(Builder $builder, $results, $model)
+    {
+        return new LazyCollection($results['results']->all());
+    }
+
+    /**
+     * Get the total count from a raw result returned by the engine.
+     *
+     * @param  mixed  $results
+     * @return int
+     */
+    public function getTotalCount($results)
+    {
+        return $results['total'];
+    }
+
+    /**
+     * Flush all of the model's records from the engine.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    public function flush($model)
+    {
+        //
+    }
+
+    /**
+     * Create a search index.
+     *
+     * @param  string  $name
+     * @param  array  $options
+     * @return mixed
+     *
+     * @throws \Exception
+     */
+    public function createIndex($name, array $options = [])
+    {
+        //
+    }
+
+    /**
+     * Delete a search index.
+     *
+     * @param  string  $name
+     * @return mixed
+     */
+    public function deleteIndex($name)
+    {
+        //
+    }
+
+    /**
+     * Start the model query for the given Scout builder.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function newModelQuery(Builder $builder)
+    {
+        return method_exists($builder->model, 'newScoutQuery')
+            ? $builder->model->newScoutQuery($builder)
+            : $builder->model->newQuery();
+    }
+
+    /**
+     * Apply shared search query constraints.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function finalizeSearchQuery(Builder $builder, $query)
+    {
+        return $this->constrainForSoftDeletes(
+            $builder, $this->addAdditionalConstraints($builder, $query->take($builder->limit))
+        );
+    }
+
+    /**
+     * Add additional, developer defined constraints to the search query.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function addAdditionalConstraints(Builder $builder, $query)
+    {
+        return $query->when(! is_null($builder->callback), function ($query) use ($builder) {
+            call_user_func($builder->callback, $query, $builder, $builder->query);
+        })->when(! $builder->callback && count($builder->wheres) > 0, function ($query) use ($builder) {
+            foreach ($builder->wheres as $where) {
+                if ($where['field'] !== '__soft_deleted') {
+                    $query->where($where['field'], $where['operator'], $where['value']);
+                }
+            }
+        })->when(! $builder->callback && count($builder->whereIns) > 0, function ($query) use ($builder) {
+            foreach ($builder->whereIns as $key => $values) {
+                $query->whereIn($key, $values);
+            }
+        })->when(! $builder->callback && count($builder->whereNotIns) > 0, function ($query) use ($builder) {
+            foreach ($builder->whereNotIns as $key => $values) {
+                $query->whereNotIn($key, $values);
+            }
+        })->when(! is_null($builder->queryCallback), function ($query) use ($builder) {
+            call_user_func($builder->queryCallback, $query);
+        });
+    }
+
+    /**
+     * Ensure that soft delete constraints are properly applied to the query.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function constrainForSoftDeletes($builder, $query)
+    {
+        $softDeleteWhere = collect($builder->wheres)->firstWhere('field', '__soft_deleted');
+
+        if ($softDeleteWhere && $softDeleteWhere['value'] === 0) {
+            return $query->withoutTrashed();
+        }
+
+        if ($softDeleteWhere && $softDeleteWhere['value'] === 1) {
+            return $query->onlyTrashed();
+        }
+
+        if (in_array(SoftDeletes::class, class_uses_recursive(get_class($builder->model))) &&
+            config('scout.soft_delete', false)) {
+            return $query->withTrashed();
+        }
+
+        return $query;
+    }
+
+    /**
+     * Initialize / build the search query for the given Scout builder.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    abstract protected function buildSearchQuery(Builder $builder);
+
+    /**
+     * Add ordering to the search query.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    abstract protected function orderSearchQuery(Builder $builder, $query);
+}

--- a/src/Engines/PgsqlEngine.php
+++ b/src/Engines/PgsqlEngine.php
@@ -189,8 +189,10 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
         }
 
         $usesTrigram = $this->trigram()->uses($builder);
+        $trigramColumns = $usesTrigram ? $this->wrappedTrigramColumns($builder) : [];
+        $usesTrigram = $usesTrigram && ! empty($trigramColumns);
 
-        return $query->where(function ($query) use ($builder, $columns, $usesTrigram) {
+        return $query->where(function ($query) use ($builder, $columns, $trigramColumns, $usesTrigram) {
             $canSearchPrimaryKey = ctype_digit($builder->query) &&
                 in_array($builder->model->getKeyType(), ['int', 'integer']) &&
                 $builder->query <= PHP_INT_MAX &&
@@ -207,11 +209,8 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
 
             if ($usesTrigram) {
                 $query->orWhereRaw(
-                    sprintf('%s >= ?', $this->trigramSimilarityExpression($builder)),
-                    array_merge(
-                        $this->trigram()->similarityBindings($builder, $this->wrappedSearchableColumns($builder)),
-                        [$this->trigram()->threshold()]
-                    )
+                    $this->trigram()->predicateExpression($trigramColumns),
+                    $this->trigram()->predicateBindings($builder, $trigramColumns)
                 );
             }
         });
@@ -233,16 +232,19 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
         })->when(empty($builder->orders) && blank($builder->query), function ($query) use ($builder) {
             $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
         })->when(empty($builder->orders) && filled($builder->query), function ($query) use ($builder) {
-            if ($this->trigram()->uses($builder)) {
+            $usesTrigram = $this->trigram()->uses($builder);
+            $trigramColumns = $usesTrigram ? $this->wrappedTrigramColumns($builder) : [];
+
+            if ($usesTrigram && ! empty($trigramColumns)) {
                 $query->orderByRaw(
                     sprintf(
                         '((%s * ?) + (%s * ?)) desc',
                         $this->rankExpression($builder),
-                        $this->trigramSimilarityExpression($builder)
+                        $this->trigramSimilarityExpression($trigramColumns)
                     ),
                     array_merge(
                         [$this->language(), $builder->query, $this->trigram()->scoreWeight('full_text', 1.0)],
-                        $this->trigram()->similarityBindings($builder, $this->wrappedSearchableColumns($builder)),
+                        $this->trigram()->similarityBindings($builder, $trigramColumns),
                         [$this->trigram()->scoreWeight('trigram', 0.25)]
                     )
                 );
@@ -311,12 +313,12 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
     /**
      * Get the trigram similarity expression for the query.
      *
-     * @param  \Laravel\Scout\Builder  $builder
+     * @param  array  $columns
      * @return string
      */
-    protected function trigramSimilarityExpression(Builder $builder)
+    protected function trigramSimilarityExpression(array $columns)
     {
-        return $this->trigram()->similarityExpression($this->wrappedSearchableColumns($builder));
+        return $this->trigram()->similarityExpression($columns);
     }
 
     /**
@@ -328,6 +330,42 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
     protected function wrappedSearchableColumns(Builder $builder)
     {
         return array_map(fn ($column) => $this->searchableColumn($builder, $column), $this->searchableColumns($builder));
+    }
+
+    /**
+     * Get the wrapped configured trigram columns present in the model's searchable columns.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return array
+     */
+    protected function wrappedTrigramColumns(Builder $builder)
+    {
+        return array_map(fn ($column) => $this->searchableColumn($builder, $column), $this->trigramColumns($builder));
+    }
+
+    /**
+     * Get the configured trigram columns present in the model's searchable columns.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return array
+     */
+    protected function trigramColumns(Builder $builder)
+    {
+        $columns = $this->config['trigram']['columns'] ?? [];
+
+        if (! is_array($columns)) {
+            throw new InvalidArgumentException('The [pgsql] Scout driver trigram columns must be an array.');
+        }
+
+        $searchableColumns = array_flip($this->searchableColumns($builder));
+
+        return array_values(array_filter($columns, function ($column) use ($searchableColumns) {
+            if (! $this->isValidIdentifier($column)) {
+                throw new InvalidArgumentException(sprintf('The [pgsql] Scout driver trigram column [%s] must be a valid column name.', $column));
+            }
+
+            return array_key_exists($column, $searchableColumns);
+        }));
     }
 
     /**

--- a/src/Engines/PgsqlEngine.php
+++ b/src/Engines/PgsqlEngine.php
@@ -20,8 +20,6 @@ class PgsqlEngine extends DatabaseModelEngine
         'ts_rank_cd',
     ];
 
-    protected const COLUMN_WEIGHTS = ['A', 'B', 'C', 'D'];
-
     /**
      * The PostgreSQL trigram helper instance.
      *

--- a/src/Engines/PgsqlEngine.php
+++ b/src/Engines/PgsqlEngine.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Laravel\Scout\Engines;
+
+use Illuminate\Support\LazyCollection;
+use InvalidArgumentException;
+use Laravel\Scout\Builder;
+use Laravel\Scout\Contracts\PaginatesEloquentModelsUsingDatabase;
+
+class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
+{
+    /**
+     * Create a new engine instance.
+     *
+     * @param  array  $config
+     * @return void
+     */
+    public function __construct(protected array $config)
+    {
+        //
+    }
+
+    /**
+     * Update the given model in the index.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @return void
+     */
+    public function update($models)
+    {
+        //
+    }
+
+    /**
+     * Remove the given model from the index.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @return void
+     */
+    public function delete($models)
+    {
+        //
+    }
+
+    /**
+     * Perform the given search on the engine.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return mixed
+     */
+    public function search(Builder $builder)
+    {
+        $this->ensurePostgresqlConnection($builder);
+
+        return [
+            'results' => $builder->model->newCollection(),
+            'total' => 0,
+        ];
+    }
+
+    /**
+     * Paginate the given search on the engine.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  int  $perPage
+     * @param  int  $page
+     * @return mixed
+     */
+    public function paginate(Builder $builder, $perPage, $page)
+    {
+        return $this->paginateUsingDatabase($builder, $perPage, 'page', $page);
+    }
+
+    /**
+     * Paginate the given search on the engine.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  int  $perPage
+     * @param  string  $pageName
+     * @param  int  $page
+     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
+     */
+    public function paginateUsingDatabase(Builder $builder, $perPage, $pageName, $page)
+    {
+        $this->ensurePostgresqlConnection($builder);
+
+        return $builder->model->newQuery()->whereRaw('1 = 0')->paginate($perPage, ['*'], $pageName, $page);
+    }
+
+    /**
+     * Paginate the given search on the engine using simple pagination.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  int  $perPage
+     * @param  string  $pageName
+     * @param  int  $page
+     * @return \Illuminate\Contracts\Pagination\Paginator
+     */
+    public function simplePaginateUsingDatabase(Builder $builder, $perPage, $pageName, $page)
+    {
+        $this->ensurePostgresqlConnection($builder);
+
+        return $builder->model->newQuery()->whereRaw('1 = 0')->simplePaginate($perPage, ['*'], $pageName, $page);
+    }
+
+    /**
+     * Pluck and return the primary keys of the given results.
+     *
+     * @param  mixed  $results
+     * @return \Illuminate\Support\Collection
+     */
+    public function mapIds($results)
+    {
+        return count($results['results']) > 0
+            ? collect($results['results']->modelKeys())
+            : collect();
+    }
+
+    /**
+     * Map the given results to instances of the given model.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  mixed  $results
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function map(Builder $builder, $results, $model)
+    {
+        return $results['results'];
+    }
+
+    /**
+     * Map the given results to instances of the given model via a lazy collection.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  mixed  $results
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Support\LazyCollection
+     */
+    public function lazyMap(Builder $builder, $results, $model)
+    {
+        return new LazyCollection($results['results']->all());
+    }
+
+    /**
+     * Get the total count from a raw result returned by the engine.
+     *
+     * @param  mixed  $results
+     * @return int
+     */
+    public function getTotalCount($results)
+    {
+        return $results['total'];
+    }
+
+    /**
+     * Flush all of the model's records from the engine.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    public function flush($model)
+    {
+        //
+    }
+
+    /**
+     * Create a search index.
+     *
+     * @param  string  $name
+     * @param  array  $options
+     * @return mixed
+     */
+    public function createIndex($name, array $options = [])
+    {
+        //
+    }
+
+    /**
+     * Delete a search index.
+     *
+     * @param  string  $name
+     * @return mixed
+     */
+    public function deleteIndex($name)
+    {
+        //
+    }
+
+    /**
+     * Ensure the builder's model is using a PostgreSQL connection.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return void
+     */
+    protected function ensurePostgresqlConnection(Builder $builder)
+    {
+        if ($builder->modelConnectionType() !== 'pgsql') {
+            throw new InvalidArgumentException('The [pgsql] Scout driver may only be used with PostgreSQL connections.');
+        }
+    }
+}

--- a/src/Engines/PgsqlEngine.php
+++ b/src/Engines/PgsqlEngine.php
@@ -10,6 +10,18 @@ use Laravel\Scout\Contracts\PaginatesEloquentModelsUsingDatabase;
 
 class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
 {
+    protected const QUERY_FUNCTIONS = [
+        'plainto_tsquery',
+        'phraseto_tsquery',
+        'websearch_to_tsquery',
+        'to_tsquery',
+    ];
+
+    protected const RANK_FUNCTIONS = [
+        'ts_rank',
+        'ts_rank_cd',
+    ];
+
     /**
      * Create a new engine instance.
      *
@@ -69,19 +81,12 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
      */
     protected function searchModels(Builder $builder, $page = null, $perPage = null)
     {
-        return $this->buildSearchQuery($builder)
+        $query = $this->buildSearchQuery($builder)
             ->when(! is_null($page) && ! is_null($perPage), function ($query) use ($page, $perPage) {
                 $query->forPage($page, $perPage);
-            })
-            ->when($builder->orders, function ($query) use ($builder) {
-                foreach ($builder->orders as $order) {
-                    $query->orderBy($order['column'], $order['direction']);
-                }
-            })
-            ->when(empty($builder->orders), function ($query) use ($builder) {
-                $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
-            })
-            ->get();
+            });
+
+        return $this->orderSearchQuery($builder, $query)->get();
     }
 
     /**
@@ -108,15 +113,7 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
      */
     public function paginateUsingDatabase(Builder $builder, $perPage, $pageName, $page)
     {
-        return $this->buildSearchQuery($builder)
-            ->when($builder->orders, function ($query) use ($builder) {
-                foreach ($builder->orders as $order) {
-                    $query->orderBy($order['column'], $order['direction']);
-                }
-            })
-            ->when(empty($builder->orders), function ($query) use ($builder) {
-                $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
-            })
+        return $this->orderSearchQuery($builder, $this->buildSearchQuery($builder))
             ->paginate($perPage, ['*'], $pageName, $page);
     }
 
@@ -143,15 +140,7 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
      */
     public function simplePaginateUsingDatabase(Builder $builder, $perPage, $pageName, $page)
     {
-        return $this->buildSearchQuery($builder)
-            ->when($builder->orders, function ($query) use ($builder) {
-                foreach ($builder->orders as $order) {
-                    $query->orderBy($order['column'], $order['direction']);
-                }
-            })
-            ->when(empty($builder->orders), function ($query) use ($builder) {
-                $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
-            })
+        return $this->orderSearchQuery($builder, $this->buildSearchQuery($builder))
             ->simplePaginate($perPage, ['*'], $pageName, $page);
     }
 
@@ -199,20 +188,38 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
                 $query->orWhere($builder->model->getQualifiedKeyName(), $builder->query);
             }
 
-            foreach ($columns as $column) {
-                if ($canSearchPrimaryKey && $column === $builder->model->getScoutKeyName()) {
-                    continue;
-                }
+            $query->orWhereRaw(
+                sprintf('%s @@ %s(?::regconfig, ?)', $this->vectorColumn($builder), $this->queryFunction()),
+                [$this->language(), $builder->query]
+            );
+        });
+    }
 
-                $wrappedColumn = $query->getQuery()->getGrammar()->wrap(
-                    $builder->model->qualifyColumn($column)
-                );
-
-                $query->orWhereRaw(
-                    sprintf('lower(cast(%s as text)) like lower(?)', $wrappedColumn),
-                    ['%'.$builder->query.'%']
-                );
+    /**
+     * Add ordering to the search query.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function orderSearchQuery(Builder $builder, $query)
+    {
+        return $query->when($builder->orders, function ($query) use ($builder) {
+            foreach ($builder->orders as $order) {
+                $query->orderBy($order['column'], $order['direction']);
             }
+        })->when(empty($builder->orders) && blank($builder->query), function ($query) use ($builder) {
+            $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
+        })->when(empty($builder->orders) && filled($builder->query), function ($query) use ($builder) {
+            $query->orderByRaw(
+                sprintf(
+                    '%s(%s, %s(?::regconfig, ?)) desc',
+                    $this->rankFunction(),
+                    $this->vectorColumn($builder),
+                    $this->queryFunction()
+                ),
+                [$this->language(), $builder->query]
+            );
         });
     }
 
@@ -264,6 +271,79 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
                 config('scout.soft_delete', false) => $query->withTrashed(),
             default => $query,
         };
+    }
+
+    /**
+     * Get the configured PostgreSQL text search language.
+     *
+     * @return string
+     */
+    protected function language()
+    {
+        $language = $this->config['language'] ?? 'english';
+
+        if (! is_string($language) || ! preg_match('/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/', $language)) {
+            throw new InvalidArgumentException('The [pgsql] Scout driver language must be a valid PostgreSQL text search configuration name.');
+        }
+
+        return $language;
+    }
+
+    /**
+     * Get the configured PostgreSQL search vector column.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return string
+     */
+    protected function vectorColumn(Builder $builder)
+    {
+        $column = $this->config['vector_column'] ?? 'search_vector';
+
+        if (! is_string($column) || ! preg_match('/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/', $column)) {
+            throw new InvalidArgumentException('The [pgsql] Scout driver vector column must be a valid column name.');
+        }
+
+        return $builder->model->getConnection()->getQueryGrammar()->wrap(
+            $builder->model->qualifyColumn($column)
+        );
+    }
+
+    /**
+     * Get the configured PostgreSQL tsquery function.
+     *
+     * @return string
+     */
+    protected function queryFunction()
+    {
+        $function = $this->config['query_function'] ?? self::QUERY_FUNCTIONS[0];
+
+        if (! in_array($function, self::QUERY_FUNCTIONS)) {
+            throw new InvalidArgumentException(sprintf(
+                'The [pgsql] Scout driver query function must be one of: %s.',
+                implode(', ', self::QUERY_FUNCTIONS)
+            ));
+        }
+
+        return $function;
+    }
+
+    /**
+     * Get the configured PostgreSQL rank function.
+     *
+     * @return string
+     */
+    protected function rankFunction()
+    {
+        $function = $this->config['rank_function'] ?? self::RANK_FUNCTIONS[0];
+
+        if (! in_array($function, self::RANK_FUNCTIONS)) {
+            throw new InvalidArgumentException(sprintf(
+                'The [pgsql] Scout driver rank function must be one of: %s.',
+                implode(', ', self::RANK_FUNCTIONS)
+            ));
+        }
+
+        return $function;
     }
 
     /**

--- a/src/Engines/PgsqlEngine.php
+++ b/src/Engines/PgsqlEngine.php
@@ -2,14 +2,11 @@
 
 namespace Laravel\Scout\Engines;
 
-use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Support\LazyCollection;
 use InvalidArgumentException;
 use Laravel\Scout\Builder;
-use Laravel\Scout\Contracts\PaginatesEloquentModelsUsingDatabase;
 use Laravel\Scout\Pgsql\Trigram;
 
-class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
+class PgsqlEngine extends DatabaseModelEngine
 {
     protected const QUERY_FUNCTIONS = [
         'plainto_tsquery',
@@ -44,117 +41,6 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
     }
 
     /**
-     * Update the given model in the index.
-     *
-     * @param  \Illuminate\Database\Eloquent\Collection  $models
-     * @return void
-     */
-    public function update($models)
-    {
-        //
-    }
-
-    /**
-     * Remove the given model from the index.
-     *
-     * @param  \Illuminate\Database\Eloquent\Collection  $models
-     * @return void
-     */
-    public function delete($models)
-    {
-        //
-    }
-
-    /**
-     * Perform the given search on the engine.
-     *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @return array
-     */
-    public function search(Builder $builder)
-    {
-        $models = $this->searchModels($builder);
-
-        return [
-            'results' => $models,
-            'total' => $models->count(),
-        ];
-    }
-
-    /**
-     * Get the Eloquent models for the given builder.
-     *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @param  int|null  $page
-     * @param  int|null  $perPage
-     * @return \Illuminate\Database\Eloquent\Collection
-     */
-    protected function searchModels(Builder $builder, $page = null, $perPage = null)
-    {
-        $query = $this->buildSearchQuery($builder)
-            ->when(! is_null($page) && ! is_null($perPage), function ($query) use ($page, $perPage) {
-                $query->forPage($page, $perPage);
-            });
-
-        return $this->orderSearchQuery($builder, $query)->get();
-    }
-
-    /**
-     * Paginate the given search on the engine.
-     *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @param  int  $perPage
-     * @param  int  $page
-     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
-     */
-    public function paginate(Builder $builder, $perPage, $page)
-    {
-        return $this->paginateUsingDatabase($builder, $perPage, 'page', $page);
-    }
-
-    /**
-     * Paginate the given search on the engine.
-     *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @param  int  $perPage
-     * @param  string  $pageName
-     * @param  int  $page
-     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
-     */
-    public function paginateUsingDatabase(Builder $builder, $perPage, $pageName, $page)
-    {
-        return $this->orderSearchQuery($builder, $this->buildSearchQuery($builder))
-            ->paginate($perPage, ['*'], $pageName, $page);
-    }
-
-    /**
-     * Paginate the given search on the engine using simple pagination.
-     *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @param  int  $perPage
-     * @param  int  $page
-     * @return \Illuminate\Contracts\Pagination\Paginator
-     */
-    public function simplePaginate(Builder $builder, $perPage, $page)
-    {
-        return $this->simplePaginateUsingDatabase($builder, $perPage, 'page', $page);
-    }
-
-    /**
-     * Paginate the given query into a simple paginator.
-     *
-     * @param  int  $perPage
-     * @param  string  $pageName
-     * @param  int|null  $page
-     * @return \Illuminate\Contracts\Pagination\Paginator
-     */
-    public function simplePaginateUsingDatabase(Builder $builder, $perPage, $pageName, $page)
-    {
-        return $this->orderSearchQuery($builder, $this->buildSearchQuery($builder))
-            ->simplePaginate($perPage, ['*'], $pageName, $page);
-    }
-
-    /**
      * Initialize / build the search query for the given Scout builder.
      *
      * @param  \Laravel\Scout\Builder  $builder
@@ -166,9 +52,7 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
 
         $query = $this->initializeSearchQuery($builder, $this->searchableColumns($builder));
 
-        return $this->constrainForSoftDeletes(
-            $builder, $this->addAdditionalConstraints($builder, $query->take($builder->limit))
-        );
+        return $this->finalizeSearchQuery($builder, $query);
     }
 
     /**
@@ -180,9 +64,7 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
      */
     protected function initializeSearchQuery(Builder $builder, array $columns)
     {
-        $query = method_exists($builder->model, 'newScoutQuery')
-            ? $builder->model->newScoutQuery($builder)
-            : $builder->model->newQuery();
+        $query = $this->newModelQuery($builder);
 
         if (blank($builder->query)) {
             return $query;
@@ -348,56 +230,6 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
     }
 
     /**
-     * Add additional, developer defined constraints to the search query.
-     *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    protected function addAdditionalConstraints(Builder $builder, $query)
-    {
-        return $query->when(! is_null($builder->callback), function ($query) use ($builder) {
-            call_user_func($builder->callback, $query, $builder, $builder->query);
-        })->when(! $builder->callback && count($builder->wheres) > 0, function ($query) use ($builder) {
-            foreach ($builder->wheres as $where) {
-                if ($where['field'] !== '__soft_deleted') {
-                    $query->where($where['field'], $where['operator'], $where['value']);
-                }
-            }
-        })->when(! $builder->callback && count($builder->whereIns) > 0, function ($query) use ($builder) {
-            foreach ($builder->whereIns as $key => $values) {
-                $query->whereIn($key, $values);
-            }
-        })->when(! $builder->callback && count($builder->whereNotIns) > 0, function ($query) use ($builder) {
-            foreach ($builder->whereNotIns as $key => $values) {
-                $query->whereNotIn($key, $values);
-            }
-        })->when(! is_null($builder->queryCallback), function ($query) use ($builder) {
-            call_user_func($builder->queryCallback, $query);
-        });
-    }
-
-    /**
-     * Ensure that soft delete constraints are properly applied to the query.
-     *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    protected function constrainForSoftDeletes($builder, $query)
-    {
-        $softDeleteWhere = collect($builder->wheres)->firstWhere('field', '__soft_deleted');
-
-        return match (true) {
-            $softDeleteWhere && $softDeleteWhere['value'] === 0 => $query->withoutTrashed(),
-            $softDeleteWhere && $softDeleteWhere['value'] === 1 => $query->onlyTrashed(),
-            in_array(SoftDeletes::class, class_uses_recursive(get_class($builder->model))) &&
-                config('scout.soft_delete', false) => $query->withTrashed(),
-            default => $query,
-        };
-    }
-
-    /**
      * Get the configured PostgreSQL text search language.
      *
      * @return string
@@ -508,92 +340,6 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
         }
 
         return $function;
-    }
-
-    /**
-     * Pluck and return the primary keys of the given results.
-     *
-     * @param  mixed  $results
-     * @return \Illuminate\Support\Collection
-     */
-    public function mapIds($results)
-    {
-        return count($results['results']) > 0
-            ? collect($results['results']->modelKeys())
-            : collect();
-    }
-
-    /**
-     * Map the given results to instances of the given model.
-     *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @param  mixed  $results
-     * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return \Illuminate\Database\Eloquent\Collection
-     */
-    public function map(Builder $builder, $results, $model)
-    {
-        return $results['results'];
-    }
-
-    /**
-     * Map the given results to instances of the given model via a lazy collection.
-     *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @param  mixed  $results
-     * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return \Illuminate\Support\LazyCollection
-     */
-    public function lazyMap(Builder $builder, $results, $model)
-    {
-        return new LazyCollection($results['results']->all());
-    }
-
-    /**
-     * Get the total count from a raw result returned by the engine.
-     *
-     * @param  mixed  $results
-     * @return int
-     */
-    public function getTotalCount($results)
-    {
-        return $results['total'];
-    }
-
-    /**
-     * Flush all of the model's records from the engine.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return void
-     */
-    public function flush($model)
-    {
-        //
-    }
-
-    /**
-     * Create a search index.
-     *
-     * @param  string  $name
-     * @param  array  $options
-     * @return mixed
-     *
-     * @throws \Exception
-     */
-    public function createIndex($name, array $options = [])
-    {
-        //
-    }
-
-    /**
-     * Delete a search index.
-     *
-     * @param  string  $name
-     * @return mixed
-     */
-    public function deleteIndex($name)
-    {
-        //
     }
 
     /**

--- a/src/Engines/PgsqlEngine.php
+++ b/src/Engines/PgsqlEngine.php
@@ -7,6 +7,7 @@ use Illuminate\Support\LazyCollection;
 use InvalidArgumentException;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Contracts\PaginatesEloquentModelsUsingDatabase;
+use Laravel\Scout\Pgsql\Trigram;
 
 class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
 {
@@ -23,6 +24,13 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
     ];
 
     protected const COLUMN_WEIGHTS = ['A', 'B', 'C', 'D'];
+
+    /**
+     * The PostgreSQL trigram helper instance.
+     *
+     * @var \Laravel\Scout\Pgsql\Trigram|null
+     */
+    protected $trigram;
 
     /**
      * Create a new engine instance.
@@ -61,7 +69,7 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
      * Perform the given search on the engine.
      *
      * @param  \Laravel\Scout\Builder  $builder
-     * @return mixed
+     * @return float|int|string
      */
     public function search(Builder $builder)
     {
@@ -180,7 +188,9 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
             return $query;
         }
 
-        return $query->where(function ($query) use ($builder, $columns) {
+        $usesTrigram = $this->trigram()->uses($builder);
+
+        return $query->where(function ($query) use ($builder, $columns, $usesTrigram) {
             $canSearchPrimaryKey = ctype_digit($builder->query) &&
                 in_array($builder->model->getKeyType(), ['int', 'integer']) &&
                 $builder->query <= PHP_INT_MAX &&
@@ -194,6 +204,16 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
                 sprintf('%s @@ %s(?::regconfig, ?)', $this->vectorColumn($builder), $this->queryFunction()),
                 [$this->language(), $builder->query]
             );
+
+            if ($usesTrigram) {
+                $query->orWhereRaw(
+                    sprintf('%s >= ?', $this->trigramSimilarityExpression($builder)),
+                    array_merge(
+                        $this->trigram()->similarityBindings($builder, $this->wrappedSearchableColumns($builder)),
+                        [$this->trigram()->threshold()]
+                    )
+                );
+            }
         });
     }
 
@@ -213,16 +233,44 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
         })->when(empty($builder->orders) && blank($builder->query), function ($query) use ($builder) {
             $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
         })->when(empty($builder->orders) && filled($builder->query), function ($query) use ($builder) {
+            if ($this->trigram()->uses($builder)) {
+                $query->orderByRaw(
+                    sprintf(
+                        '((%s * ?) + (%s * ?)) desc',
+                        $this->rankExpression($builder),
+                        $this->trigramSimilarityExpression($builder)
+                    ),
+                    array_merge(
+                        [$this->language(), $builder->query, $this->trigram()->scoreWeight('full_text', 1.0)],
+                        $this->trigram()->similarityBindings($builder, $this->wrappedSearchableColumns($builder)),
+                        [$this->trigram()->scoreWeight('trigram', 0.25)]
+                    )
+                );
+
+                return;
+            }
+
             $query->orderByRaw(
-                sprintf(
-                    '%s(%s, %s(?::regconfig, ?)) desc',
-                    $this->rankFunction(),
-                    $this->vectorColumn($builder),
-                    $this->queryFunction()
-                ),
+                sprintf('%s desc', $this->rankExpression($builder)),
                 [$this->language(), $builder->query]
             );
         });
+    }
+
+    /**
+     * Get the PostgreSQL rank expression for the query.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return string
+     */
+    protected function rankExpression(Builder $builder)
+    {
+        return sprintf(
+            '%s(%s, %s(?::regconfig, ?))',
+            $this->rankFunction(),
+            $this->vectorColumn($builder),
+            $this->queryFunction()
+        );
     }
 
     /**
@@ -258,6 +306,38 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
     protected function searchableColumns(Builder $builder)
     {
         return array_keys($builder->model->toSearchableArray());
+    }
+
+    /**
+     * Get the trigram similarity expression for the query.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return string
+     */
+    protected function trigramSimilarityExpression(Builder $builder)
+    {
+        return $this->trigram()->similarityExpression($this->wrappedSearchableColumns($builder));
+    }
+
+    /**
+     * Get the wrapped model searchable columns.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return array
+     */
+    protected function wrappedSearchableColumns(Builder $builder)
+    {
+        return array_map(fn ($column) => $this->searchableColumn($builder, $column), $this->searchableColumns($builder));
+    }
+
+    /**
+     * Get the PostgreSQL trigram helper instance.
+     *
+     * @return \Laravel\Scout\Pgsql\Trigram
+     */
+    protected function trigram()
+    {
+        return $this->trigram ??= new Trigram($this->config);
     }
 
     /**

--- a/src/Engines/PgsqlEngine.php
+++ b/src/Engines/PgsqlEngine.php
@@ -4,6 +4,7 @@ namespace Laravel\Scout\Engines;
 
 use InvalidArgumentException;
 use Laravel\Scout\Builder;
+use Laravel\Scout\Pgsql\Identifiers;
 use Laravel\Scout\Pgsql\Trigram;
 
 class PgsqlEngine extends DatabaseModelEngine
@@ -28,6 +29,13 @@ class PgsqlEngine extends DatabaseModelEngine
     protected $trigram;
 
     /**
+     * The PostgreSQL identifier helper instance.
+     *
+     * @var \Laravel\Scout\Pgsql\Identifiers|null
+     */
+    protected $identifiers;
+
+    /**
      * Create a new engine instance.
      *
      * @param  array  $config
@@ -36,6 +44,80 @@ class PgsqlEngine extends DatabaseModelEngine
     public function __construct(protected array $config)
     {
         //
+    }
+
+    /**
+     * Perform the given search on the engine.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return mixed
+     */
+    public function search(Builder $builder)
+    {
+        return $this->withTrigramThreshold($builder, fn () => parent::search($builder));
+    }
+
+    /**
+     * Paginate the given search on the engine.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  int  $perPage
+     * @param  string  $pageName
+     * @param  int  $page
+     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
+     */
+    public function paginateUsingDatabase(Builder $builder, $perPage, $pageName, $page)
+    {
+        return $this->withTrigramThreshold($builder, fn () => parent::paginateUsingDatabase($builder, $perPage, $pageName, $page));
+    }
+
+    /**
+     * Paginate the given query into a simple paginator.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  int  $perPage
+     * @param  string  $pageName
+     * @param  int|null  $page
+     * @return \Illuminate\Contracts\Pagination\Paginator
+     */
+    public function simplePaginateUsingDatabase(Builder $builder, $perPage, $pageName, $page)
+    {
+        return $this->withTrigramThreshold($builder, fn () => parent::simplePaginateUsingDatabase($builder, $perPage, $pageName, $page));
+    }
+
+    /**
+     * Run the callback with the configured trigram threshold, then restore it.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  callable  $callback
+     * @return mixed
+     */
+    protected function withTrigramThreshold(Builder $builder, callable $callback)
+    {
+        if (! $this->shouldApplyTrigramThreshold($builder)) {
+            return $callback();
+        }
+
+        $previousThreshold = $this->trigram()->currentThreshold($builder);
+
+        $this->trigram()->applyThreshold($builder);
+
+        try {
+            return $callback();
+        } finally {
+            $this->trigram()->restoreThreshold($builder, $previousThreshold);
+        }
+    }
+
+    /**
+     * Determine if the search needs a trigram threshold during execution.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return bool
+     */
+    protected function shouldApplyTrigramThreshold(Builder $builder)
+    {
+        return $this->trigram()->uses($builder) && ! empty($this->trigramColumns($builder));
     }
 
     /**
@@ -73,17 +155,17 @@ class PgsqlEngine extends DatabaseModelEngine
         $usesTrigram = $usesTrigram && ! empty($trigramColumns);
 
         if ($usesTrigram) {
-            $this->trigram()->applyThreshold($builder);
+            $this->trigram()->threshold();
         }
 
         return $query->where(function ($query) use ($builder, $columns, $trigramColumns, $usesTrigram) {
             $canSearchPrimaryKey = ctype_digit($builder->query) &&
-                in_array($builder->model->getKeyType(), ['int', 'integer']) &&
+                in_array($builder->model->getScoutKeyType(), ['int', 'integer']) &&
                 $builder->query <= PHP_INT_MAX &&
                 in_array($builder->model->getScoutKeyName(), $columns);
 
             if ($canSearchPrimaryKey) {
-                $query->orWhere($builder->model->getQualifiedKeyName(), $builder->query);
+                $query->orWhere($builder->model->qualifyColumn($builder->model->getScoutKeyName()), $builder->query);
             }
 
             $query->orWhereRaw(
@@ -209,7 +291,7 @@ class PgsqlEngine extends DatabaseModelEngine
         $searchableColumns = array_flip($this->searchableColumns($builder));
 
         return array_values(array_filter($columns, function ($column) use ($searchableColumns) {
-            if (! $this->isValidColumnName($column)) {
+            if (! $this->identifiers()->isColumnName($column)) {
                 throw new InvalidArgumentException(sprintf('The [pgsql] Scout driver trigram column [%s] must be a valid column name.', $column));
             }
 
@@ -228,6 +310,16 @@ class PgsqlEngine extends DatabaseModelEngine
     }
 
     /**
+     * Get the PostgreSQL identifier helper instance.
+     *
+     * @return \Laravel\Scout\Pgsql\Identifiers
+     */
+    protected function identifiers()
+    {
+        return $this->identifiers ??= new Identifiers;
+    }
+
+    /**
      * Get the configured PostgreSQL text search language.
      *
      * @return string
@@ -236,7 +328,7 @@ class PgsqlEngine extends DatabaseModelEngine
     {
         $language = $this->config['language'] ?? 'english';
 
-        if (! $this->isValidConfigurationName($language)) {
+        if (! $this->identifiers()->isConfigurationName($language)) {
             throw new InvalidArgumentException('The [pgsql] Scout driver language must be a valid PostgreSQL text search configuration name.');
         }
 
@@ -253,7 +345,7 @@ class PgsqlEngine extends DatabaseModelEngine
     {
         $column = $this->config['vector_column'] ?? 'search_vector';
 
-        if (! $this->isValidColumnName($column)) {
+        if (! $this->identifiers()->isColumnName($column)) {
             throw new InvalidArgumentException('The [pgsql] Scout driver vector column must be a valid column name.');
         }
 
@@ -271,35 +363,13 @@ class PgsqlEngine extends DatabaseModelEngine
      */
     protected function searchableColumn(Builder $builder, $column)
     {
-        if (! $this->isValidColumnName($column)) {
+        if (! $this->identifiers()->isColumnName($column)) {
             throw new InvalidArgumentException(sprintf('The [pgsql] Scout driver searchable column [%s] must be a valid column name.', $column));
         }
 
         return $builder->model->getConnection()->getQueryGrammar()->wrap(
             $builder->model->qualifyColumn($column)
         );
-    }
-
-    /**
-     * Determine if the given value is a safe PostgreSQL column name.
-     *
-     * @param  mixed  $value
-     * @return bool
-     */
-    protected function isValidColumnName($value)
-    {
-        return is_string($value) && preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $value) === 1;
-    }
-
-    /**
-     * Determine if the given value is a safe PostgreSQL configuration name.
-     *
-     * @param  mixed  $value
-     * @return bool
-     */
-    protected function isValidConfigurationName($value)
-    {
-        return is_string($value) && preg_match('/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/', $value) === 1;
     }
 
     /**

--- a/src/Engines/PgsqlEngine.php
+++ b/src/Engines/PgsqlEngine.php
@@ -69,7 +69,7 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
      * Perform the given search on the engine.
      *
      * @param  \Laravel\Scout\Builder  $builder
-     * @return float|int|string
+     * @return array
      */
     public function search(Builder $builder)
     {

--- a/src/Engines/PgsqlEngine.php
+++ b/src/Engines/PgsqlEngine.php
@@ -192,6 +192,10 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
         $trigramColumns = $usesTrigram ? $this->wrappedTrigramColumns($builder) : [];
         $usesTrigram = $usesTrigram && ! empty($trigramColumns);
 
+        if ($usesTrigram) {
+            $this->trigram()->applyThreshold($builder);
+        }
+
         return $query->where(function ($query) use ($builder, $columns, $trigramColumns, $usesTrigram) {
             $canSearchPrimaryKey = ctype_digit($builder->query) &&
                 in_array($builder->model->getKeyType(), ['int', 'integer']) &&

--- a/src/Engines/PgsqlEngine.php
+++ b/src/Engines/PgsqlEngine.php
@@ -22,6 +22,8 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
         'ts_rank_cd',
     ];
 
+    protected const COLUMN_WEIGHTS = ['A', 'B', 'C', 'D'];
+
     /**
      * Create a new engine instance.
      *
@@ -154,7 +156,7 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
     {
         $this->ensurePostgresqlConnection($builder);
 
-        $query = $this->initializeSearchQuery($builder, array_keys($builder->model->toSearchableArray()));
+        $query = $this->initializeSearchQuery($builder, $this->searchableColumns($builder));
 
         return $this->constrainForSoftDeletes(
             $builder, $this->addAdditionalConstraints($builder, $query->take($builder->limit))
@@ -224,6 +226,41 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
     }
 
     /**
+     * Get the weighted PostgreSQL search vector expression for the query.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return string
+     */
+    protected function searchVectorExpression(Builder $builder)
+    {
+        $columns = $this->searchableColumns($builder);
+
+        if (empty($columns)) {
+            return "''::tsvector";
+        }
+
+        return collect($columns)->map(function ($column) use ($builder) {
+            return sprintf(
+                "setweight(to_tsvector('%s', coalesce(cast(%s as text), '')), '%s')",
+                $this->language(),
+                $this->searchableColumn($builder, $column),
+                $this->columnWeight($builder, $column)
+            );
+        })->implode(' || ');
+    }
+
+    /**
+     * Get the model's searchable columns.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return array
+     */
+    protected function searchableColumns(Builder $builder)
+    {
+        return array_keys($builder->model->toSearchableArray());
+    }
+
+    /**
      * Add additional, developer defined constraints to the search query.
      *
      * @param  \Laravel\Scout\Builder  $builder
@@ -282,7 +319,7 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
     {
         $language = $this->config['language'] ?? 'english';
 
-        if (! is_string($language) || ! preg_match('/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/', $language)) {
+        if (! $this->isValidIdentifier($language)) {
             throw new InvalidArgumentException('The [pgsql] Scout driver language must be a valid PostgreSQL text search configuration name.');
         }
 
@@ -299,13 +336,80 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
     {
         $column = $this->config['vector_column'] ?? 'search_vector';
 
-        if (! is_string($column) || ! preg_match('/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/', $column)) {
+        if (! $this->isValidIdentifier($column)) {
             throw new InvalidArgumentException('The [pgsql] Scout driver vector column must be a valid column name.');
         }
 
         return $builder->model->getConnection()->getQueryGrammar()->wrap(
             $builder->model->qualifyColumn($column)
         );
+    }
+
+    /**
+     * Get the wrapped searchable column name.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  string  $column
+     * @return string
+     */
+    protected function searchableColumn(Builder $builder, $column)
+    {
+        if (! $this->isValidIdentifier($column)) {
+            throw new InvalidArgumentException(sprintf('The [pgsql] Scout driver searchable column [%s] must be a valid column name.', $column));
+        }
+
+        return $builder->model->getConnection()->getQueryGrammar()->wrap(
+            $builder->model->qualifyColumn($column)
+        );
+    }
+
+    /**
+     * Get the configured PostgreSQL column weight.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  string  $column
+     * @return string
+     */
+    protected function columnWeight(Builder $builder, $column)
+    {
+        $weight = $this->columnWeights()[$column] ?? self::COLUMN_WEIGHTS[3];
+
+        if (! in_array($weight, self::COLUMN_WEIGHTS, true)) {
+            throw new InvalidArgumentException(sprintf(
+                'The [pgsql] Scout driver column weight for [%s] must be one of: %s.',
+                $column,
+                implode(', ', self::COLUMN_WEIGHTS)
+            ));
+        }
+
+        return $weight;
+    }
+
+    /**
+     * Get the configured PostgreSQL column weights.
+     *
+     * @return array
+     */
+    protected function columnWeights()
+    {
+        $weights = $this->config['column_weights'] ?? [];
+
+        if (! is_array($weights)) {
+            throw new InvalidArgumentException('The [pgsql] Scout driver column weights must be an array.');
+        }
+
+        return $weights;
+    }
+
+    /**
+     * Determine if the given value is a safe PostgreSQL identifier or configuration name.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    protected function isValidIdentifier($value)
+    {
+        return is_string($value) && preg_match('/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/', $value) === 1;
     }
 
     /**
@@ -317,7 +421,7 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
     {
         $function = $this->config['query_function'] ?? self::QUERY_FUNCTIONS[0];
 
-        if (! in_array($function, self::QUERY_FUNCTIONS)) {
+        if (! in_array($function, self::QUERY_FUNCTIONS, true)) {
             throw new InvalidArgumentException(sprintf(
                 'The [pgsql] Scout driver query function must be one of: %s.',
                 implode(', ', self::QUERY_FUNCTIONS)
@@ -336,7 +440,7 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
     {
         $function = $this->config['rank_function'] ?? self::RANK_FUNCTIONS[0];
 
-        if (! in_array($function, self::RANK_FUNCTIONS)) {
+        if (! in_array($function, self::RANK_FUNCTIONS, true)) {
             throw new InvalidArgumentException(sprintf(
                 'The [pgsql] Scout driver rank function must be one of: %s.',
                 implode(', ', self::RANK_FUNCTIONS)

--- a/src/Engines/PgsqlEngine.php
+++ b/src/Engines/PgsqlEngine.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Scout\Engines;
 
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\LazyCollection;
 use InvalidArgumentException;
 use Laravel\Scout\Builder;
@@ -50,12 +51,37 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
      */
     public function search(Builder $builder)
     {
-        $this->ensurePostgresqlConnection($builder);
+        $models = $this->searchModels($builder);
 
         return [
-            'results' => $builder->model->newCollection(),
-            'total' => 0,
+            'results' => $models,
+            'total' => $models->count(),
         ];
+    }
+
+    /**
+     * Get the Eloquent models for the given builder.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  int|null  $page
+     * @param  int|null  $perPage
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    protected function searchModels(Builder $builder, $page = null, $perPage = null)
+    {
+        return $this->buildSearchQuery($builder)
+            ->when(! is_null($page) && ! is_null($perPage), function ($query) use ($page, $perPage) {
+                $query->forPage($page, $perPage);
+            })
+            ->when($builder->orders, function ($query) use ($builder) {
+                foreach ($builder->orders as $order) {
+                    $query->orderBy($order['column'], $order['direction']);
+                }
+            })
+            ->when(empty($builder->orders), function ($query) use ($builder) {
+                $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
+            })
+            ->get();
     }
 
     /**
@@ -64,7 +90,7 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
      * @param  \Laravel\Scout\Builder  $builder
      * @param  int  $perPage
      * @param  int  $page
-     * @return mixed
+     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
     public function paginate(Builder $builder, $perPage, $page)
     {
@@ -82,9 +108,16 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
      */
     public function paginateUsingDatabase(Builder $builder, $perPage, $pageName, $page)
     {
-        $this->ensurePostgresqlConnection($builder);
-
-        return $builder->model->newQuery()->whereRaw('1 = 0')->paginate($perPage, ['*'], $pageName, $page);
+        return $this->buildSearchQuery($builder)
+            ->when($builder->orders, function ($query) use ($builder) {
+                foreach ($builder->orders as $order) {
+                    $query->orderBy($order['column'], $order['direction']);
+                }
+            })
+            ->when(empty($builder->orders), function ($query) use ($builder) {
+                $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
+            })
+            ->paginate($perPage, ['*'], $pageName, $page);
     }
 
     /**
@@ -92,15 +125,145 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
      *
      * @param  \Laravel\Scout\Builder  $builder
      * @param  int  $perPage
-     * @param  string  $pageName
      * @param  int  $page
+     * @return \Illuminate\Contracts\Pagination\Paginator
+     */
+    public function simplePaginate(Builder $builder, $perPage, $page)
+    {
+        return $this->simplePaginateUsingDatabase($builder, $perPage, 'page', $page);
+    }
+
+    /**
+     * Paginate the given query into a simple paginator.
+     *
+     * @param  int  $perPage
+     * @param  string  $pageName
+     * @param  int|null  $page
      * @return \Illuminate\Contracts\Pagination\Paginator
      */
     public function simplePaginateUsingDatabase(Builder $builder, $perPage, $pageName, $page)
     {
+        return $this->buildSearchQuery($builder)
+            ->when($builder->orders, function ($query) use ($builder) {
+                foreach ($builder->orders as $order) {
+                    $query->orderBy($order['column'], $order['direction']);
+                }
+            })
+            ->when(empty($builder->orders), function ($query) use ($builder) {
+                $query->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
+            })
+            ->simplePaginate($perPage, ['*'], $pageName, $page);
+    }
+
+    /**
+     * Initialize / build the search query for the given Scout builder.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function buildSearchQuery(Builder $builder)
+    {
         $this->ensurePostgresqlConnection($builder);
 
-        return $builder->model->newQuery()->whereRaw('1 = 0')->simplePaginate($perPage, ['*'], $pageName, $page);
+        $query = $this->initializeSearchQuery($builder, array_keys($builder->model->toSearchableArray()));
+
+        return $this->constrainForSoftDeletes(
+            $builder, $this->addAdditionalConstraints($builder, $query->take($builder->limit))
+        );
+    }
+
+    /**
+     * Build the initial text search database query for all searchable columns.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function initializeSearchQuery(Builder $builder, array $columns)
+    {
+        $query = method_exists($builder->model, 'newScoutQuery')
+            ? $builder->model->newScoutQuery($builder)
+            : $builder->model->newQuery();
+
+        if (blank($builder->query)) {
+            return $query;
+        }
+
+        return $query->where(function ($query) use ($builder, $columns) {
+            $canSearchPrimaryKey = ctype_digit($builder->query) &&
+                in_array($builder->model->getKeyType(), ['int', 'integer']) &&
+                $builder->query <= PHP_INT_MAX &&
+                in_array($builder->model->getScoutKeyName(), $columns);
+
+            if ($canSearchPrimaryKey) {
+                $query->orWhere($builder->model->getQualifiedKeyName(), $builder->query);
+            }
+
+            foreach ($columns as $column) {
+                if ($canSearchPrimaryKey && $column === $builder->model->getScoutKeyName()) {
+                    continue;
+                }
+
+                $wrappedColumn = $query->getQuery()->getGrammar()->wrap(
+                    $builder->model->qualifyColumn($column)
+                );
+
+                $query->orWhereRaw(
+                    sprintf('lower(cast(%s as text)) like lower(?)', $wrappedColumn),
+                    ['%'.$builder->query.'%']
+                );
+            }
+        });
+    }
+
+    /**
+     * Add additional, developer defined constraints to the search query.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function addAdditionalConstraints(Builder $builder, $query)
+    {
+        return $query->when(! is_null($builder->callback), function ($query) use ($builder) {
+            call_user_func($builder->callback, $query, $builder, $builder->query);
+        })->when(! $builder->callback && count($builder->wheres) > 0, function ($query) use ($builder) {
+            foreach ($builder->wheres as $where) {
+                if ($where['field'] !== '__soft_deleted') {
+                    $query->where($where['field'], $where['operator'], $where['value']);
+                }
+            }
+        })->when(! $builder->callback && count($builder->whereIns) > 0, function ($query) use ($builder) {
+            foreach ($builder->whereIns as $key => $values) {
+                $query->whereIn($key, $values);
+            }
+        })->when(! $builder->callback && count($builder->whereNotIns) > 0, function ($query) use ($builder) {
+            foreach ($builder->whereNotIns as $key => $values) {
+                $query->whereNotIn($key, $values);
+            }
+        })->when(! is_null($builder->queryCallback), function ($query) use ($builder) {
+            call_user_func($builder->queryCallback, $query);
+        });
+    }
+
+    /**
+     * Ensure that soft delete constraints are properly applied to the query.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function constrainForSoftDeletes($builder, $query)
+    {
+        $softDeleteWhere = collect($builder->wheres)->firstWhere('field', '__soft_deleted');
+
+        return match (true) {
+            $softDeleteWhere && $softDeleteWhere['value'] === 0 => $query->withoutTrashed(),
+            $softDeleteWhere && $softDeleteWhere['value'] === 1 => $query->onlyTrashed(),
+            in_array(SoftDeletes::class, class_uses_recursive(get_class($builder->model))) &&
+                config('scout.soft_delete', false) => $query->withTrashed(),
+            default => $query,
+        };
     }
 
     /**
@@ -170,6 +333,8 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
      * @param  string  $name
      * @param  array  $options
      * @return mixed
+     *
+     * @throws \Exception
      */
     public function createIndex($name, array $options = [])
     {

--- a/src/Engines/PgsqlEngine.php
+++ b/src/Engines/PgsqlEngine.php
@@ -276,30 +276,6 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
     }
 
     /**
-     * Get the weighted PostgreSQL search vector expression for the query.
-     *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @return string
-     */
-    protected function searchVectorExpression(Builder $builder)
-    {
-        $columns = $this->searchableColumns($builder);
-
-        if (empty($columns)) {
-            return "''::tsvector";
-        }
-
-        return collect($columns)->map(function ($column) use ($builder) {
-            return sprintf(
-                "setweight(to_tsvector('%s', coalesce(cast(%s as text), '')), '%s')",
-                $this->language(),
-                $this->searchableColumn($builder, $column),
-                $this->columnWeight($builder, $column)
-            );
-        })->implode(' || ');
-    }
-
-    /**
      * Get the model's searchable columns.
      *
      * @param  \Laravel\Scout\Builder  $builder
@@ -319,17 +295,6 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
     protected function trigramSimilarityExpression(array $columns)
     {
         return $this->trigram()->similarityExpression($columns);
-    }
-
-    /**
-     * Get the wrapped model searchable columns.
-     *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @return array
-     */
-    protected function wrappedSearchableColumns(Builder $builder)
-    {
-        return array_map(fn ($column) => $this->searchableColumn($builder, $column), $this->searchableColumns($builder));
     }
 
     /**
@@ -360,7 +325,7 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
         $searchableColumns = array_flip($this->searchableColumns($builder));
 
         return array_values(array_filter($columns, function ($column) use ($searchableColumns) {
-            if (! $this->isValidIdentifier($column)) {
+            if (! $this->isValidColumnName($column)) {
                 throw new InvalidArgumentException(sprintf('The [pgsql] Scout driver trigram column [%s] must be a valid column name.', $column));
             }
 
@@ -437,7 +402,7 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
     {
         $language = $this->config['language'] ?? 'english';
 
-        if (! $this->isValidIdentifier($language)) {
+        if (! $this->isValidConfigurationName($language)) {
             throw new InvalidArgumentException('The [pgsql] Scout driver language must be a valid PostgreSQL text search configuration name.');
         }
 
@@ -454,7 +419,7 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
     {
         $column = $this->config['vector_column'] ?? 'search_vector';
 
-        if (! $this->isValidIdentifier($column)) {
+        if (! $this->isValidColumnName($column)) {
             throw new InvalidArgumentException('The [pgsql] Scout driver vector column must be a valid column name.');
         }
 
@@ -472,7 +437,7 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
      */
     protected function searchableColumn(Builder $builder, $column)
     {
-        if (! $this->isValidIdentifier($column)) {
+        if (! $this->isValidColumnName($column)) {
             throw new InvalidArgumentException(sprintf('The [pgsql] Scout driver searchable column [%s] must be a valid column name.', $column));
         }
 
@@ -482,50 +447,23 @@ class PgsqlEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
     }
 
     /**
-     * Get the configured PostgreSQL column weight.
-     *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @param  string  $column
-     * @return string
-     */
-    protected function columnWeight(Builder $builder, $column)
-    {
-        $weight = $this->columnWeights()[$column] ?? self::COLUMN_WEIGHTS[3];
-
-        if (! in_array($weight, self::COLUMN_WEIGHTS, true)) {
-            throw new InvalidArgumentException(sprintf(
-                'The [pgsql] Scout driver column weight for [%s] must be one of: %s.',
-                $column,
-                implode(', ', self::COLUMN_WEIGHTS)
-            ));
-        }
-
-        return $weight;
-    }
-
-    /**
-     * Get the configured PostgreSQL column weights.
-     *
-     * @return array
-     */
-    protected function columnWeights()
-    {
-        $weights = $this->config['column_weights'] ?? [];
-
-        if (! is_array($weights)) {
-            throw new InvalidArgumentException('The [pgsql] Scout driver column weights must be an array.');
-        }
-
-        return $weights;
-    }
-
-    /**
-     * Determine if the given value is a safe PostgreSQL identifier or configuration name.
+     * Determine if the given value is a safe PostgreSQL column name.
      *
      * @param  mixed  $value
      * @return bool
      */
-    protected function isValidIdentifier($value)
+    protected function isValidColumnName($value)
+    {
+        return is_string($value) && preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $value) === 1;
+    }
+
+    /**
+     * Determine if the given value is a safe PostgreSQL configuration name.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    protected function isValidConfigurationName($value)
     {
         return is_string($value) && preg_match('/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/', $value) === 1;
     }

--- a/src/Pgsql/Identifiers.php
+++ b/src/Pgsql/Identifiers.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Laravel\Scout\Pgsql;
+
+class Identifiers
+{
+    /**
+     * Determine if the given value is a safe PostgreSQL column name.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function isColumnName($value)
+    {
+        return is_string($value) && preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $value) === 1;
+    }
+
+    /**
+     * Determine if the given value is a safe PostgreSQL configuration name.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function isConfigurationName($value)
+    {
+        return is_string($value) && preg_match('/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/', $value) === 1;
+    }
+}

--- a/src/Pgsql/SearchableSchema.php
+++ b/src/Pgsql/SearchableSchema.php
@@ -5,6 +5,7 @@ namespace Laravel\Scout\Pgsql;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder as SchemaBuilder;
 use Illuminate\Database\Schema\Grammars\PostgresGrammar;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Fluent;
@@ -16,6 +17,13 @@ class SearchableSchema
      * The supported PostgreSQL text search weights.
      */
     protected const COLUMN_WEIGHTS = ['A', 'B', 'C', 'D'];
+
+    /**
+     * The PostgreSQL identifier helper instance.
+     *
+     * @var \Laravel\Scout\Pgsql\Identifiers|null
+     */
+    protected $identifiers;
 
     /**
      * Create a new searchable schema helper instance.
@@ -49,19 +57,11 @@ class SearchableSchema
             Blueprint::macro('searchable', function ($columns, array $options = []) {
                 $helper = new SearchableSchema(config('scout.pgsql', []));
 
-                $connection = null;
-
-                if (property_exists($this, 'connection')) {
-                    /** @phpstan-ignore property.protected */
-                    $connection = $this->connection;
-                }
-
-                $connection = $connection instanceof Connection ? $connection : app('db')->connection();
-
+                $connection = $helper->connection($this);
                 $helper->ensurePostgresqlConnection($connection);
 
                 $columns = Arr::wrap($columns);
-                $vectorColumn = $helper->vectorColumn($options);
+                $vectorColumn = $helper->vectorColumn();
 
                 if ($helper->shouldCreateTrigramExtension($options)) {
                     /** @phpstan-ignore method.protected */
@@ -87,18 +87,10 @@ class SearchableSchema
             Blueprint::macro('dropSearchable', function (array $options = []) {
                 $helper = new SearchableSchema(config('scout.pgsql', []));
 
-                $connection = null;
-
-                if (property_exists($this, 'connection')) {
-                    /** @phpstan-ignore property.protected */
-                    $connection = $this->connection;
-                }
-
-                $connection = $connection instanceof Connection ? $connection : app('db')->connection();
-
+                $connection = $helper->connection($this);
                 $helper->ensurePostgresqlConnection($connection);
 
-                $vectorColumn = $helper->vectorColumn($options);
+                $vectorColumn = $helper->vectorColumn();
 
                 if (array_key_exists('index', $options)) {
                     $this->dropIndex($options['index']);
@@ -135,6 +127,68 @@ class SearchableSchema
     }
 
     /**
+     * Resolve the connection that owns the given schema blueprint.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @return \Illuminate\Database\Connection
+     */
+    public function connection(Blueprint $blueprint)
+    {
+        $connection = $this->connectionFromBlueprint($blueprint) ?? $this->connectionFromSchemaBuilder();
+
+        if ($connection instanceof Connection) {
+            return $connection;
+        }
+
+        throw new InvalidArgumentException('The [pgsql] Scout schema helper may only be used with PostgreSQL connections.');
+    }
+
+    /**
+     * Resolve a connection exposed directly by the blueprint.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @return \Illuminate\Database\Connection|null
+     */
+    protected function connectionFromBlueprint(Blueprint $blueprint)
+    {
+        if (method_exists($blueprint, 'getConnection')) {
+            $connection = $blueprint->getConnection();
+
+            if ($connection instanceof Connection) {
+                return $connection;
+            }
+        }
+
+        if (! property_exists($blueprint, 'connection')) {
+            return null;
+        }
+
+        $connection = (function () {
+            return $this->connection ?? null;
+        })->call($blueprint);
+
+        return $connection instanceof Connection ? $connection : null;
+    }
+
+    /**
+     * Resolve the schema builder connection while older blueprints are constructed.
+     *
+     * @return \Illuminate\Database\Connection|null
+     */
+    protected function connectionFromSchemaBuilder()
+    {
+        foreach (debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS) as $frame) {
+            $object = $frame['object'] ?? null;
+
+            if ($object instanceof SchemaBuilder) {
+                return $object->getConnection();
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Build the generated search vector expression.
      *
      * @param  \Illuminate\Database\Connection  $connection
@@ -145,7 +199,7 @@ class SearchableSchema
     public function searchVectorExpression(Connection $connection, array $columns, array $options = [])
     {
         $grammar = $connection->getSchemaGrammar();
-        $language = $this->language($options);
+        $language = $this->language();
         $weights = $this->columnWeights($options);
         $columns = $this->searchableColumns($columns);
 
@@ -164,14 +218,13 @@ class SearchableSchema
     /**
      * Get the configured search vector column.
      *
-     * @param  array  $options
      * @return string
      */
-    public function vectorColumn(array $options = [])
+    public function vectorColumn()
     {
-        $column = $options['vector_column'] ?? $this->config['vector_column'] ?? 'search_vector';
+        $column = $this->config['vector_column'] ?? 'search_vector';
 
-        if (! $this->isValidColumnName($column)) {
+        if (! $this->identifiers()->isColumnName($column)) {
             throw new InvalidArgumentException('The [pgsql] Scout schema helper vector column must be a valid column name.');
         }
 
@@ -228,14 +281,13 @@ class SearchableSchema
     /**
      * Get the configured text search language.
      *
-     * @param  array  $options
      * @return string
      */
-    protected function language(array $options = [])
+    protected function language()
     {
-        $language = $options['language'] ?? $this->config['language'] ?? 'english';
+        $language = $this->config['language'] ?? 'english';
 
-        if (! $this->isValidConfigurationName($language)) {
+        if (! $this->identifiers()->isConfigurationName($language)) {
             throw new InvalidArgumentException('The [pgsql] Scout schema helper language must be a valid PostgreSQL text search configuration name.');
         }
 
@@ -297,7 +349,7 @@ class SearchableSchema
      */
     protected function column($column, $type)
     {
-        if (! $this->isValidColumnName($column)) {
+        if (! $this->identifiers()->isColumnName($column)) {
             throw new InvalidArgumentException(sprintf('The [pgsql] Scout schema helper %s column [%s] must be a valid column name.', $type, $column));
         }
 
@@ -305,24 +357,12 @@ class SearchableSchema
     }
 
     /**
-     * Determine if the given value is a safe PostgreSQL column name.
+     * Get the PostgreSQL identifier helper instance.
      *
-     * @param  mixed  $value
-     * @return bool
+     * @return \Laravel\Scout\Pgsql\Identifiers
      */
-    protected function isValidColumnName($value)
+    protected function identifiers()
     {
-        return is_string($value) && preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $value) === 1;
-    }
-
-    /**
-     * Determine if the given value is a safe PostgreSQL configuration name.
-     *
-     * @param  mixed  $value
-     * @return bool
-     */
-    protected function isValidConfigurationName($value)
-    {
-        return is_string($value) && preg_match('/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/', $value) === 1;
+        return $this->identifiers ??= new Identifiers;
     }
 }

--- a/src/Pgsql/SearchableSchema.php
+++ b/src/Pgsql/SearchableSchema.php
@@ -67,6 +67,27 @@ class SearchableSchema
             });
         }
 
+        if (! Blueprint::hasMacro('dropSearchable')) {
+            Blueprint::macro('dropSearchable', function (array $options = []) {
+                $helper = new SearchableSchema(config('scout.pgsql', []));
+
+                /** @phpstan-ignore property.protected */
+                $connection = $this->connection;
+
+                $helper->ensurePostgresqlConnection($connection);
+
+                $vectorColumn = $helper->vectorColumn($options);
+
+                $this->dropIndex($options['index'] ?? $helper->indexName($this->getTable(), [$vectorColumn], 'index'));
+
+                foreach ($helper->trigramColumns($options) as $column) {
+                    $this->dropIndex($helper->indexName($this->getTable(), [$column], 'trigram_index'));
+                }
+
+                $this->dropColumn($vectorColumn);
+            });
+        }
+
         if (! PostgresGrammar::hasMacro('compileScoutPgsqlExtension')) {
             PostgresGrammar::macro('compileScoutPgsqlExtension', function (Blueprint $blueprint, Fluent $command) {
                 return sprintf('create extension if not exists %s', $this->wrap($command->extension));
@@ -140,7 +161,7 @@ class SearchableSchema
      */
     public function shouldCreateTrigramExtension(array $options = [])
     {
-        return (bool) data_get($options, 'trigram.extension.create', data_get($this->config, 'trigram.extension.create', false));
+        return (bool) data_get($options, 'trigram.create_extension', data_get($this->config, 'trigram.create_extension', false));
     }
 
     /**

--- a/src/Pgsql/SearchableSchema.php
+++ b/src/Pgsql/SearchableSchema.php
@@ -39,44 +39,37 @@ class SearchableSchema
             Blueprint::macro('searchable', function ($columns, array $options = []) {
                 $helper = new SearchableSchema(config('scout.pgsql', []));
 
-                $helper->ensurePostgresqlConnection($this->connection);
+                /** @phpstan-ignore property.protected */
+                $connection = $this->connection;
+
+                $helper->ensurePostgresqlConnection($connection);
 
                 $columns = Arr::wrap($columns);
                 $vectorColumn = $helper->vectorColumn($options);
 
                 if ($helper->shouldCreateTrigramExtension($options)) {
+                    /** @phpstan-ignore method.protected */
                     $this->addCommand('scoutPgsqlExtension', ['extension' => 'pg_trgm']);
                 }
 
                 $this->tsvector($vectorColumn)->storedAs(new Expression(
-                    $helper->searchVectorExpression($this->connection, $columns, $options)
+                    $helper->searchVectorExpression($connection, $columns, $options)
                 ));
 
                 $this->index($vectorColumn, $options['index'] ?? null, 'gin');
 
                 foreach ($helper->trigramColumns($options) as $column) {
-                    $this->addCommand('scoutPgsqlTrigramIndex', [
-                        'column' => $column,
-                        'index' => $this->createIndexName('trigram_index', [$column]),
-                    ]);
+                    $this->rawIndex(
+                        sprintf('%s gin_trgm_ops', $connection->getSchemaGrammar()->wrap($column)),
+                        $helper->indexName($this->getTable(), [$column], 'trigram_index')
+                    )->algorithm('gin');
                 }
             });
         }
 
         if (! PostgresGrammar::hasMacro('compileScoutPgsqlExtension')) {
             PostgresGrammar::macro('compileScoutPgsqlExtension', function (Blueprint $blueprint, Fluent $command) {
-                return sprintf('create extension if not exists %s', $this->wrapValue($command->extension));
-            });
-        }
-
-        if (! PostgresGrammar::hasMacro('compileScoutPgsqlTrigramIndex')) {
-            PostgresGrammar::macro('compileScoutPgsqlTrigramIndex', function (Blueprint $blueprint, Fluent $command) {
-                return sprintf(
-                    'create index %s on %s using gin (%s gin_trgm_ops)',
-                    $this->wrap($command->index),
-                    $this->wrapTable($blueprint),
-                    $this->wrap($command->column)
-                );
+                return sprintf('create extension if not exists %s', $this->wrap($command->extension));
             });
         }
     }
@@ -159,6 +152,21 @@ class SearchableSchema
     public function trigramColumns(array $options = [])
     {
         return Arr::wrap(data_get($options, 'trigram.columns', []));
+    }
+
+    /**
+     * Create a conventional index name for the table.
+     *
+     * @param  string  $table
+     * @param  array  $columns
+     * @param  string  $type
+     * @return string
+     */
+    public function indexName($table, array $columns, $type)
+    {
+        $index = strtolower($table.'_'.implode('_', $columns).'_'.$type);
+
+        return str_replace(['-', '.'], '_', $index);
     }
 
     /**

--- a/src/Pgsql/SearchableSchema.php
+++ b/src/Pgsql/SearchableSchema.php
@@ -39,8 +39,14 @@ class SearchableSchema
             Blueprint::macro('searchable', function ($columns, array $options = []) {
                 $helper = new SearchableSchema(config('scout.pgsql', []));
 
-                /** @phpstan-ignore property.protected */
-                $connection = $this->connection;
+                $connection = null;
+
+                if (property_exists($this, 'connection')) {
+                    /** @phpstan-ignore property.protected */
+                    $connection = $this->connection;
+                }
+
+                $connection = $connection instanceof Connection ? $connection : app('db')->connection();
 
                 $helper->ensurePostgresqlConnection($connection);
 
@@ -71,8 +77,14 @@ class SearchableSchema
             Blueprint::macro('dropSearchable', function (array $options = []) {
                 $helper = new SearchableSchema(config('scout.pgsql', []));
 
-                /** @phpstan-ignore property.protected */
-                $connection = $this->connection;
+                $connection = null;
+
+                if (property_exists($this, 'connection')) {
+                    /** @phpstan-ignore property.protected */
+                    $connection = $this->connection;
+                }
+
+                $connection = $connection instanceof Connection ? $connection : app('db')->connection();
 
                 $helper->ensurePostgresqlConnection($connection);
 

--- a/src/Pgsql/SearchableSchema.php
+++ b/src/Pgsql/SearchableSchema.php
@@ -35,6 +35,16 @@ class SearchableSchema
      */
     public static function register()
     {
+        if (! method_exists(Blueprint::class, 'tsvector') && ! Blueprint::hasMacro('tsvector')) {
+            Blueprint::macro('tsvector', function ($column) {
+                return $this->addColumn('tsvector', $column);
+            });
+        }
+
+        if (! method_exists(PostgresGrammar::class, 'typeTsvector') && ! PostgresGrammar::hasMacro('typeTsvector')) {
+            PostgresGrammar::macro('typeTsvector', fn (Fluent $column) => 'tsvector');
+        }
+
         if (! Blueprint::hasMacro('searchable')) {
             Blueprint::macro('searchable', function ($columns, array $options = []) {
                 $helper = new SearchableSchema(config('scout.pgsql', []));

--- a/src/Pgsql/SearchableSchema.php
+++ b/src/Pgsql/SearchableSchema.php
@@ -78,7 +78,11 @@ class SearchableSchema
 
                 $vectorColumn = $helper->vectorColumn($options);
 
-                $this->dropIndex($options['index'] ?? $helper->indexName($this->getTable(), [$vectorColumn], 'index'));
+                if (array_key_exists('index', $options)) {
+                    $this->dropIndex($options['index']);
+                } else {
+                    $this->dropIndex([$vectorColumn]);
+                }
 
                 foreach ($helper->trigramColumns($options) as $column) {
                     $this->dropIndex($helper->indexName($this->getTable(), [$column], 'trigram_index'));
@@ -121,17 +125,10 @@ class SearchableSchema
         $grammar = $connection->getSchemaGrammar();
         $language = $this->language($options);
         $weights = $this->columnWeights($options);
+        $columns = $this->searchableColumns($columns);
 
         return collect($columns)->map(function ($column) use ($grammar, $language, $weights) {
             $weight = $weights[$column] ?? self::COLUMN_WEIGHTS[3];
-
-            if (! in_array($weight, self::COLUMN_WEIGHTS, true)) {
-                throw new InvalidArgumentException(sprintf(
-                    'The [pgsql] Scout schema helper column weight for [%s] must be one of: %s.',
-                    $column,
-                    implode(', ', self::COLUMN_WEIGHTS)
-                ));
-            }
 
             return sprintf(
                 "setweight(to_tsvector(%s, coalesce(cast(%s as text), '')), '%s')",
@@ -150,7 +147,13 @@ class SearchableSchema
      */
     public function vectorColumn(array $options = [])
     {
-        return $options['vector_column'] ?? $this->config['vector_column'] ?? 'search_vector';
+        $column = $options['vector_column'] ?? $this->config['vector_column'] ?? 'search_vector';
+
+        if (! $this->isValidIdentifier($column)) {
+            throw new InvalidArgumentException('The [pgsql] Scout schema helper vector column must be a valid column name.');
+        }
+
+        return $column;
     }
 
     /**
@@ -172,7 +175,10 @@ class SearchableSchema
      */
     public function trigramColumns(array $options = [])
     {
-        return Arr::wrap(data_get($options, 'trigram.columns', []));
+        return array_map(
+            fn ($column) => $this->column($column, 'trigram'),
+            Arr::wrap(data_get($options, 'trigram.columns', []))
+        );
     }
 
     /**
@@ -198,7 +204,24 @@ class SearchableSchema
      */
     protected function language(array $options = [])
     {
-        return $options['language'] ?? $this->config['language'] ?? 'english';
+        $language = $options['language'] ?? $this->config['language'] ?? 'english';
+
+        if (! $this->isValidIdentifier($language)) {
+            throw new InvalidArgumentException('The [pgsql] Scout schema helper language must be a valid PostgreSQL text search configuration name.');
+        }
+
+        return $language;
+    }
+
+    /**
+     * Get the validated searchable columns.
+     *
+     * @param  array  $columns
+     * @return array
+     */
+    protected function searchableColumns(array $columns)
+    {
+        return array_map(fn ($column) => $this->column($column, 'searchable'), $columns);
     }
 
     /**
@@ -209,6 +232,51 @@ class SearchableSchema
      */
     protected function columnWeights(array $options = [])
     {
-        return $options['weights'] ?? $options['column_weights'] ?? $this->config['column_weights'] ?? [];
+        $weights = $options['weights'] ?? $options['column_weights'] ?? $this->config['column_weights'] ?? [];
+
+        if (! is_array($weights)) {
+            throw new InvalidArgumentException('The [pgsql] Scout schema helper column weights must be an array.');
+        }
+
+        foreach ($weights as $column => $weight) {
+            $this->column($column, 'column weight');
+
+            if (! in_array($weight, self::COLUMN_WEIGHTS, true)) {
+                throw new InvalidArgumentException(sprintf(
+                    'The [pgsql] Scout schema helper column weight for [%s] must be one of: %s.',
+                    $column,
+                    implode(', ', self::COLUMN_WEIGHTS)
+                ));
+            }
+        }
+
+        return $weights;
+    }
+
+    /**
+     * Get a validated column name.
+     *
+     * @param  mixed  $column
+     * @param  string  $type
+     * @return string
+     */
+    protected function column($column, $type)
+    {
+        if (! $this->isValidIdentifier($column)) {
+            throw new InvalidArgumentException(sprintf('The [pgsql] Scout schema helper %s column [%s] must be a valid column name.', $type, $column));
+        }
+
+        return $column;
+    }
+
+    /**
+     * Determine if the given value is a safe PostgreSQL identifier or configuration name.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    protected function isValidIdentifier($value)
+    {
+        return is_string($value) && preg_match('/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/', $value) === 1;
     }
 }

--- a/src/Pgsql/SearchableSchema.php
+++ b/src/Pgsql/SearchableSchema.php
@@ -149,7 +149,7 @@ class SearchableSchema
     {
         $column = $options['vector_column'] ?? $this->config['vector_column'] ?? 'search_vector';
 
-        if (! $this->isValidIdentifier($column)) {
+        if (! $this->isValidColumnName($column)) {
             throw new InvalidArgumentException('The [pgsql] Scout schema helper vector column must be a valid column name.');
         }
 
@@ -177,7 +177,7 @@ class SearchableSchema
     {
         return array_map(
             fn ($column) => $this->column($column, 'trigram'),
-            Arr::wrap(data_get($options, 'trigram.columns', []))
+            Arr::wrap(data_get($options, 'trigram.columns', data_get($this->config, 'trigram.columns', [])))
         );
     }
 
@@ -213,7 +213,7 @@ class SearchableSchema
     {
         $language = $options['language'] ?? $this->config['language'] ?? 'english';
 
-        if (! $this->isValidIdentifier($language)) {
+        if (! $this->isValidConfigurationName($language)) {
             throw new InvalidArgumentException('The [pgsql] Scout schema helper language must be a valid PostgreSQL text search configuration name.');
         }
 
@@ -275,7 +275,7 @@ class SearchableSchema
      */
     protected function column($column, $type)
     {
-        if (! $this->isValidIdentifier($column)) {
+        if (! $this->isValidColumnName($column)) {
             throw new InvalidArgumentException(sprintf('The [pgsql] Scout schema helper %s column [%s] must be a valid column name.', $type, $column));
         }
 
@@ -283,12 +283,23 @@ class SearchableSchema
     }
 
     /**
-     * Determine if the given value is a safe PostgreSQL identifier or configuration name.
+     * Determine if the given value is a safe PostgreSQL column name.
      *
      * @param  mixed  $value
      * @return bool
      */
-    protected function isValidIdentifier($value)
+    protected function isValidColumnName($value)
+    {
+        return is_string($value) && preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $value) === 1;
+    }
+
+    /**
+     * Determine if the given value is a safe PostgreSQL configuration name.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    protected function isValidConfigurationName($value)
     {
         return is_string($value) && preg_match('/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/', $value) === 1;
     }

--- a/src/Pgsql/SearchableSchema.php
+++ b/src/Pgsql/SearchableSchema.php
@@ -61,7 +61,7 @@ class SearchableSchema
                 foreach ($helper->trigramColumns($options) as $column) {
                     $this->rawIndex(
                         sprintf('%s gin_trgm_ops', $connection->getSchemaGrammar()->wrap($column)),
-                        $helper->indexName($this->getTable(), [$column], 'trigram_index')
+                        $helper->indexName($connection, $this->getTable(), [$column], 'trigram_index')
                     )->algorithm('gin');
                 }
             });
@@ -85,7 +85,7 @@ class SearchableSchema
                 }
 
                 foreach ($helper->trigramColumns($options) as $column) {
-                    $this->dropIndex($helper->indexName($this->getTable(), [$column], 'trigram_index'));
+                    $this->dropIndex($helper->indexName($connection, $this->getTable(), [$column], 'trigram_index'));
                 }
 
                 $this->dropColumn($vectorColumn);
@@ -184,13 +184,20 @@ class SearchableSchema
     /**
      * Create a conventional index name for the table.
      *
+     * @param  \Illuminate\Database\Connection  $connection
      * @param  string  $table
      * @param  array  $columns
      * @param  string  $type
      * @return string
      */
-    public function indexName($table, array $columns, $type)
+    public function indexName(Connection $connection, $table, array $columns, $type)
     {
+        if ($connection->getConfig('prefix_indexes')) {
+            $table = str_contains($table, '.')
+                ? substr_replace($table, '.'.$connection->getTablePrefix(), strrpos($table, '.'), 1)
+                : $connection->getTablePrefix().$table;
+        }
+
         $index = strtolower($table.'_'.implode('_', $columns).'_'.$type);
 
         return str_replace(['-', '.'], '_', $index);
@@ -221,7 +228,13 @@ class SearchableSchema
      */
     protected function searchableColumns(array $columns)
     {
-        return array_map(fn ($column) => $this->column($column, 'searchable'), $columns);
+        $columns = array_map(fn ($column) => $this->column($column, 'searchable'), $columns);
+
+        if (empty($columns)) {
+            throw new InvalidArgumentException('The [pgsql] Scout schema helper searchable columns must not be empty.');
+        }
+
+        return $columns;
     }
 
     /**

--- a/src/Pgsql/SearchableSchema.php
+++ b/src/Pgsql/SearchableSchema.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Laravel\Scout\Pgsql;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Grammars\PostgresGrammar;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Fluent;
+use InvalidArgumentException;
+
+class SearchableSchema
+{
+    /**
+     * The supported PostgreSQL text search weights.
+     */
+    protected const COLUMN_WEIGHTS = ['A', 'B', 'C', 'D'];
+
+    /**
+     * Create a new searchable schema helper instance.
+     *
+     * @param  array  $config
+     * @return void
+     */
+    public function __construct(protected array $config)
+    {
+        //
+    }
+
+    /**
+     * Register the PostgreSQL searchable schema macros.
+     *
+     * @return void
+     */
+    public static function register()
+    {
+        if (! Blueprint::hasMacro('searchable')) {
+            Blueprint::macro('searchable', function ($columns, array $options = []) {
+                $helper = new SearchableSchema(config('scout.pgsql', []));
+
+                $helper->ensurePostgresqlConnection($this->connection);
+
+                $columns = Arr::wrap($columns);
+                $vectorColumn = $helper->vectorColumn($options);
+
+                if ($helper->shouldCreateTrigramExtension($options)) {
+                    $this->addCommand('scoutPgsqlExtension', ['extension' => 'pg_trgm']);
+                }
+
+                $this->tsvector($vectorColumn)->storedAs(new Expression(
+                    $helper->searchVectorExpression($this->connection, $columns, $options)
+                ));
+
+                $this->index($vectorColumn, $options['index'] ?? null, 'gin');
+
+                foreach ($helper->trigramColumns($options) as $column) {
+                    $this->addCommand('scoutPgsqlTrigramIndex', [
+                        'column' => $column,
+                        'index' => $this->createIndexName('trigram_index', [$column]),
+                    ]);
+                }
+            });
+        }
+
+        if (! PostgresGrammar::hasMacro('compileScoutPgsqlExtension')) {
+            PostgresGrammar::macro('compileScoutPgsqlExtension', function (Blueprint $blueprint, Fluent $command) {
+                return sprintf('create extension if not exists %s', $this->wrapValue($command->extension));
+            });
+        }
+
+        if (! PostgresGrammar::hasMacro('compileScoutPgsqlTrigramIndex')) {
+            PostgresGrammar::macro('compileScoutPgsqlTrigramIndex', function (Blueprint $blueprint, Fluent $command) {
+                return sprintf(
+                    'create index %s on %s using gin (%s gin_trgm_ops)',
+                    $this->wrap($command->index),
+                    $this->wrapTable($blueprint),
+                    $this->wrap($command->column)
+                );
+            });
+        }
+    }
+
+    /**
+     * Ensure that the helper is running on a PostgreSQL connection.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return void
+     */
+    public function ensurePostgresqlConnection(Connection $connection)
+    {
+        if ($connection->getDriverName() !== 'pgsql') {
+            throw new InvalidArgumentException('The [pgsql] Scout schema helper may only be used with PostgreSQL connections.');
+        }
+    }
+
+    /**
+     * Build the generated search vector expression.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @param  array  $columns
+     * @param  array  $options
+     * @return string
+     */
+    public function searchVectorExpression(Connection $connection, array $columns, array $options = [])
+    {
+        $grammar = $connection->getSchemaGrammar();
+        $language = $this->language($options);
+        $weights = $this->columnWeights($options);
+
+        return collect($columns)->map(function ($column) use ($grammar, $language, $weights) {
+            $weight = $weights[$column] ?? self::COLUMN_WEIGHTS[3];
+
+            if (! in_array($weight, self::COLUMN_WEIGHTS, true)) {
+                throw new InvalidArgumentException(sprintf(
+                    'The [pgsql] Scout schema helper column weight for [%s] must be one of: %s.',
+                    $column,
+                    implode(', ', self::COLUMN_WEIGHTS)
+                ));
+            }
+
+            return sprintf(
+                "setweight(to_tsvector(%s, coalesce(cast(%s as text), '')), '%s')",
+                $grammar->quoteString($language),
+                $grammar->wrap($column),
+                $weight
+            );
+        })->implode(' || ');
+    }
+
+    /**
+     * Get the configured search vector column.
+     *
+     * @param  array  $options
+     * @return string
+     */
+    public function vectorColumn(array $options = [])
+    {
+        return $options['vector_column'] ?? $this->config['vector_column'] ?? 'search_vector';
+    }
+
+    /**
+     * Determine if the pg_trgm extension should be created.
+     *
+     * @param  array  $options
+     * @return bool
+     */
+    public function shouldCreateTrigramExtension(array $options = [])
+    {
+        return (bool) data_get($options, 'trigram.extension.create', data_get($this->config, 'trigram.extension.create', false));
+    }
+
+    /**
+     * Get the configured trigram index columns.
+     *
+     * @param  array  $options
+     * @return array
+     */
+    public function trigramColumns(array $options = [])
+    {
+        return Arr::wrap(data_get($options, 'trigram.columns', []));
+    }
+
+    /**
+     * Get the configured text search language.
+     *
+     * @param  array  $options
+     * @return string
+     */
+    protected function language(array $options = [])
+    {
+        return $options['language'] ?? $this->config['language'] ?? 'english';
+    }
+
+    /**
+     * Get the configured column weights.
+     *
+     * @param  array  $options
+     * @return array
+     */
+    protected function columnWeights(array $options = [])
+    {
+        return $options['weights'] ?? $options['column_weights'] ?? $this->config['column_weights'] ?? [];
+    }
+}

--- a/src/Pgsql/Trigram.php
+++ b/src/Pgsql/Trigram.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Laravel\Scout\Pgsql;
+
+use Laravel\Scout\Builder;
+use Throwable;
+
+class Trigram
+{
+    /**
+     * The cached pg_trgm availability results.
+     *
+     * @var array
+     */
+    protected array $availability = [];
+
+    /**
+     * Create a new trigram helper instance.
+     *
+     * @param  array  $config
+     * @return void
+     */
+    public function __construct(protected array $config)
+    {
+        //
+    }
+
+    /**
+     * Determine if trigram search should be used for the query.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return bool
+     */
+    public function uses(Builder $builder)
+    {
+        return filled($builder->query) &&
+            (bool) ($this->config['trigram']['enabled'] ?? false) &&
+            $this->available($builder);
+    }
+
+    /**
+     * Determine if the pg_trgm extension is available.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return bool
+     */
+    public function available(Builder $builder)
+    {
+        $connection = $builder->model->getConnection();
+
+        $key = spl_object_id($connection);
+
+        if (array_key_exists($key, $this->availability)) {
+            return $this->availability[$key];
+        }
+
+        try {
+            $result = $connection->selectOne(
+                "select exists (select 1 from pg_extension where extname = 'pg_trgm') as available"
+            );
+        } catch (Throwable) {
+            return $this->availability[$key] = false;
+        }
+
+        return $this->availability[$key] = (bool) ($result->available ?? false);
+    }
+
+    /**
+     * Get the trigram similarity expression for the query.
+     *
+     * @param  array  $columns
+     * @return string
+     */
+    public function similarityExpression(array $columns)
+    {
+        if (empty($columns)) {
+            return '0';
+        }
+
+        return sprintf('greatest(%s)', collect($columns)->map(function ($column) {
+            return sprintf("similarity(coalesce(cast(%s as text), ''), ?)", $column);
+        })->implode(', '));
+    }
+
+    /**
+     * Get the trigram similarity bindings for the query.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  array  $columns
+     * @return array
+     */
+    public function similarityBindings(Builder $builder, array $columns)
+    {
+        return array_fill(0, count($columns), $builder->query);
+    }
+
+    /**
+     * Get the configured trigram threshold.
+     *
+     * @return float|int|string
+     */
+    public function threshold()
+    {
+        return $this->config['trigram']['threshold'] ?? 0.3;
+    }
+
+    /**
+     * Get the configured score weight.
+     *
+     * @param  string  $key
+     * @param  float|int  $default
+     * @return float|int|string
+     */
+    public function scoreWeight($key, $default)
+    {
+        return $this->config['weights'][$key] ?? $default;
+    }
+}

--- a/src/Pgsql/Trigram.php
+++ b/src/Pgsql/Trigram.php
@@ -83,6 +83,34 @@ class Trigram
     }
 
     /**
+     * Get the indexable trigram predicate for the query.
+     *
+     * @param  array  $columns
+     * @return string
+     */
+    public function predicateExpression(array $columns)
+    {
+        return empty($columns) ? 'false' : sprintf(
+            '(set_config(\'pg_trgm.similarity_threshold\', ?::text, true) is not null and (%s))',
+            collect($columns)->map(fn ($column) => sprintf('%s %% ?', $column))->implode(' or ')
+        );
+    }
+
+    /**
+     * Get the indexable trigram predicate bindings for the query.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  array  $columns
+     * @return array
+     */
+    public function predicateBindings(Builder $builder, array $columns)
+    {
+        return empty($columns)
+            ? []
+            : array_merge([$this->threshold()], array_fill(0, count($columns), $builder->query));
+    }
+
+    /**
      * Get the trigram similarity bindings for the query.
      *
      * @param  \Laravel\Scout\Builder  $builder

--- a/src/Pgsql/Trigram.php
+++ b/src/Pgsql/Trigram.php
@@ -132,8 +132,8 @@ class Trigram
     {
         $threshold = $this->config['trigram']['threshold'] ?? 0.3;
 
-        if (! is_numeric($threshold)) {
-            throw new InvalidArgumentException('The [pgsql] Scout driver trigram threshold must be numeric.');
+        if (! is_numeric($threshold) || $threshold < 0 || $threshold > 1) {
+            throw new InvalidArgumentException('The [pgsql] Scout driver trigram threshold must be numeric and between 0 and 1.');
         }
 
         return $threshold;

--- a/src/Pgsql/Trigram.php
+++ b/src/Pgsql/Trigram.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Scout\Pgsql;
 
+use InvalidArgumentException;
 use Laravel\Scout\Builder;
 use Throwable;
 
@@ -129,7 +130,13 @@ class Trigram
      */
     public function threshold()
     {
-        return $this->config['trigram']['threshold'] ?? 0.3;
+        $threshold = $this->config['trigram']['threshold'] ?? 0.3;
+
+        if (! is_numeric($threshold)) {
+            throw new InvalidArgumentException('The [pgsql] Scout driver trigram threshold must be numeric.');
+        }
+
+        return $threshold;
     }
 
     /**
@@ -141,6 +148,12 @@ class Trigram
      */
     public function scoreWeight($key, $default)
     {
-        return $this->config['weights'][$key] ?? $default;
+        $weight = $this->config['weights'][$key] ?? $default;
+
+        if (! is_numeric($weight)) {
+            throw new InvalidArgumentException(sprintf('The [pgsql] Scout driver score weight [%s] must be numeric.', $key));
+        }
+
+        return $weight;
     }
 }

--- a/src/Pgsql/Trigram.php
+++ b/src/Pgsql/Trigram.php
@@ -3,11 +3,17 @@
 namespace Laravel\Scout\Pgsql;
 
 use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\Log;
 use InvalidArgumentException;
 use Laravel\Scout\Builder;
 
 class Trigram
 {
+    /**
+     * The warning emitted when pg_trgm is unavailable.
+     */
+    protected const MISSING_EXTENSION_WARNING = 'Scout [pgsql] trigram search is enabled, but the [pg_trgm] extension is not available. Falling back to PostgreSQL full-text search.';
+
     /**
      * The cached pg_trgm availability results.
      *
@@ -60,10 +66,33 @@ class Trigram
                 "select exists (select 1 from pg_extension where extname = 'pg_trgm') as available"
             );
         } catch (QueryException) {
+            Log::warning(self::MISSING_EXTENSION_WARNING);
+
             return $this->availability[$key] = false;
         }
 
-        return $this->availability[$key] = (bool) ($result->available ?? false);
+        $available = (bool) ($result->available ?? false);
+
+        if (! $available) {
+            Log::warning(self::MISSING_EXTENSION_WARNING);
+        }
+
+        return $this->availability[$key] = $available;
+    }
+
+    /**
+     * Get the current trigram threshold for the connection.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return string|null
+     */
+    public function currentThreshold(Builder $builder)
+    {
+        $result = $builder->model->getConnection()->selectOne(
+            "select current_setting('pg_trgm.similarity_threshold', true) as threshold"
+        );
+
+        return $result->threshold ?? null;
     }
 
     /**
@@ -77,6 +106,25 @@ class Trigram
         $builder->model->getConnection()->select(
             "select set_config('pg_trgm.similarity_threshold', ?::text, false)",
             [$this->threshold()]
+        );
+    }
+
+    /**
+     * Restore the previous trigram threshold for the connection.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  string|null  $threshold
+     * @return void
+     */
+    public function restoreThreshold(Builder $builder, $threshold)
+    {
+        if (is_null($threshold)) {
+            return;
+        }
+
+        $builder->model->getConnection()->select(
+            "select set_config('pg_trgm.similarity_threshold', ?::text, false)",
+            [$threshold]
         );
     }
 

--- a/src/Pgsql/Trigram.php
+++ b/src/Pgsql/Trigram.php
@@ -2,9 +2,9 @@
 
 namespace Laravel\Scout\Pgsql;
 
+use Illuminate\Database\QueryException;
 use InvalidArgumentException;
 use Laravel\Scout\Builder;
-use Throwable;
 
 class Trigram
 {
@@ -59,11 +59,25 @@ class Trigram
             $result = $connection->selectOne(
                 "select exists (select 1 from pg_extension where extname = 'pg_trgm') as available"
             );
-        } catch (Throwable) {
+        } catch (QueryException) {
             return $this->availability[$key] = false;
         }
 
         return $this->availability[$key] = (bool) ($result->available ?? false);
+    }
+
+    /**
+     * Apply the configured trigram threshold for the connection.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return void
+     */
+    public function applyThreshold(Builder $builder)
+    {
+        $builder->model->getConnection()->select(
+            "select set_config('pg_trgm.similarity_threshold', ?::text, false)",
+            [$this->threshold()]
+        );
     }
 
     /**
@@ -92,7 +106,7 @@ class Trigram
     public function predicateExpression(array $columns)
     {
         return empty($columns) ? 'false' : sprintf(
-            '(set_config(\'pg_trgm.similarity_threshold\', ?::text, true) is not null and (%s))',
+            '(%s)',
             collect($columns)->map(fn ($column) => sprintf('%s %% ?', $column))->implode(' or ')
         );
     }
@@ -106,9 +120,7 @@ class Trigram
      */
     public function predicateBindings(Builder $builder, array $columns)
     {
-        return empty($columns)
-            ? []
-            : array_merge([$this->threshold()], array_fill(0, count($columns), $builder->query));
+        return array_fill(0, count($columns), $builder->query);
     }
 
     /**

--- a/src/ScoutServiceProvider.php
+++ b/src/ScoutServiceProvider.php
@@ -48,9 +48,7 @@ class ScoutServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        if ($this->app['config']->get('scout.driver') === 'pgsql') {
-            SearchableSchema::register();
-        }
+        SearchableSchema::register();
 
         if ($this->app->runningInConsole()) {
             $this->commands([

--- a/src/ScoutServiceProvider.php
+++ b/src/ScoutServiceProvider.php
@@ -10,6 +10,7 @@ use Laravel\Scout\Console\ImportCommand;
 use Laravel\Scout\Console\IndexCommand;
 use Laravel\Scout\Console\QueueImportCommand;
 use Laravel\Scout\Console\SyncIndexSettingsCommand;
+use Laravel\Scout\Pgsql\SearchableSchema;
 use Meilisearch\Client as Meilisearch;
 
 class ScoutServiceProvider extends ServiceProvider
@@ -47,6 +48,10 @@ class ScoutServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        if ($this->app['config']->get('scout.driver') === 'pgsql') {
+            SearchableSchema::register();
+        }
+
         if ($this->app->runningInConsole()) {
             $this->commands([
                 QueueImportCommand::class,

--- a/tests/Feature/Commands/ImportCommandTest.php
+++ b/tests/Feature/Commands/ImportCommandTest.php
@@ -106,8 +106,12 @@ class ImportCommandTest extends TestCase
         $schema = Mockery::mock(Builder::class);
         $schema->shouldReceive('getColumnListing')->once()->with('users')->andReturn(['id', 'name', 'email', 'age', 'search_vector']);
         $schema->shouldReceive('hasColumn')->once()->with('users', 'search_vector')->andReturn(true);
-        $schema->shouldReceive('hasIndex')->once()->with('users', ['search_vector'], 'gin')->andReturn(false);
-        $schema->shouldReceive('hasIndex')->once()->with('users', 'users_name_trigram_index', 'gin')->andReturn(false);
+
+        if (method_exists(Builder::class, 'hasIndex')) {
+            $schema->shouldReceive('hasIndex')->once()->with('users', ['search_vector'], 'gin')->andReturn(false);
+            $schema->shouldReceive('hasIndex')->once()->with('users', 'users_name_trigram_index', 'gin')->andReturn(false);
+        }
+
         $schema->shouldReceive('table')->once()->with('users', Mockery::on(function ($callback) {
             $table = Mockery::mock();
             $index = Mockery::mock();

--- a/tests/Feature/Commands/ImportCommandTest.php
+++ b/tests/Feature/Commands/ImportCommandTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Scout\Tests\Feature\Commands;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Builder;
 use Illuminate\Database\SQLiteConnection;
 use Laravel\Scout\Scout;
 use Laravel\Scout\Searchable;
@@ -24,20 +25,60 @@ class ImportCommandTest extends TestCase
         ]);
 
         $app->make('db')->extend('testing-pgsql-schema', function ($config) {
-            return new ImportCommandPgsqlTestingConnection(new PDO('sqlite::memory:'), $config['database'], $config['prefix'], $config);
+            $connection = new ImportCommandPgsqlTestingConnection(new PDO('sqlite::memory:'), $config['database'], $config['prefix'], $config);
+            $connection->useDefaultSchemaGrammar();
+
+            return $connection;
         });
     }
 
-    public function test_it_can_prepare_pgsql_search_schema_before_importing()
+    public function test_pgsql_import_warns_that_search_schema_must_be_created_with_migrations()
     {
         config(['scout.driver' => 'pgsql']);
 
-        $schema = Mockery::mock();
+        $class = ImportCommandPgsqlSearchableUser::class;
+
+        $this->artisan('scout:import', [
+            'model' => $class,
+        ])
+            ->expectsOutput('Using the [pgsql] Scout engine does not create PostgreSQL search columns or indexes.')
+            ->expectsOutput('Add the PostgreSQL search vector and any trigram indexes through a migration before importing.')
+            ->expectsOutput("All [{$class}] records have been imported.")
+            ->assertSuccessful();
+    }
+
+    public function test_model_specific_pgsql_engine_imports_without_schema_mutation()
+    {
+        config(['scout.driver' => 'collection']);
+
+        $class = ImportCommandModelSpecificPgsqlSearchableUser::class;
+
+        $this->artisan('scout:import', [
+            'model' => $class,
+        ])
+            ->expectsOutput('Using the [pgsql] Scout engine does not create PostgreSQL search columns or indexes.')
+            ->expectsOutput('Add the PostgreSQL search vector and any trigram indexes through a migration before importing.')
+            ->expectsOutput("All [{$class}] records have been imported.")
+            ->assertSuccessful();
+    }
+
+    public function test_prepare_pgsql_option_creates_search_schema_from_database_columns()
+    {
+        config(['scout.driver' => 'pgsql']);
+
+        $class = ImportCommandPgsqlSearchableUser::class;
+
+        $schema = Mockery::mock(Builder::class);
+        $schema->shouldReceive('getColumnListing')->once()->with('users')->andReturn(['id', 'name', 'email', 'age']);
         $schema->shouldReceive('hasColumn')->once()->with('users', 'search_vector')->andReturn(false);
         $schema->shouldReceive('table')->once()->with('users', Mockery::on(function ($callback) {
             $table = Mockery::mock();
 
-            $table->shouldReceive('searchable')->once()->with(['id', 'name', 'email', 'age']);
+            $table->shouldReceive('searchable')->once()->with(['id', 'name', 'email', 'age'], [
+                'trigram' => [
+                    'columns' => [],
+                ],
+            ]);
 
             $callback($table);
 
@@ -47,49 +88,47 @@ class ImportCommandTest extends TestCase
         $this->useSchemaBuilder($schema);
 
         $this->artisan('scout:import', [
-            'model' => ImportCommandPgsqlSearchableUser::class,
+            'model' => $class,
             '--prepare-pgsql' => true,
         ])
-            ->expectsOutput('Prepared PostgreSQL search columns and indexes for ['.ImportCommandPgsqlSearchableUser::class.'].')
-            ->expectsOutput('All ['.ImportCommandPgsqlSearchableUser::class.'] records have been imported.')
+            ->expectsOutput("Prepared PostgreSQL search columns and indexes for [{$class}].")
+            ->expectsOutput("All [{$class}] records have been imported.")
             ->assertSuccessful();
     }
 
-    public function test_it_skips_pgsql_preparation_when_search_vector_already_exists()
+    public function test_prepare_pgsql_option_creates_missing_indexes_when_vector_column_exists()
     {
         config(['scout.driver' => 'pgsql']);
+        config(['scout.pgsql.trigram.columns' => ['name']]);
 
-        $schema = Mockery::mock();
+        $class = ImportCommandPgsqlSearchableUser::class;
+
+        $schema = Mockery::mock(Builder::class);
+        $schema->shouldReceive('getColumnListing')->once()->with('users')->andReturn(['id', 'name', 'email', 'age', 'search_vector']);
         $schema->shouldReceive('hasColumn')->once()->with('users', 'search_vector')->andReturn(true);
-        $schema->shouldNotReceive('table');
+        $schema->shouldReceive('hasIndex')->once()->with('users', ['search_vector'], 'gin')->andReturn(false);
+        $schema->shouldReceive('hasIndex')->once()->with('users', 'users_name_trigram_index', 'gin')->andReturn(false);
+        $schema->shouldReceive('table')->once()->with('users', Mockery::on(function ($callback) {
+            $table = Mockery::mock();
+            $index = Mockery::mock();
+
+            $table->shouldReceive('index')->once()->with('search_vector', null, 'gin');
+            $table->shouldReceive('rawIndex')->once()->with('"name" gin_trgm_ops', 'users_name_trigram_index')->andReturn($index);
+            $index->shouldReceive('algorithm')->once()->with('gin');
+
+            $callback($table);
+
+            return true;
+        }));
 
         $this->useSchemaBuilder($schema);
 
         $this->artisan('scout:import', [
-            'model' => ImportCommandPgsqlSearchableUser::class,
+            'model' => $class,
             '--prepare-pgsql' => true,
         ])
-            ->expectsOutput('PostgreSQL search column [search_vector] already exists for ['.ImportCommandPgsqlSearchableUser::class.']; skipping preparation.')
-            ->expectsOutput('All ['.ImportCommandPgsqlSearchableUser::class.'] records have been imported.')
-            ->assertSuccessful();
-    }
-
-    public function test_prepare_pgsql_option_warns_when_driver_is_not_pgsql()
-    {
-        config(['scout.driver' => 'database']);
-
-        $schema = Mockery::mock();
-        $schema->shouldNotReceive('hasColumn');
-        $schema->shouldNotReceive('table');
-
-        $this->useSchemaBuilder($schema);
-
-        $this->artisan('scout:import', [
-            'model' => ImportCommandPgsqlSearchableUser::class,
-            '--prepare-pgsql' => true,
-        ])
-            ->expectsOutput('The [--prepare-pgsql] option only applies to models using the [pgsql] Scout engine.')
-            ->expectsOutput('All ['.ImportCommandPgsqlSearchableUser::class.'] records have been imported.')
+            ->expectsOutput("Prepared PostgreSQL search indexes for [{$class}].")
+            ->expectsOutput("All [{$class}] records have been imported.")
             ->assertSuccessful();
     }
 
@@ -97,45 +136,57 @@ class ImportCommandTest extends TestCase
     {
         config(['scout.driver' => 'collection']);
 
-        $schema = Mockery::mock();
+        $class = ImportCommandModelSpecificPgsqlSearchableUser::class;
+
+        $schema = Mockery::mock(Builder::class);
+        $schema->shouldReceive('getColumnListing')->once()->with('users')->andReturn(['id', 'name', 'email', 'age']);
         $schema->shouldReceive('hasColumn')->once()->with('users', 'search_vector')->andReturn(false);
-        $schema->shouldReceive('table')->once()->with('users', Mockery::on(function ($callback) {
-            $table = Mockery::mock();
-
-            $table->shouldReceive('searchable')->once()->with(['id', 'name', 'email', 'age']);
-
-            $callback($table);
-
-            return true;
-        }));
+        $schema->shouldReceive('table')->once()->with('users', Mockery::type('callable'));
 
         $this->useSchemaBuilder($schema);
 
         $this->artisan('scout:import', [
-            'model' => ImportCommandModelSpecificPgsqlSearchableUser::class,
+            'model' => $class,
             '--prepare-pgsql' => true,
         ])
-            ->expectsOutput('Prepared PostgreSQL search columns and indexes for ['.ImportCommandModelSpecificPgsqlSearchableUser::class.'].')
-            ->expectsOutput('All ['.ImportCommandModelSpecificPgsqlSearchableUser::class.'] records have been imported.')
+            ->expectsOutput("Prepared PostgreSQL search columns and indexes for [{$class}].")
+            ->expectsOutput("All [{$class}] records have been imported.")
             ->assertSuccessful();
     }
 
-    public function test_prepare_pgsql_option_skips_model_specific_non_pgsql_engine()
+    public function test_prepare_pgsql_option_warns_when_driver_is_not_pgsql()
     {
-        config(['scout.driver' => 'pgsql']);
+        config(['scout.driver' => 'database']);
 
-        $schema = Mockery::mock();
-        $schema->shouldNotReceive('hasColumn');
+        $class = ImportCommandPgsqlSearchableUser::class;
+
+        $schema = Mockery::mock(Builder::class);
+        $schema->shouldNotReceive('getColumnListing');
         $schema->shouldNotReceive('table');
 
         $this->useSchemaBuilder($schema);
 
         $this->artisan('scout:import', [
-            'model' => ImportCommandModelSpecificCollectionSearchableUser::class,
+            'model' => $class,
             '--prepare-pgsql' => true,
         ])
             ->expectsOutput('The [--prepare-pgsql] option only applies to models using the [pgsql] Scout engine.')
-            ->expectsOutput('All ['.ImportCommandModelSpecificCollectionSearchableUser::class.'] records have been imported.')
+            ->expectsOutput("All [{$class}] records have been imported.")
+            ->assertSuccessful();
+    }
+
+    public function test_model_specific_non_pgsql_engine_imports_without_pgsql_warning()
+    {
+        config(['scout.driver' => 'pgsql']);
+
+        $class = ImportCommandModelSpecificCollectionSearchableUser::class;
+
+        $this->artisan('scout:import', [
+            'model' => $class,
+        ])
+            ->doesntExpectOutput('Using the [pgsql] Scout engine does not create PostgreSQL search columns or indexes.')
+            ->doesntExpectOutput('Add the PostgreSQL search vector and any trigram indexes through a migration before importing.')
+            ->expectsOutput("All [{$class}] records have been imported.")
             ->assertSuccessful();
     }
 
@@ -160,6 +211,7 @@ class ImportCommandPgsqlSearchableUser extends Model
             'name' => null,
             'email' => null,
             'age' => null,
+            'profile' => null,
         ];
     }
 

--- a/tests/Feature/Commands/ImportCommandTest.php
+++ b/tests/Feature/Commands/ImportCommandTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Laravel\Scout\Tests\Feature\Commands;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\SQLiteConnection;
+use Laravel\Scout\Scout;
+use Laravel\Scout\Searchable;
+use Mockery;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+use PDO;
+
+class ImportCommandTest extends TestCase
+{
+    use WithWorkbench;
+
+    protected function defineEnvironment($app)
+    {
+        $app->make('config')->set('database.connections.pgsql_schema', [
+            'driver' => 'testing-pgsql-schema',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        $app->make('db')->extend('testing-pgsql-schema', function ($config) {
+            return new ImportCommandPgsqlTestingConnection(new PDO('sqlite::memory:'), $config['database'], $config['prefix'], $config);
+        });
+    }
+
+    public function test_it_can_prepare_pgsql_search_schema_before_importing()
+    {
+        config(['scout.driver' => 'pgsql']);
+
+        $schema = Mockery::mock();
+        $schema->shouldReceive('hasColumn')->once()->with('users', 'search_vector')->andReturn(false);
+        $schema->shouldReceive('table')->once()->with('users', Mockery::on(function ($callback) {
+            $table = Mockery::mock();
+
+            $table->shouldReceive('searchable')->once()->with(['id', 'name', 'email', 'age']);
+
+            $callback($table);
+
+            return true;
+        }));
+
+        $this->useSchemaBuilder($schema);
+
+        $this->artisan('scout:import', [
+            'model' => ImportCommandPgsqlSearchableUser::class,
+            '--prepare-pgsql' => true,
+        ])
+            ->expectsOutput('Prepared PostgreSQL search columns and indexes for ['.ImportCommandPgsqlSearchableUser::class.'].')
+            ->expectsOutput('All ['.ImportCommandPgsqlSearchableUser::class.'] records have been imported.')
+            ->assertSuccessful();
+    }
+
+    public function test_it_skips_pgsql_preparation_when_search_vector_already_exists()
+    {
+        config(['scout.driver' => 'pgsql']);
+
+        $schema = Mockery::mock();
+        $schema->shouldReceive('hasColumn')->once()->with('users', 'search_vector')->andReturn(true);
+        $schema->shouldNotReceive('table');
+
+        $this->useSchemaBuilder($schema);
+
+        $this->artisan('scout:import', [
+            'model' => ImportCommandPgsqlSearchableUser::class,
+            '--prepare-pgsql' => true,
+        ])
+            ->expectsOutput('PostgreSQL search column [search_vector] already exists for ['.ImportCommandPgsqlSearchableUser::class.']; skipping preparation.')
+            ->expectsOutput('All ['.ImportCommandPgsqlSearchableUser::class.'] records have been imported.')
+            ->assertSuccessful();
+    }
+
+    public function test_prepare_pgsql_option_warns_when_driver_is_not_pgsql()
+    {
+        config(['scout.driver' => 'database']);
+
+        $schema = Mockery::mock();
+        $schema->shouldNotReceive('hasColumn');
+        $schema->shouldNotReceive('table');
+
+        $this->useSchemaBuilder($schema);
+
+        $this->artisan('scout:import', [
+            'model' => ImportCommandPgsqlSearchableUser::class,
+            '--prepare-pgsql' => true,
+        ])
+            ->expectsOutput('The [--prepare-pgsql] option only applies to models using the [pgsql] Scout engine.')
+            ->expectsOutput('All ['.ImportCommandPgsqlSearchableUser::class.'] records have been imported.')
+            ->assertSuccessful();
+    }
+
+    public function test_prepare_pgsql_option_uses_model_specific_pgsql_engine()
+    {
+        config(['scout.driver' => 'collection']);
+
+        $schema = Mockery::mock();
+        $schema->shouldReceive('hasColumn')->once()->with('users', 'search_vector')->andReturn(false);
+        $schema->shouldReceive('table')->once()->with('users', Mockery::on(function ($callback) {
+            $table = Mockery::mock();
+
+            $table->shouldReceive('searchable')->once()->with(['id', 'name', 'email', 'age']);
+
+            $callback($table);
+
+            return true;
+        }));
+
+        $this->useSchemaBuilder($schema);
+
+        $this->artisan('scout:import', [
+            'model' => ImportCommandModelSpecificPgsqlSearchableUser::class,
+            '--prepare-pgsql' => true,
+        ])
+            ->expectsOutput('Prepared PostgreSQL search columns and indexes for ['.ImportCommandModelSpecificPgsqlSearchableUser::class.'].')
+            ->expectsOutput('All ['.ImportCommandModelSpecificPgsqlSearchableUser::class.'] records have been imported.')
+            ->assertSuccessful();
+    }
+
+    public function test_prepare_pgsql_option_skips_model_specific_non_pgsql_engine()
+    {
+        config(['scout.driver' => 'pgsql']);
+
+        $schema = Mockery::mock();
+        $schema->shouldNotReceive('hasColumn');
+        $schema->shouldNotReceive('table');
+
+        $this->useSchemaBuilder($schema);
+
+        $this->artisan('scout:import', [
+            'model' => ImportCommandModelSpecificCollectionSearchableUser::class,
+            '--prepare-pgsql' => true,
+        ])
+            ->expectsOutput('The [--prepare-pgsql] option only applies to models using the [pgsql] Scout engine.')
+            ->expectsOutput('All ['.ImportCommandModelSpecificCollectionSearchableUser::class.'] records have been imported.')
+            ->assertSuccessful();
+    }
+
+    protected function useSchemaBuilder($schema)
+    {
+        $this->app['db']->connection('pgsql_schema')->schemaBuilder = $schema;
+    }
+}
+
+class ImportCommandPgsqlSearchableUser extends Model
+{
+    use Searchable;
+
+    protected $connection = 'pgsql_schema';
+
+    protected $table = 'users';
+
+    public function toSearchableArray()
+    {
+        return [
+            'id' => null,
+            'name' => null,
+            'email' => null,
+            'age' => null,
+        ];
+    }
+
+    public static function makeAllSearchable($chunk = null)
+    {
+        //
+    }
+
+    public static function removeAllFromSearch()
+    {
+        //
+    }
+}
+
+class ImportCommandModelSpecificPgsqlSearchableUser extends ImportCommandPgsqlSearchableUser
+{
+    public function searchableUsing()
+    {
+        return Scout::engine('pgsql');
+    }
+}
+
+class ImportCommandModelSpecificCollectionSearchableUser extends ImportCommandPgsqlSearchableUser
+{
+    public function searchableUsing()
+    {
+        return Scout::engine('collection');
+    }
+}
+
+class ImportCommandPgsqlTestingConnection extends SQLiteConnection
+{
+    public $schemaBuilder;
+
+    public function getDriverName()
+    {
+        return 'pgsql';
+    }
+
+    public function getSchemaBuilder()
+    {
+        return $this->schemaBuilder ?: parent::getSchemaBuilder();
+    }
+}

--- a/tests/Feature/DatabaseEngineTest.php
+++ b/tests/Feature/DatabaseEngineTest.php
@@ -8,6 +8,7 @@ use Orchestra\Testbench\Concerns\WithLaravelMigrations;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
 use Workbench\App\Models\Bookmark;
+use Workbench\App\Models\Chirp;
 use Workbench\App\Models\SearchableUser;
 use Workbench\Database\Factories\BookmarkFactory;
 use Workbench\Database\Factories\ChirpFactory;
@@ -269,5 +270,32 @@ class DatabaseEngineTest extends TestCase
 
         $this->assertCount(1, $models);
         $this->assertEquals('Abigail Otwell', $models[0]->name);
+    }
+
+    public function test_it_can_filter_with_where_in_and_where_not_in()
+    {
+        $models = SearchableUser::search()
+            ->whereIn('email', ['taylor@laravel.com', 'abigail@laravel.com'])
+            ->whereNotIn('name', ['Abigail Otwell'])
+            ->get();
+
+        $this->assertCount(1, $models);
+        $this->assertEquals('Taylor Otwell', $models[0]->name);
+    }
+
+    public function test_it_applies_soft_delete_constraints()
+    {
+        $this->app->make('config')->set('scout.soft_delete', true);
+
+        $active = ChirpFactory::new()->create(['content' => 'laravel scout search']);
+        $deleted = ChirpFactory::new()->create(['content' => 'laravel scout search']);
+
+        $deleted->delete();
+
+        $this->assertCount(1, Chirp::search()->get());
+        $this->assertSame($active->getKey(), Chirp::search()->first()->getKey());
+        $this->assertCount(2, Chirp::search()->withTrashed()->get());
+        $this->assertCount(1, Chirp::search()->onlyTrashed()->get());
+        $this->assertSame($deleted->getKey(), Chirp::search()->onlyTrashed()->first()->getKey());
     }
 }

--- a/tests/Feature/PgsqlEngineTest.php
+++ b/tests/Feature/PgsqlEngineTest.php
@@ -11,8 +11,10 @@ use Laravel\Scout\Pgsql\Trigram;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
 use PDO;
+use Workbench\App\Models\Bookmark;
 use Workbench\App\Models\Chirp;
 use Workbench\App\Models\SearchableUser;
+use Workbench\Database\Factories\BookmarkFactory;
 use Workbench\Database\Factories\ChirpFactory;
 use Workbench\Database\Factories\SearchableUserFactory;
 
@@ -63,6 +65,13 @@ class PgsqlEngineTest extends TestCase
             $table->timestamps();
             $table->softDeletes();
         });
+
+        Schema::create('bookmarks', function ($table) {
+            $table->id();
+            $table->foreignId('chirp_id');
+            $table->string('label');
+            $table->timestamps();
+        });
     }
 
     protected function seedSearchableUsers()
@@ -110,6 +119,20 @@ class PgsqlEngineTest extends TestCase
         $this->assertCount(1, SearchableUser::search()->simplePaginate(1));
     }
 
+    public function test_it_uses_custom_page_names_for_database_pagination()
+    {
+        $models = SearchableUser::search()->paginate(1, 'users_page', 2);
+
+        $this->assertSame(3, $models->total());
+        $this->assertSame(2, $models->currentPage());
+        $this->assertStringContainsString('users_page=1', $models->url(1));
+
+        $models = SearchableUser::search()->simplePaginate(1, 'simple_users_page', 2);
+
+        $this->assertSame(2, $models->currentPage());
+        $this->assertStringContainsString('simple_users_page=1', $models->url(1));
+    }
+
     public function test_it_applies_constraints_callbacks_and_limits()
     {
         $models = SearchableUser::search()->where('email', 'taylor@laravel.com')->get();
@@ -132,6 +155,12 @@ class PgsqlEngineTest extends TestCase
         $this->assertCount(1, $models);
         $this->assertSame('Taylor Otwell', $models[0]->name);
 
+        $models = SearchableUser::search()->tap(function ($builder) {
+            $builder->take(1);
+        })->get();
+
+        $this->assertCount(1, $models);
+
         $this->assertCount(1, SearchableUser::search()->take(1)->get());
     }
 
@@ -144,6 +173,24 @@ class PgsqlEngineTest extends TestCase
         $models = SearchableUser::search()->orderBy('name', 'desc')->get();
 
         $this->assertSame(['Taylor Otwell', 'Nuno Maduro', 'Abigail Otwell'], $models->pluck('name')->all());
+
+        $models = SearchableUser::search()->orderByDesc('name')->get();
+
+        $this->assertSame(['Taylor Otwell', 'Nuno Maduro', 'Abigail Otwell'], $models->pluck('name')->all());
+    }
+
+    public function test_it_starts_from_custom_scout_queries()
+    {
+        BookmarkFactory::new()
+            ->for(ChirpFactory::new()->create(['content' => 'This chirp is searchable']))
+            ->create([
+                'label' => 'laravel',
+            ]);
+
+        $query = $this->buildPgsqlSearchQuery(Bookmark::search('chirp'));
+
+        $this->assertStringContainsString('inner join "chirps" on "chirps"."id" = "bookmarks"."chirp_id"', $query->toSql());
+        $this->assertStringContainsString('"bookmarks"."search_vector" @@ plainto_tsquery(?::regconfig, ?)', $query->toSql());
     }
 
     public function test_non_empty_searches_use_the_configured_vector_column_and_default_tsquery_function()
@@ -291,19 +338,59 @@ class PgsqlEngineTest extends TestCase
     public function test_trigram_similarity_can_match_when_full_text_does_not()
     {
         $this->app->make('config')->set('scout.pgsql.trigram.enabled', true);
+        $this->app->make('config')->set('scout.pgsql.trigram.columns', ['name', 'email']);
 
         $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle'), true);
 
         $this->assertStringContainsString('"users"."search_vector" @@ plainto_tsquery(?::regconfig, ?)', $query->toSql());
-        $this->assertStringContainsString('greatest(similarity(coalesce(cast("users"."id" as text), \'\'), ?), similarity(coalesce(cast("users"."name" as text), \'\'), ?), similarity(coalesce(cast("users"."email" as text), \'\'), ?), similarity(coalesce(cast("users"."age" as text), \'\'), ?)) >= ?', $query->toSql());
+        $this->assertStringContainsString('(set_config(\'pg_trgm.similarity_threshold\', ?::text, true) is not null and ("users"."name" % ? or "users"."email" % ?))', $query->toSql());
+        $this->assertStringContainsString('similarity(coalesce(cast("users"."name" as text), \'\'), ?)', $query->toSql());
+        $this->assertStringContainsString('similarity(coalesce(cast("users"."email" as text), \'\'), ?)', $query->toSql());
+        $this->assertSame([
+            'english', 'laravle', 0.3, 'laravle', 'laravle',
+            'english', 'laravle', 1.0, 'laravle', 'laravle', 0.25,
+        ], $query->getBindings());
+    }
+
+    public function test_trigram_search_uses_configured_columns_only()
+    {
+        $this->app->make('config')->set('scout.pgsql.trigram.enabled', true);
+        $this->app->make('config')->set('scout.pgsql.trigram.columns', ['name']);
+
+        $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle'), true);
+
+        $this->assertStringContainsString('"users"."name" % ?', $query->toSql());
+        $this->assertStringContainsString('similarity(coalesce(cast("users"."name" as text), \'\'), ?)', $query->toSql());
+        $this->assertStringNotContainsString('"users"."id" % ?', $query->toSql());
+        $this->assertStringNotContainsString('"users"."email" % ?', $query->toSql());
+        $this->assertStringNotContainsString('"users"."age" % ?', $query->toSql());
+        $this->assertStringNotContainsString('similarity(coalesce(cast("users"."id" as text)', $query->toSql());
+        $this->assertStringNotContainsString('similarity(coalesce(cast("users"."email" as text)', $query->toSql());
+        $this->assertStringNotContainsString('similarity(coalesce(cast("users"."age" as text)', $query->toSql());
     }
 
     public function test_trigram_behavior_is_skipped_when_disabled()
     {
+        $this->app->make('config')->set('scout.pgsql.trigram.columns', ['invalid column']);
+
         $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle'), true);
 
         $this->assertStringNotContainsString('similarity(', $query->toSql());
+        $this->assertStringNotContainsString(' % ?', $query->toSql());
         $this->assertStringContainsString('order by ts_rank("users"."search_vector", plainto_tsquery(?::regconfig, ?)) desc', $query->toSql());
+    }
+
+    public function test_trigram_behavior_is_skipped_without_configured_columns()
+    {
+        $this->app->make('config')->set('scout.pgsql.trigram.enabled', true);
+
+        $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle'), true);
+
+        $this->assertStringContainsString('"users"."search_vector" @@ plainto_tsquery(?::regconfig, ?)', $query->toSql());
+        $this->assertStringNotContainsString('similarity(', $query->toSql());
+        $this->assertStringNotContainsString(' % ?', $query->toSql());
+        $this->assertStringContainsString('order by ts_rank("users"."search_vector", plainto_tsquery(?::regconfig, ?)) desc', $query->toSql());
+        $this->assertSame(['english', 'laravle', 'english', 'laravle'], $query->getBindings());
     }
 
     public function test_missing_trigram_extension_falls_back_to_full_text_search()
@@ -314,33 +401,37 @@ class PgsqlEngineTest extends TestCase
 
         $this->assertStringContainsString('"users"."search_vector" @@ plainto_tsquery(?::regconfig, ?)', $query->toSql());
         $this->assertStringNotContainsString('similarity(', $query->toSql());
+        $this->assertStringNotContainsString(' % ?', $query->toSql());
         $this->assertSame(['english', 'laravle', 'english', 'laravle'], $query->getBindings());
     }
 
     public function test_trigram_ranking_blends_full_text_rank_and_similarity()
     {
         $this->app->make('config')->set('scout.pgsql.trigram.enabled', true);
+        $this->app->make('config')->set('scout.pgsql.trigram.columns', ['name', 'email']);
         $this->app->make('config')->set('scout.pgsql.weights.full_text', 1.5);
         $this->app->make('config')->set('scout.pgsql.weights.trigram', 0.5);
 
         $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle'), true);
 
-        $this->assertStringContainsString('order by ((ts_rank("users"."search_vector", plainto_tsquery(?::regconfig, ?)) * ?) + (greatest(similarity(coalesce(cast("users"."id" as text), \'\'), ?), similarity(coalesce(cast("users"."name" as text), \'\'), ?), similarity(coalesce(cast("users"."email" as text), \'\'), ?), similarity(coalesce(cast("users"."age" as text), \'\'), ?)) * ?)) desc', $query->toSql());
+        $this->assertStringContainsString('order by ((ts_rank("users"."search_vector", plainto_tsquery(?::regconfig, ?)) * ?) + (greatest(similarity(coalesce(cast("users"."name" as text), \'\'), ?), similarity(coalesce(cast("users"."email" as text), \'\'), ?)) * ?)) desc', $query->toSql());
         $this->assertSame([
-            'english', 'laravle', 'laravle', 'laravle', 'laravle', 'laravle', 0.3,
-            'english', 'laravle', 1.5, 'laravle', 'laravle', 'laravle', 'laravle', 0.5,
+            'english', 'laravle', 0.3, 'laravle', 'laravle',
+            'english', 'laravle', 1.5, 'laravle', 'laravle', 0.5,
         ], $query->getBindings());
     }
 
     public function test_explicit_ordering_overrides_blended_relevance_ranking()
     {
         $this->app->make('config')->set('scout.pgsql.trigram.enabled', true);
+        $this->app->make('config')->set('scout.pgsql.trigram.columns', ['name']);
 
         $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle')->orderBy('name'), true);
 
-        $this->assertStringContainsString('similarity(', $query->toSql());
+        $this->assertStringContainsString('"users"."name" % ?', $query->toSql());
         $this->assertStringContainsString('order by "name" asc', $query->toSql());
         $this->assertStringNotContainsString('ts_rank', $query->toSql());
+        $this->assertStringNotContainsString('similarity(', $query->toSql());
     }
 
     public function test_it_applies_soft_delete_constraints()

--- a/tests/Feature/PgsqlEngineTest.php
+++ b/tests/Feature/PgsqlEngineTest.php
@@ -421,6 +421,42 @@ class PgsqlEngineTest extends TestCase
         ], $query->getBindings());
     }
 
+    public function test_invalid_trigram_threshold_fails_clearly()
+    {
+        $this->app->make('config')->set('scout.pgsql.trigram.enabled', true);
+        $this->app->make('config')->set('scout.pgsql.trigram.columns', ['name']);
+        $this->app->make('config')->set('scout.pgsql.trigram.threshold', 'invalid');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout driver trigram threshold must be numeric.');
+
+        $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle'), true);
+    }
+
+    public function test_invalid_full_text_score_weight_fails_clearly()
+    {
+        $this->app->make('config')->set('scout.pgsql.trigram.enabled', true);
+        $this->app->make('config')->set('scout.pgsql.trigram.columns', ['name']);
+        $this->app->make('config')->set('scout.pgsql.weights.full_text', 'invalid');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout driver score weight [full_text] must be numeric.');
+
+        $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle'), true);
+    }
+
+    public function test_invalid_trigram_score_weight_fails_clearly()
+    {
+        $this->app->make('config')->set('scout.pgsql.trigram.enabled', true);
+        $this->app->make('config')->set('scout.pgsql.trigram.columns', ['name']);
+        $this->app->make('config')->set('scout.pgsql.weights.trigram', 'invalid');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout driver score weight [trigram] must be numeric.');
+
+        $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle'), true);
+    }
+
     public function test_explicit_ordering_overrides_blended_relevance_ranking()
     {
         $this->app->make('config')->set('scout.pgsql.trigram.enabled', true);

--- a/tests/Feature/PgsqlEngineTest.php
+++ b/tests/Feature/PgsqlEngineTest.php
@@ -514,7 +514,6 @@ class PgsqlEngineTest extends TestCase
     {
         return (new InspectablePgsqlEngine($this->app->make('config')->get('scout.pgsql'), $trigramAvailable))->buildOrderedSearchQueryForTest($builder);
     }
-
 }
 
 class InspectablePgsqlEngine extends PgsqlEngine

--- a/tests/Feature/PgsqlEngineTest.php
+++ b/tests/Feature/PgsqlEngineTest.php
@@ -2,12 +2,15 @@
 
 namespace Laravel\Scout\Tests\Feature;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\SQLiteConnection;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use InvalidArgumentException;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\PgsqlEngine;
 use Laravel\Scout\Pgsql\Trigram;
+use Laravel\Scout\Searchable;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
 use PDO;
@@ -72,6 +75,20 @@ class PgsqlEngineTest extends TestCase
             $table->string('label');
             $table->timestamps();
         });
+
+        Schema::create('external_documents', function ($table) {
+            $table->id();
+            $table->integer('external_id');
+            $table->string('title');
+            $table->timestamps();
+        });
+
+        Schema::create('string_documents', function ($table) {
+            $table->id();
+            $table->string('code');
+            $table->string('title');
+            $table->timestamps();
+        });
     }
 
     protected function seedSearchableUsers()
@@ -117,6 +134,36 @@ class PgsqlEngineTest extends TestCase
         $this->assertEqualsCanonicalizing([1, 2, 3], SearchableUser::search()->keys()->all());
         $this->assertSame(3, SearchableUser::search()->paginate(1)->total());
         $this->assertCount(1, SearchableUser::search()->simplePaginate(1));
+    }
+
+    public function test_keys_returns_scout_keys_for_database_backed_engines()
+    {
+        PgsqlIntegerScoutKeyDocument::query()->create([
+            'external_id' => 1001,
+            'title' => 'First document',
+        ]);
+        PgsqlIntegerScoutKeyDocument::query()->create([
+            'external_id' => 1002,
+            'title' => 'Second document',
+        ]);
+
+        $this->assertSame([1002, 1001], PgsqlIntegerScoutKeyDocument::search()->keys()->all());
+    }
+
+    public function test_numeric_search_checks_integer_scout_key_column()
+    {
+        $query = $this->buildPgsqlSearchQuery(PgsqlIntegerScoutKeyDocument::search('1001'));
+
+        $this->assertStringContainsString('"external_documents"."external_id" = ?', $query->toSql());
+        $this->assertStringNotContainsString('"external_documents"."id" = ?', $query->toSql());
+    }
+
+    public function test_numeric_search_does_not_use_exact_key_optimization_for_non_integer_scout_keys()
+    {
+        $query = $this->buildPgsqlSearchQuery(PgsqlStringScoutKeyDocument::search('123'));
+
+        $this->assertStringNotContainsString('"string_documents"."code" = ?', $query->toSql());
+        $this->assertStringNotContainsString('"string_documents"."id" = ?', $query->toSql());
     }
 
     public function test_it_uses_custom_page_names_for_database_pagination()
@@ -199,6 +246,17 @@ class PgsqlEngineTest extends TestCase
 
         $this->assertStringContainsString('"users"."search_vector" @@ plainto_tsquery(?::regconfig, ?)', $query->toSql());
         $this->assertStringContainsString('order by ts_rank("users"."search_vector", plainto_tsquery(?::regconfig, ?)) desc', $query->toSql());
+        $this->assertSame(['english', 'laravel', 'english', 'laravel'], $query->getBindings());
+    }
+
+    public function test_non_empty_searches_use_the_configured_vector_column()
+    {
+        $this->app->make('config')->set('scout.pgsql.vector_column', 'document_vector');
+
+        $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravel'));
+
+        $this->assertStringContainsString('"users"."document_vector" @@ plainto_tsquery(?::regconfig, ?)', $query->toSql());
+        $this->assertStringContainsString('order by ts_rank("users"."document_vector", plainto_tsquery(?::regconfig, ?)) desc', $query->toSql());
         $this->assertSame(['english', 'laravel', 'english', 'laravel'], $query->getBindings());
     }
 
@@ -306,10 +364,10 @@ class PgsqlEngineTest extends TestCase
             'english', 'laravle', 'laravle', 'laravle',
             'english', 'laravle', 1.0, 'laravle', 'laravle', 0.25,
         ], $query->getBindings());
-        $this->assertSame([0.3], $engine->appliedThresholds());
+        $this->assertSame([], $engine->appliedThresholds());
     }
 
-    public function test_trigram_threshold_is_applied_before_trigram_predicate_execution()
+    public function test_trigram_threshold_is_not_applied_while_building_the_query()
     {
         $this->app->make('config')->set('scout.pgsql.trigram.enabled', true);
         $this->app->make('config')->set('scout.pgsql.trigram.threshold', 0.15);
@@ -319,7 +377,7 @@ class PgsqlEngineTest extends TestCase
         $query = $engine->buildOrderedSearchQueryForTest(SearchableUser::search('laravle'));
 
         $this->assertStringContainsString('("users"."name" % ?)', $query->toSql());
-        $this->assertSame([0.15], $engine->appliedThresholds());
+        $this->assertSame([], $engine->appliedThresholds());
         $this->assertSame([
             'english', 'laravle', 'laravle',
             'english', 'laravle', 1.0, 'laravle', 0.25,
@@ -389,13 +447,29 @@ class PgsqlEngineTest extends TestCase
     public function test_missing_trigram_extension_falls_back_to_full_text_search()
     {
         $this->app->make('config')->set('scout.pgsql.trigram.enabled', true);
+        $this->app->make('config')->set('scout.pgsql.trigram.columns', ['name']);
 
-        $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle'), false);
+        Log::shouldReceive('warning')->once()->with('Scout [pgsql] trigram search is enabled, but the [pg_trgm] extension is not available. Falling back to PostgreSQL full-text search.');
+
+        $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle'));
 
         $this->assertStringContainsString('"users"."search_vector" @@ plainto_tsquery(?::regconfig, ?)', $query->toSql());
         $this->assertStringNotContainsString('similarity(', $query->toSql());
         $this->assertStringNotContainsString(' % ?', $query->toSql());
         $this->assertSame(['english', 'laravle', 'english', 'laravle'], $query->getBindings());
+    }
+
+    public function test_missing_trigram_extension_warning_is_emitted_once_per_connection()
+    {
+        $this->app->make('config')->set('scout.pgsql.trigram.enabled', true);
+        $this->app->make('config')->set('scout.pgsql.trigram.columns', ['name']);
+
+        Log::shouldReceive('warning')->once()->with('Scout [pgsql] trigram search is enabled, but the [pg_trgm] extension is not available. Falling back to PostgreSQL full-text search.');
+
+        $engine = $this->pgsqlEngine();
+
+        $engine->buildOrderedSearchQueryForTest(SearchableUser::search('laravle'));
+        $engine->buildOrderedSearchQueryForTest(SearchableUser::search('laravle'));
     }
 
     public function test_trigram_ranking_blends_full_text_rank_and_similarity()
@@ -436,7 +510,7 @@ class PgsqlEngineTest extends TestCase
 
         $engine->buildOrderedSearchQueryForTest(SearchableUser::search('laravle'));
 
-        $this->assertSame([0], $engine->appliedThresholds());
+        $this->assertSame([], $engine->appliedThresholds());
     }
 
     public function test_trigram_threshold_accepts_one()
@@ -449,7 +523,7 @@ class PgsqlEngineTest extends TestCase
 
         $engine->buildOrderedSearchQueryForTest(SearchableUser::search('laravle'));
 
-        $this->assertSame([1], $engine->appliedThresholds());
+        $this->assertSame([], $engine->appliedThresholds());
     }
 
     public function test_trigram_threshold_rejects_values_below_zero()
@@ -597,6 +671,70 @@ class InspectablePgsqlEngine extends PgsqlEngine
                 $this->engine->recordAppliedThreshold($this->threshold());
             }
         };
+    }
+}
+
+class PgsqlIntegerScoutKeyDocument extends Model
+{
+    use Searchable;
+
+    protected $guarded = [];
+
+    protected $table = 'external_documents';
+
+    public function getScoutKey()
+    {
+        return $this->external_id;
+    }
+
+    public function getScoutKeyName()
+    {
+        return 'external_id';
+    }
+
+    public function getScoutKeyType()
+    {
+        return 'int';
+    }
+
+    public function toSearchableArray()
+    {
+        return [
+            'external_id' => $this->external_id,
+            'title' => $this->title,
+        ];
+    }
+}
+
+class PgsqlStringScoutKeyDocument extends Model
+{
+    use Searchable;
+
+    protected $guarded = [];
+
+    protected $table = 'string_documents';
+
+    public function getScoutKey()
+    {
+        return $this->code;
+    }
+
+    public function getScoutKeyName()
+    {
+        return 'code';
+    }
+
+    public function getScoutKeyType()
+    {
+        return 'string';
+    }
+
+    public function toSearchableArray()
+    {
+        return [
+            'code' => $this->code,
+            'title' => $this->title,
+        ];
     }
 }
 

--- a/tests/Feature/PgsqlEngineTest.php
+++ b/tests/Feature/PgsqlEngineTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Schema;
 use InvalidArgumentException;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\PgsqlEngine;
+use Laravel\Scout\Pgsql\Trigram;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
 use PDO;
@@ -287,6 +288,61 @@ class PgsqlEngineTest extends TestCase
         $this->assertStringNotContainsString('"users"."age"', $expression);
     }
 
+    public function test_trigram_similarity_can_match_when_full_text_does_not()
+    {
+        $this->app->make('config')->set('scout.pgsql.trigram.enabled', true);
+
+        $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle'), true);
+
+        $this->assertStringContainsString('"users"."search_vector" @@ plainto_tsquery(?::regconfig, ?)', $query->toSql());
+        $this->assertStringContainsString('greatest(similarity(coalesce(cast("users"."id" as text), \'\'), ?), similarity(coalesce(cast("users"."name" as text), \'\'), ?), similarity(coalesce(cast("users"."email" as text), \'\'), ?), similarity(coalesce(cast("users"."age" as text), \'\'), ?)) >= ?', $query->toSql());
+    }
+
+    public function test_trigram_behavior_is_skipped_when_disabled()
+    {
+        $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle'), true);
+
+        $this->assertStringNotContainsString('similarity(', $query->toSql());
+        $this->assertStringContainsString('order by ts_rank("users"."search_vector", plainto_tsquery(?::regconfig, ?)) desc', $query->toSql());
+    }
+
+    public function test_missing_trigram_extension_falls_back_to_full_text_search()
+    {
+        $this->app->make('config')->set('scout.pgsql.trigram.enabled', true);
+
+        $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle'), false);
+
+        $this->assertStringContainsString('"users"."search_vector" @@ plainto_tsquery(?::regconfig, ?)', $query->toSql());
+        $this->assertStringNotContainsString('similarity(', $query->toSql());
+        $this->assertSame(['english', 'laravle', 'english', 'laravle'], $query->getBindings());
+    }
+
+    public function test_trigram_ranking_blends_full_text_rank_and_similarity()
+    {
+        $this->app->make('config')->set('scout.pgsql.trigram.enabled', true);
+        $this->app->make('config')->set('scout.pgsql.weights.full_text', 1.5);
+        $this->app->make('config')->set('scout.pgsql.weights.trigram', 0.5);
+
+        $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle'), true);
+
+        $this->assertStringContainsString('order by ((ts_rank("users"."search_vector", plainto_tsquery(?::regconfig, ?)) * ?) + (greatest(similarity(coalesce(cast("users"."id" as text), \'\'), ?), similarity(coalesce(cast("users"."name" as text), \'\'), ?), similarity(coalesce(cast("users"."email" as text), \'\'), ?), similarity(coalesce(cast("users"."age" as text), \'\'), ?)) * ?)) desc', $query->toSql());
+        $this->assertSame([
+            'english', 'laravle', 'laravle', 'laravle', 'laravle', 'laravle', 0.3,
+            'english', 'laravle', 1.5, 'laravle', 'laravle', 'laravle', 'laravle', 0.5,
+        ], $query->getBindings());
+    }
+
+    public function test_explicit_ordering_overrides_blended_relevance_ranking()
+    {
+        $this->app->make('config')->set('scout.pgsql.trigram.enabled', true);
+
+        $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle')->orderBy('name'), true);
+
+        $this->assertStringContainsString('similarity(', $query->toSql());
+        $this->assertStringContainsString('order by "name" asc', $query->toSql());
+        $this->assertStringNotContainsString('ts_rank', $query->toSql());
+    }
+
     public function test_it_applies_soft_delete_constraints()
     {
         $this->app->make('config')->set('scout.soft_delete', true);
@@ -308,9 +364,9 @@ class PgsqlEngineTest extends TestCase
         return (new InspectablePgsqlEngine($this->app->make('config')->get('scout.pgsql')))->buildSearchQueryForTest($builder);
     }
 
-    protected function buildOrderedPgsqlSearchQuery($builder)
+    protected function buildOrderedPgsqlSearchQuery($builder, $trigramAvailable = null)
     {
-        return (new InspectablePgsqlEngine($this->app->make('config')->get('scout.pgsql')))->buildOrderedSearchQueryForTest($builder);
+        return (new InspectablePgsqlEngine($this->app->make('config')->get('scout.pgsql'), $trigramAvailable))->buildOrderedSearchQueryForTest($builder);
     }
 
     protected function buildPgsqlSearchVectorExpression($builder)
@@ -321,6 +377,11 @@ class PgsqlEngineTest extends TestCase
 
 class InspectablePgsqlEngine extends PgsqlEngine
 {
+    public function __construct(array $config, protected $trigramAvailable = null)
+    {
+        parent::__construct($config);
+    }
+
     public function buildSearchQueryForTest(Builder $builder)
     {
         return $this->buildSearchQuery($builder);
@@ -334,6 +395,26 @@ class InspectablePgsqlEngine extends PgsqlEngine
     public function buildSearchVectorExpressionForTest(Builder $builder)
     {
         return $this->searchVectorExpression($builder);
+    }
+
+    protected function trigram()
+    {
+        if (is_null($this->trigramAvailable)) {
+            return parent::trigram();
+        }
+
+        return $this->trigram ??= new class($this->config, $this->trigramAvailable) extends Trigram
+        {
+            public function __construct(array $config, protected bool $available)
+            {
+                parent::__construct($config);
+            }
+
+            public function available(Builder $builder)
+            {
+                return $this->available;
+            }
+        };
     }
 }
 

--- a/tests/Feature/PgsqlEngineTest.php
+++ b/tests/Feature/PgsqlEngineTest.php
@@ -4,6 +4,9 @@ namespace Laravel\Scout\Tests\Feature;
 
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Support\Facades\Schema;
+use InvalidArgumentException;
+use Laravel\Scout\Builder;
+use Laravel\Scout\Engines\PgsqlEngine;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
 use PDO;
@@ -97,23 +100,23 @@ class PgsqlEngineTest extends TestCase
 
     public function test_it_can_retrieve_keys_and_paginated_results()
     {
-        $models = SearchableUser::search('laravel')->get();
+        $models = SearchableUser::search()->get();
 
-        $this->assertCount(2, $models);
-        $this->assertEqualsCanonicalizing([1, 2], $models->modelKeys());
-        $this->assertEqualsCanonicalizing([1, 2], SearchableUser::search('laravel')->keys()->all());
-        $this->assertSame(2, SearchableUser::search('laravel')->paginate(1)->total());
-        $this->assertCount(1, SearchableUser::search('laravel')->simplePaginate(1));
+        $this->assertCount(3, $models);
+        $this->assertEqualsCanonicalizing([1, 2, 3], $models->modelKeys());
+        $this->assertEqualsCanonicalizing([1, 2, 3], SearchableUser::search()->keys()->all());
+        $this->assertSame(3, SearchableUser::search()->paginate(1)->total());
+        $this->assertCount(1, SearchableUser::search()->simplePaginate(1));
     }
 
     public function test_it_applies_constraints_callbacks_and_limits()
     {
-        $models = SearchableUser::search('laravel')->where('email', 'taylor@laravel.com')->get();
+        $models = SearchableUser::search()->where('email', 'taylor@laravel.com')->get();
 
         $this->assertCount(1, $models);
         $this->assertSame('Taylor Otwell', $models[0]->name);
 
-        $models = SearchableUser::search('laravel')
+        $models = SearchableUser::search()
             ->whereIn('email', ['taylor@laravel.com', 'nuno@example.com'])
             ->whereNotIn('name', ['Nuno Maduro'])
             ->get();
@@ -121,25 +124,111 @@ class PgsqlEngineTest extends TestCase
         $this->assertCount(1, $models);
         $this->assertSame('Taylor Otwell', $models[0]->name);
 
-        $models = SearchableUser::search('laravel')->query(function ($query) {
+        $models = SearchableUser::search()->query(function ($query) {
             $query->where('age', '>', 30);
         })->get();
 
         $this->assertCount(1, $models);
         $this->assertSame('Taylor Otwell', $models[0]->name);
 
-        $this->assertCount(1, SearchableUser::search('laravel')->take(1)->get());
+        $this->assertCount(1, SearchableUser::search()->take(1)->get());
     }
 
     public function test_explicit_ordering_takes_precedence()
     {
-        $models = SearchableUser::search('laravel')->orderBy('name', 'asc')->get();
+        $models = SearchableUser::search()->orderBy('name', 'asc')->get();
 
-        $this->assertSame(['Abigail Otwell', 'Taylor Otwell'], $models->pluck('name')->all());
+        $this->assertSame(['Abigail Otwell', 'Nuno Maduro', 'Taylor Otwell'], $models->pluck('name')->all());
 
-        $models = SearchableUser::search('laravel')->orderBy('name', 'desc')->get();
+        $models = SearchableUser::search()->orderBy('name', 'desc')->get();
 
-        $this->assertSame(['Taylor Otwell', 'Abigail Otwell'], $models->pluck('name')->all());
+        $this->assertSame(['Taylor Otwell', 'Nuno Maduro', 'Abigail Otwell'], $models->pluck('name')->all());
+    }
+
+    public function test_non_empty_searches_use_the_configured_vector_column_and_default_tsquery_function()
+    {
+        $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravel'));
+
+        $this->assertStringContainsString('"users"."search_vector" @@ plainto_tsquery(?::regconfig, ?)', $query->toSql());
+        $this->assertStringContainsString('order by ts_rank("users"."search_vector", plainto_tsquery(?::regconfig, ?)) desc', $query->toSql());
+        $this->assertSame(['english', 'laravel', 'english', 'laravel'], $query->getBindings());
+    }
+
+    public function test_non_empty_searches_use_the_configured_language()
+    {
+        $this->app->make('config')->set('scout.pgsql.language', 'simple');
+
+        $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravel'));
+
+        $this->assertStringContainsString('plainto_tsquery(?::regconfig, ?)', $query->toSql());
+        $this->assertSame(['simple', 'laravel', 'simple', 'laravel'], $query->getBindings());
+    }
+
+    public function test_non_empty_searches_can_use_websearch_queries()
+    {
+        $this->app->make('config')->set('scout.pgsql.query_function', 'websearch_to_tsquery');
+
+        $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravel'));
+
+        $this->assertStringContainsString('"users"."search_vector" @@ websearch_to_tsquery(?::regconfig, ?)', $query->toSql());
+        $this->assertStringContainsString('order by ts_rank("users"."search_vector", websearch_to_tsquery(?::regconfig, ?)) desc', $query->toSql());
+    }
+
+    public function test_non_empty_searches_can_use_cover_density_ranking()
+    {
+        $this->app->make('config')->set('scout.pgsql.rank_function', 'ts_rank_cd');
+
+        $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravel'));
+
+        $this->assertStringContainsString('order by ts_rank_cd("users"."search_vector", plainto_tsquery(?::regconfig, ?)) desc', $query->toSql());
+    }
+
+    public function test_explicit_ordering_skips_relevance_ranking()
+    {
+        $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravel')->orderBy('name'));
+
+        $this->assertStringContainsString('order by "name" asc', $query->toSql());
+        $this->assertStringNotContainsString('ts_rank', $query->toSql());
+    }
+
+    public function test_invalid_pgsql_search_config_fails_clearly()
+    {
+        $this->app->make('config')->set('scout.pgsql.rank_function', 'rank(search_vector) desc; --');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout driver rank function must be one of: ts_rank, ts_rank_cd.');
+
+        $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravel'));
+    }
+
+    public function test_invalid_pgsql_language_fails_clearly()
+    {
+        $this->app->make('config')->set('scout.pgsql.language', 'english; --');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout driver language must be a valid PostgreSQL text search configuration name.');
+
+        $this->buildPgsqlSearchQuery(SearchableUser::search('laravel'));
+    }
+
+    public function test_invalid_pgsql_query_function_fails_clearly()
+    {
+        $this->app->make('config')->set('scout.pgsql.query_function', 'custom_tsquery');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout driver query function must be one of: plainto_tsquery, phraseto_tsquery, websearch_to_tsquery, to_tsquery.');
+
+        $this->buildPgsqlSearchQuery(SearchableUser::search('laravel'));
+    }
+
+    public function test_invalid_pgsql_vector_column_fails_clearly()
+    {
+        $this->app->make('config')->set('scout.pgsql.vector_column', 'search_vector) desc; --');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout driver vector column must be a valid column name.');
+
+        $this->buildPgsqlSearchQuery(SearchableUser::search('laravel'));
     }
 
     public function test_it_applies_soft_delete_constraints()
@@ -151,11 +240,34 @@ class PgsqlEngineTest extends TestCase
 
         $deleted->delete();
 
-        $this->assertCount(1, Chirp::search('laravel')->get());
-        $this->assertSame($active->getKey(), Chirp::search('laravel')->first()->getKey());
-        $this->assertCount(2, Chirp::search('laravel')->withTrashed()->get());
-        $this->assertCount(1, Chirp::search('laravel')->onlyTrashed()->get());
-        $this->assertSame($deleted->getKey(), Chirp::search('laravel')->onlyTrashed()->first()->getKey());
+        $this->assertCount(1, Chirp::search()->get());
+        $this->assertSame($active->getKey(), Chirp::search()->first()->getKey());
+        $this->assertCount(2, Chirp::search()->withTrashed()->get());
+        $this->assertCount(1, Chirp::search()->onlyTrashed()->get());
+        $this->assertSame($deleted->getKey(), Chirp::search()->onlyTrashed()->first()->getKey());
+    }
+
+    protected function buildPgsqlSearchQuery($builder)
+    {
+        return (new InspectablePgsqlEngine($this->app->make('config')->get('scout.pgsql')))->buildSearchQueryForTest($builder);
+    }
+
+    protected function buildOrderedPgsqlSearchQuery($builder)
+    {
+        return (new InspectablePgsqlEngine($this->app->make('config')->get('scout.pgsql')))->buildOrderedSearchQueryForTest($builder);
+    }
+}
+
+class InspectablePgsqlEngine extends PgsqlEngine
+{
+    public function buildSearchQueryForTest(Builder $builder)
+    {
+        return $this->buildSearchQuery($builder);
+    }
+
+    public function buildOrderedSearchQueryForTest(Builder $builder)
+    {
+        return $this->orderSearchQuery($builder, $this->buildSearchQuery($builder));
     }
 }
 

--- a/tests/Feature/PgsqlEngineTest.php
+++ b/tests/Feature/PgsqlEngineTest.php
@@ -279,60 +279,14 @@ class PgsqlEngineTest extends TestCase
         $this->buildPgsqlSearchQuery(SearchableUser::search('laravel'));
     }
 
-    public function test_search_vector_expression_uses_default_column_weights()
+    public function test_schema_qualified_pgsql_vector_column_fails_clearly()
     {
-        $expression = $this->buildPgsqlSearchVectorExpression(SearchableUser::search('laravel'));
-
-        $this->assertStringContainsString('setweight(to_tsvector(\'english\', coalesce(cast("users"."id" as text), \'\')), \'D\')', $expression);
-        $this->assertStringContainsString('setweight(to_tsvector(\'english\', coalesce(cast("users"."name" as text), \'\')), \'D\')', $expression);
-        $this->assertStringContainsString('setweight(to_tsvector(\'english\', coalesce(cast("users"."email" as text), \'\')), \'D\')', $expression);
-        $this->assertStringContainsString('setweight(to_tsvector(\'english\', coalesce(cast("users"."age" as text), \'\')), \'D\')', $expression);
-    }
-
-    public function test_search_vector_expression_uses_configured_column_weights()
-    {
-        $this->app->make('config')->set('scout.pgsql.column_weights', [
-            'name' => 'A',
-            'email' => 'B',
-            'age' => 'C',
-        ]);
-
-        $expression = $this->buildPgsqlSearchVectorExpression(SearchableUser::search('laravel'));
-
-        $this->assertStringContainsString('setweight(to_tsvector(\'english\', coalesce(cast("users"."name" as text), \'\')), \'A\')', $expression);
-        $this->assertStringContainsString('setweight(to_tsvector(\'english\', coalesce(cast("users"."email" as text), \'\')), \'B\')', $expression);
-        $this->assertStringContainsString('setweight(to_tsvector(\'english\', coalesce(cast("users"."age" as text), \'\')), \'C\')', $expression);
-        $this->assertStringContainsString('setweight(to_tsvector(\'english\', coalesce(cast("users"."id" as text), \'\')), \'D\')', $expression);
-    }
-
-    public function test_invalid_pgsql_column_weight_fails_clearly()
-    {
-        $this->app->make('config')->set('scout.pgsql.column_weights', [
-            'name' => 'Z',
-        ]);
+        $this->app->make('config')->set('scout.pgsql.vector_column', 'users.search_vector');
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The [pgsql] Scout driver column weight for [name] must be one of: A, B, C, D.');
+        $this->expectExceptionMessage('The [pgsql] Scout driver vector column must be a valid column name.');
 
-        $this->buildPgsqlSearchVectorExpression(SearchableUser::search('laravel'));
-    }
-
-    public function test_search_vector_expression_uses_only_searchable_array_fields()
-    {
-        $_ENV['user.toSearchableArray'] = fn () => [
-            'name' => 'Taylor Otwell',
-        ];
-
-        try {
-            $expression = $this->buildPgsqlSearchVectorExpression(SearchableUser::search('laravel'));
-        } finally {
-            unset($_ENV['user.toSearchableArray']);
-        }
-
-        $this->assertStringContainsString('"users"."name"', $expression);
-        $this->assertStringNotContainsString('"users"."id"', $expression);
-        $this->assertStringNotContainsString('"users"."email"', $expression);
-        $this->assertStringNotContainsString('"users"."age"', $expression);
+        $this->buildPgsqlSearchQuery(SearchableUser::search('laravel'));
     }
 
     public function test_trigram_similarity_can_match_when_full_text_does_not()
@@ -367,6 +321,25 @@ class PgsqlEngineTest extends TestCase
         $this->assertStringNotContainsString('similarity(coalesce(cast("users"."id" as text)', $query->toSql());
         $this->assertStringNotContainsString('similarity(coalesce(cast("users"."email" as text)', $query->toSql());
         $this->assertStringNotContainsString('similarity(coalesce(cast("users"."age" as text)', $query->toSql());
+    }
+
+    public function test_trigram_search_rejects_schema_qualified_columns()
+    {
+        $_ENV['user.toSearchableArray'] = fn () => [
+            'users.name' => 'Taylor Otwell',
+        ];
+
+        try {
+            $this->app->make('config')->set('scout.pgsql.trigram.enabled', true);
+            $this->app->make('config')->set('scout.pgsql.trigram.columns', ['users.name']);
+
+            $this->expectException(InvalidArgumentException::class);
+            $this->expectExceptionMessage('The [pgsql] Scout driver trigram column [users.name] must be a valid column name.');
+
+            $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle'), true);
+        } finally {
+            unset($_ENV['user.toSearchableArray']);
+        }
     }
 
     public function test_trigram_behavior_is_skipped_when_disabled()
@@ -542,10 +515,6 @@ class PgsqlEngineTest extends TestCase
         return (new InspectablePgsqlEngine($this->app->make('config')->get('scout.pgsql'), $trigramAvailable))->buildOrderedSearchQueryForTest($builder);
     }
 
-    protected function buildPgsqlSearchVectorExpression($builder)
-    {
-        return (new InspectablePgsqlEngine($this->app->make('config')->get('scout.pgsql')))->buildSearchVectorExpressionForTest($builder);
-    }
 }
 
 class InspectablePgsqlEngine extends PgsqlEngine
@@ -563,11 +532,6 @@ class InspectablePgsqlEngine extends PgsqlEngine
     public function buildOrderedSearchQueryForTest(Builder $builder)
     {
         return $this->orderSearchQuery($builder, $this->buildSearchQuery($builder));
-    }
-
-    public function buildSearchVectorExpressionForTest(Builder $builder)
-    {
-        return $this->searchVectorExpression($builder);
     }
 
     protected function trigram()

--- a/tests/Feature/PgsqlEngineTest.php
+++ b/tests/Feature/PgsqlEngineTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Laravel\Scout\Tests\Feature;
+
+use Illuminate\Database\SQLiteConnection;
+use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+use PDO;
+use Workbench\App\Models\Chirp;
+use Workbench\App\Models\SearchableUser;
+use Workbench\Database\Factories\ChirpFactory;
+use Workbench\Database\Factories\SearchableUserFactory;
+
+class PgsqlEngineTest extends TestCase
+{
+    use WithWorkbench;
+
+    protected function defineEnvironment($app)
+    {
+        $app->make('config')->set('scout.driver', 'pgsql');
+        $app->make('config')->set('database.default', 'testing');
+        $app->make('config')->set('database.connections.testing', [
+            'driver' => 'testing-pgsql',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        $app->make('db')->extend('testing-pgsql', function ($config) {
+            return new PgsqlTestingSQLiteConnection(new PDO('sqlite::memory:'), $config['database'], $config['prefix'], $config);
+        });
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->defineDatabaseSchema();
+        $this->seedSearchableUsers();
+    }
+
+    protected function defineDatabaseSchema()
+    {
+        Schema::create('users', function ($table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email');
+            $table->integer('age')->nullable();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->string('password')->nullable();
+            $table->string('remember_token')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('chirps', function ($table) {
+            $table->id();
+            $table->uuid('scout_id');
+            $table->text('content');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    protected function seedSearchableUsers()
+    {
+        SearchableUserFactory::new()->create([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'age' => 35,
+        ]);
+
+        SearchableUserFactory::new()->create([
+            'name' => 'Abigail Otwell',
+            'email' => 'abigail@laravel.com',
+            'age' => 25,
+        ]);
+
+        SearchableUserFactory::new()->create([
+            'name' => 'Nuno Maduro',
+            'email' => 'nuno@example.com',
+            'age' => 30,
+        ]);
+    }
+
+    public function test_it_can_retrieve_results_with_empty_search_without_search_constraints()
+    {
+        $models = SearchableUser::search()->get();
+
+        $this->assertCount(3, $models);
+
+        SearchableUser::search('')->query(function ($query) {
+            $this->assertStringNotContainsString('search_vector', $query->toSql());
+            $this->assertStringNotContainsString('to_tsvector', $query->toSql());
+            $this->assertStringNotContainsString('similarity', $query->toSql());
+        })->get();
+    }
+
+    public function test_it_can_retrieve_keys_and_paginated_results()
+    {
+        $models = SearchableUser::search('laravel')->get();
+
+        $this->assertCount(2, $models);
+        $this->assertEqualsCanonicalizing([1, 2], $models->modelKeys());
+        $this->assertEqualsCanonicalizing([1, 2], SearchableUser::search('laravel')->keys()->all());
+        $this->assertSame(2, SearchableUser::search('laravel')->paginate(1)->total());
+        $this->assertCount(1, SearchableUser::search('laravel')->simplePaginate(1));
+    }
+
+    public function test_it_applies_constraints_callbacks_and_limits()
+    {
+        $models = SearchableUser::search('laravel')->where('email', 'taylor@laravel.com')->get();
+
+        $this->assertCount(1, $models);
+        $this->assertSame('Taylor Otwell', $models[0]->name);
+
+        $models = SearchableUser::search('laravel')
+            ->whereIn('email', ['taylor@laravel.com', 'nuno@example.com'])
+            ->whereNotIn('name', ['Nuno Maduro'])
+            ->get();
+
+        $this->assertCount(1, $models);
+        $this->assertSame('Taylor Otwell', $models[0]->name);
+
+        $models = SearchableUser::search('laravel')->query(function ($query) {
+            $query->where('age', '>', 30);
+        })->get();
+
+        $this->assertCount(1, $models);
+        $this->assertSame('Taylor Otwell', $models[0]->name);
+
+        $this->assertCount(1, SearchableUser::search('laravel')->take(1)->get());
+    }
+
+    public function test_explicit_ordering_takes_precedence()
+    {
+        $models = SearchableUser::search('laravel')->orderBy('name', 'asc')->get();
+
+        $this->assertSame(['Abigail Otwell', 'Taylor Otwell'], $models->pluck('name')->all());
+
+        $models = SearchableUser::search('laravel')->orderBy('name', 'desc')->get();
+
+        $this->assertSame(['Taylor Otwell', 'Abigail Otwell'], $models->pluck('name')->all());
+    }
+
+    public function test_it_applies_soft_delete_constraints()
+    {
+        $this->app->make('config')->set('scout.soft_delete', true);
+
+        $active = ChirpFactory::new()->create(['content' => 'laravel scout search']);
+        $deleted = ChirpFactory::new()->create(['content' => 'laravel scout search']);
+
+        $deleted->delete();
+
+        $this->assertCount(1, Chirp::search('laravel')->get());
+        $this->assertSame($active->getKey(), Chirp::search('laravel')->first()->getKey());
+        $this->assertCount(2, Chirp::search('laravel')->withTrashed()->get());
+        $this->assertCount(1, Chirp::search('laravel')->onlyTrashed()->get());
+        $this->assertSame($deleted->getKey(), Chirp::search('laravel')->onlyTrashed()->first()->getKey());
+    }
+}
+
+class PgsqlTestingSQLiteConnection extends SQLiteConnection
+{
+    public function getDriverName()
+    {
+        return 'pgsql';
+    }
+}

--- a/tests/Feature/PgsqlEngineTest.php
+++ b/tests/Feature/PgsqlEngineTest.php
@@ -428,7 +428,53 @@ class PgsqlEngineTest extends TestCase
         $this->app->make('config')->set('scout.pgsql.trigram.threshold', 'invalid');
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The [pgsql] Scout driver trigram threshold must be numeric.');
+        $this->expectExceptionMessage('The [pgsql] Scout driver trigram threshold must be numeric and between 0 and 1.');
+
+        $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle'), true);
+    }
+
+    public function test_trigram_threshold_accepts_zero()
+    {
+        $this->app->make('config')->set('scout.pgsql.trigram.enabled', true);
+        $this->app->make('config')->set('scout.pgsql.trigram.columns', ['name']);
+        $this->app->make('config')->set('scout.pgsql.trigram.threshold', 0);
+
+        $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle'), true);
+
+        $this->assertSame(0, $query->getBindings()[2]);
+    }
+
+    public function test_trigram_threshold_accepts_one()
+    {
+        $this->app->make('config')->set('scout.pgsql.trigram.enabled', true);
+        $this->app->make('config')->set('scout.pgsql.trigram.columns', ['name']);
+        $this->app->make('config')->set('scout.pgsql.trigram.threshold', 1);
+
+        $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle'), true);
+
+        $this->assertSame(1, $query->getBindings()[2]);
+    }
+
+    public function test_trigram_threshold_rejects_values_below_zero()
+    {
+        $this->app->make('config')->set('scout.pgsql.trigram.enabled', true);
+        $this->app->make('config')->set('scout.pgsql.trigram.columns', ['name']);
+        $this->app->make('config')->set('scout.pgsql.trigram.threshold', -0.1);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout driver trigram threshold must be numeric and between 0 and 1.');
+
+        $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle'), true);
+    }
+
+    public function test_trigram_threshold_rejects_values_above_one()
+    {
+        $this->app->make('config')->set('scout.pgsql.trigram.enabled', true);
+        $this->app->make('config')->set('scout.pgsql.trigram.columns', ['name']);
+        $this->app->make('config')->set('scout.pgsql.trigram.threshold', 1.1);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout driver trigram threshold must be numeric and between 0 and 1.');
 
         $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle'), true);
     }

--- a/tests/Feature/PgsqlEngineTest.php
+++ b/tests/Feature/PgsqlEngineTest.php
@@ -294,15 +294,35 @@ class PgsqlEngineTest extends TestCase
         $this->app->make('config')->set('scout.pgsql.trigram.enabled', true);
         $this->app->make('config')->set('scout.pgsql.trigram.columns', ['name', 'email']);
 
-        $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle'), true);
+        $engine = $this->pgsqlEngine(true);
+        $query = $engine->buildOrderedSearchQueryForTest(SearchableUser::search('laravle'));
 
         $this->assertStringContainsString('"users"."search_vector" @@ plainto_tsquery(?::regconfig, ?)', $query->toSql());
-        $this->assertStringContainsString('(set_config(\'pg_trgm.similarity_threshold\', ?::text, true) is not null and ("users"."name" % ? or "users"."email" % ?))', $query->toSql());
+        $this->assertStringContainsString('("users"."name" % ? or "users"."email" % ?)', $query->toSql());
+        $this->assertStringNotContainsString('set_config(\'pg_trgm.similarity_threshold\'', $query->toSql());
         $this->assertStringContainsString('similarity(coalesce(cast("users"."name" as text), \'\'), ?)', $query->toSql());
         $this->assertStringContainsString('similarity(coalesce(cast("users"."email" as text), \'\'), ?)', $query->toSql());
         $this->assertSame([
-            'english', 'laravle', 0.3, 'laravle', 'laravle',
+            'english', 'laravle', 'laravle', 'laravle',
             'english', 'laravle', 1.0, 'laravle', 'laravle', 0.25,
+        ], $query->getBindings());
+        $this->assertSame([0.3], $engine->appliedThresholds());
+    }
+
+    public function test_trigram_threshold_is_applied_before_trigram_predicate_execution()
+    {
+        $this->app->make('config')->set('scout.pgsql.trigram.enabled', true);
+        $this->app->make('config')->set('scout.pgsql.trigram.threshold', 0.15);
+        $this->app->make('config')->set('scout.pgsql.trigram.columns', ['name']);
+
+        $engine = $this->pgsqlEngine(true);
+        $query = $engine->buildOrderedSearchQueryForTest(SearchableUser::search('laravle'));
+
+        $this->assertStringContainsString('("users"."name" % ?)', $query->toSql());
+        $this->assertSame([0.15], $engine->appliedThresholds());
+        $this->assertSame([
+            'english', 'laravle', 'laravle',
+            'english', 'laravle', 1.0, 'laravle', 0.25,
         ], $query->getBindings());
     }
 
@@ -389,7 +409,7 @@ class PgsqlEngineTest extends TestCase
 
         $this->assertStringContainsString('order by ((ts_rank("users"."search_vector", plainto_tsquery(?::regconfig, ?)) * ?) + (greatest(similarity(coalesce(cast("users"."name" as text), \'\'), ?), similarity(coalesce(cast("users"."email" as text), \'\'), ?)) * ?)) desc', $query->toSql());
         $this->assertSame([
-            'english', 'laravle', 0.3, 'laravle', 'laravle',
+            'english', 'laravle', 'laravle', 'laravle',
             'english', 'laravle', 1.5, 'laravle', 'laravle', 0.5,
         ], $query->getBindings());
     }
@@ -412,9 +432,11 @@ class PgsqlEngineTest extends TestCase
         $this->app->make('config')->set('scout.pgsql.trigram.columns', ['name']);
         $this->app->make('config')->set('scout.pgsql.trigram.threshold', 0);
 
-        $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle'), true);
+        $engine = $this->pgsqlEngine(true);
 
-        $this->assertSame(0, $query->getBindings()[2]);
+        $engine->buildOrderedSearchQueryForTest(SearchableUser::search('laravle'));
+
+        $this->assertSame([0], $engine->appliedThresholds());
     }
 
     public function test_trigram_threshold_accepts_one()
@@ -423,9 +445,11 @@ class PgsqlEngineTest extends TestCase
         $this->app->make('config')->set('scout.pgsql.trigram.columns', ['name']);
         $this->app->make('config')->set('scout.pgsql.trigram.threshold', 1);
 
-        $query = $this->buildOrderedPgsqlSearchQuery(SearchableUser::search('laravle'), true);
+        $engine = $this->pgsqlEngine(true);
 
-        $this->assertSame(1, $query->getBindings()[2]);
+        $engine->buildOrderedSearchQueryForTest(SearchableUser::search('laravle'));
+
+        $this->assertSame([1], $engine->appliedThresholds());
     }
 
     public function test_trigram_threshold_rejects_values_below_zero()
@@ -512,12 +536,19 @@ class PgsqlEngineTest extends TestCase
 
     protected function buildOrderedPgsqlSearchQuery($builder, $trigramAvailable = null)
     {
-        return (new InspectablePgsqlEngine($this->app->make('config')->get('scout.pgsql'), $trigramAvailable))->buildOrderedSearchQueryForTest($builder);
+        return $this->pgsqlEngine($trigramAvailable)->buildOrderedSearchQueryForTest($builder);
+    }
+
+    protected function pgsqlEngine($trigramAvailable = null)
+    {
+        return new InspectablePgsqlEngine($this->app->make('config')->get('scout.pgsql'), $trigramAvailable);
     }
 }
 
 class InspectablePgsqlEngine extends PgsqlEngine
 {
+    protected array $appliedThresholds = [];
+
     public function __construct(array $config, protected $trigramAvailable = null)
     {
         parent::__construct($config);
@@ -533,15 +564,25 @@ class InspectablePgsqlEngine extends PgsqlEngine
         return $this->orderSearchQuery($builder, $this->buildSearchQuery($builder));
     }
 
+    public function appliedThresholds()
+    {
+        return $this->appliedThresholds;
+    }
+
+    public function recordAppliedThreshold($threshold)
+    {
+        $this->appliedThresholds[] = $threshold;
+    }
+
     protected function trigram()
     {
         if (is_null($this->trigramAvailable)) {
             return parent::trigram();
         }
 
-        return $this->trigram ??= new class($this->config, $this->trigramAvailable) extends Trigram
+        return $this->trigram ??= new class($this->config, $this->trigramAvailable, $this) extends Trigram
         {
-            public function __construct(array $config, protected bool $available)
+            public function __construct(array $config, protected bool $available, protected InspectablePgsqlEngine $engine)
             {
                 parent::__construct($config);
             }
@@ -549,6 +590,11 @@ class InspectablePgsqlEngine extends PgsqlEngine
             public function available(Builder $builder)
             {
                 return $this->available;
+            }
+
+            public function applyThreshold(Builder $builder)
+            {
+                $this->engine->recordAppliedThreshold($this->threshold());
             }
         };
     }

--- a/tests/Feature/PgsqlEngineTest.php
+++ b/tests/Feature/PgsqlEngineTest.php
@@ -231,6 +231,62 @@ class PgsqlEngineTest extends TestCase
         $this->buildPgsqlSearchQuery(SearchableUser::search('laravel'));
     }
 
+    public function test_search_vector_expression_uses_default_column_weights()
+    {
+        $expression = $this->buildPgsqlSearchVectorExpression(SearchableUser::search('laravel'));
+
+        $this->assertStringContainsString('setweight(to_tsvector(\'english\', coalesce(cast("users"."id" as text), \'\')), \'D\')', $expression);
+        $this->assertStringContainsString('setweight(to_tsvector(\'english\', coalesce(cast("users"."name" as text), \'\')), \'D\')', $expression);
+        $this->assertStringContainsString('setweight(to_tsvector(\'english\', coalesce(cast("users"."email" as text), \'\')), \'D\')', $expression);
+        $this->assertStringContainsString('setweight(to_tsvector(\'english\', coalesce(cast("users"."age" as text), \'\')), \'D\')', $expression);
+    }
+
+    public function test_search_vector_expression_uses_configured_column_weights()
+    {
+        $this->app->make('config')->set('scout.pgsql.column_weights', [
+            'name' => 'A',
+            'email' => 'B',
+            'age' => 'C',
+        ]);
+
+        $expression = $this->buildPgsqlSearchVectorExpression(SearchableUser::search('laravel'));
+
+        $this->assertStringContainsString('setweight(to_tsvector(\'english\', coalesce(cast("users"."name" as text), \'\')), \'A\')', $expression);
+        $this->assertStringContainsString('setweight(to_tsvector(\'english\', coalesce(cast("users"."email" as text), \'\')), \'B\')', $expression);
+        $this->assertStringContainsString('setweight(to_tsvector(\'english\', coalesce(cast("users"."age" as text), \'\')), \'C\')', $expression);
+        $this->assertStringContainsString('setweight(to_tsvector(\'english\', coalesce(cast("users"."id" as text), \'\')), \'D\')', $expression);
+    }
+
+    public function test_invalid_pgsql_column_weight_fails_clearly()
+    {
+        $this->app->make('config')->set('scout.pgsql.column_weights', [
+            'name' => 'Z',
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout driver column weight for [name] must be one of: A, B, C, D.');
+
+        $this->buildPgsqlSearchVectorExpression(SearchableUser::search('laravel'));
+    }
+
+    public function test_search_vector_expression_uses_only_searchable_array_fields()
+    {
+        $_ENV['user.toSearchableArray'] = fn () => [
+            'name' => 'Taylor Otwell',
+        ];
+
+        try {
+            $expression = $this->buildPgsqlSearchVectorExpression(SearchableUser::search('laravel'));
+        } finally {
+            unset($_ENV['user.toSearchableArray']);
+        }
+
+        $this->assertStringContainsString('"users"."name"', $expression);
+        $this->assertStringNotContainsString('"users"."id"', $expression);
+        $this->assertStringNotContainsString('"users"."email"', $expression);
+        $this->assertStringNotContainsString('"users"."age"', $expression);
+    }
+
     public function test_it_applies_soft_delete_constraints()
     {
         $this->app->make('config')->set('scout.soft_delete', true);
@@ -256,6 +312,11 @@ class PgsqlEngineTest extends TestCase
     {
         return (new InspectablePgsqlEngine($this->app->make('config')->get('scout.pgsql')))->buildOrderedSearchQueryForTest($builder);
     }
+
+    protected function buildPgsqlSearchVectorExpression($builder)
+    {
+        return (new InspectablePgsqlEngine($this->app->make('config')->get('scout.pgsql')))->buildSearchVectorExpressionForTest($builder);
+    }
 }
 
 class InspectablePgsqlEngine extends PgsqlEngine
@@ -268,6 +329,11 @@ class InspectablePgsqlEngine extends PgsqlEngine
     public function buildOrderedSearchQueryForTest(Builder $builder)
     {
         return $this->orderSearchQuery($builder, $this->buildSearchQuery($builder));
+    }
+
+    public function buildSearchVectorExpressionForTest(Builder $builder)
+    {
+        return $this->searchVectorExpression($builder);
     }
 }
 

--- a/tests/Feature/PgsqlEngineTest.php
+++ b/tests/Feature/PgsqlEngineTest.php
@@ -680,6 +680,10 @@ class PgsqlIntegerScoutKeyDocument extends Model
 
     protected $guarded = [];
 
+    protected $casts = [
+        'external_id' => 'integer',
+    ];
+
     protected $table = 'external_documents';
 
     public function getScoutKey()

--- a/tests/Feature/PgsqlSchemaHelperTest.php
+++ b/tests/Feature/PgsqlSchemaHelperTest.php
@@ -476,7 +476,9 @@ class PgsqlSchemaHelperTest extends TestCase
             return $blueprint->toSql();
         }
 
-        $blueprint = new Blueprint('posts', $callback, $connection->getTablePrefix());
+        $blueprint = new Blueprint('posts', null, $connection->getTablePrefix());
+        $blueprint->connection = $connection;
+        $callback($blueprint);
 
         return $blueprint->toSql($connection, $connection->getSchemaGrammar());
     }

--- a/tests/Feature/PgsqlSchemaHelperTest.php
+++ b/tests/Feature/PgsqlSchemaHelperTest.php
@@ -63,6 +63,34 @@ class PgsqlSchemaHelperTest extends TestCase
         $this->assertContains('create index "posts_search_vector_index" on "posts" using gin ("search_vector")', $sql);
     }
 
+    public function test_searchable_helper_uses_configured_column_weights()
+    {
+        $this->app['config']->set('scout.pgsql.column_weights', [
+            'title' => 'A',
+            'body' => 'B',
+        ]);
+
+        $sql = $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable(['title', 'body']);
+        });
+
+        $this->assertContains('alter table "posts" add column "search_vector" tsvector not null generated always as (setweight(to_tsvector(\'english\', coalesce(cast("title" as text), \'\')), \'A\') || setweight(to_tsvector(\'english\', coalesce(cast("body" as text), \'\')), \'B\')) stored', $sql);
+    }
+
+    public function test_searchable_helper_rejects_invalid_configured_column_weights()
+    {
+        $this->app['config']->set('scout.pgsql.column_weights', [
+            'title' => 'Z',
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout schema helper column weight for [title] must be one of: A, B, C, D.');
+
+        $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable(['title']);
+        });
+    }
+
     public function test_searchable_helper_accepts_schema_qualified_languages()
     {
         $sql = $this->compilePgsqlBlueprint(function ($table) {

--- a/tests/Feature/PgsqlSchemaHelperTest.php
+++ b/tests/Feature/PgsqlSchemaHelperTest.php
@@ -97,6 +97,16 @@ class PgsqlSchemaHelperTest extends TestCase
         });
     }
 
+    public function test_searchable_helper_rejects_empty_searchable_columns()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout schema helper searchable columns must not be empty.');
+
+        $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable([]);
+        });
+    }
+
     public function test_searchable_helper_rejects_invalid_trigram_columns()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -172,6 +182,21 @@ class PgsqlSchemaHelperTest extends TestCase
         $this->assertContains('create index "posts_title_trigram_index" on "posts" using gin ("title" gin_trgm_ops)', $sql);
     }
 
+    public function test_searchable_helper_creates_prefixed_trigram_indexes()
+    {
+        $sql = $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable(['title', 'body'], [
+                'trigram' => [
+                    'columns' => ['title'],
+                ],
+            ]);
+        }, $this->makePgsqlConnection([
+            'prefix_indexes' => true,
+        ], 'prefix_'));
+
+        $this->assertContains('create index "prefix_posts_title_trigram_index" on "prefix_posts" using gin ("title" gin_trgm_ops)', $sql);
+    }
+
     public function test_drop_searchable_helper_drops_generated_vector_index_and_column()
     {
         $sql = $this->compilePgsqlBlueprint(function ($table) {
@@ -240,6 +265,23 @@ class PgsqlSchemaHelperTest extends TestCase
         $this->assertContains('drop index "posts_search_vector_index"', $sql);
         $this->assertContains('drop index "posts_title_trigram_index"', $sql);
         $this->assertContains('alter table "posts" drop column "search_vector"', $sql);
+    }
+
+    public function test_drop_searchable_helper_drops_prefixed_trigram_indexes()
+    {
+        $sql = $this->compilePgsqlBlueprint(function ($table) {
+            $table->dropSearchable([
+                'trigram' => [
+                    'columns' => ['title'],
+                ],
+            ]);
+        }, $this->makePgsqlConnection([
+            'prefix_indexes' => true,
+        ], 'prefix_'));
+
+        $this->assertContains('drop index "prefix_posts_search_vector_index"', $sql);
+        $this->assertContains('drop index "prefix_posts_title_trigram_index"', $sql);
+        $this->assertContains('alter table "prefix_posts" drop column "search_vector"', $sql);
     }
 
     public function test_searchable_helper_rejects_non_postgresql_connections()

--- a/tests/Feature/PgsqlSchemaHelperTest.php
+++ b/tests/Feature/PgsqlSchemaHelperTest.php
@@ -52,6 +52,91 @@ class PgsqlSchemaHelperTest extends TestCase
         $this->assertContains('create index "posts_search_vector_index" on "posts" using gin ("search_vector")', $sql);
     }
 
+    public function test_searchable_helper_accepts_schema_qualified_languages()
+    {
+        $sql = $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable(['title'], [
+                'language' => 'pg_catalog.english',
+            ]);
+        });
+
+        $this->assertContains('alter table "posts" add column "search_vector" tsvector not null generated always as (setweight(to_tsvector(\'pg_catalog.english\', coalesce(cast("title" as text), \'\')), \'D\')) stored', $sql);
+    }
+
+    public function test_searchable_helper_rejects_invalid_languages()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout schema helper language must be a valid PostgreSQL text search configuration name.');
+
+        $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable(['title'], [
+                'language' => 'english; --',
+            ]);
+        });
+    }
+
+    public function test_searchable_helper_rejects_invalid_vector_columns()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout schema helper vector column must be a valid column name.');
+
+        $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable(['title'], [
+                'vector_column' => 'search_vector) desc; --',
+            ]);
+        });
+    }
+
+    public function test_searchable_helper_rejects_invalid_searchable_columns()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout schema helper searchable column [title; --] must be a valid column name.');
+
+        $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable(['title; --']);
+        });
+    }
+
+    public function test_searchable_helper_rejects_invalid_trigram_columns()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout schema helper trigram column [title; --] must be a valid column name.');
+
+        $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable(['title'], [
+                'trigram' => [
+                    'columns' => ['title; --'],
+                ],
+            ]);
+        });
+    }
+
+    public function test_searchable_helper_rejects_non_array_column_weights()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout schema helper column weights must be an array.');
+
+        $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable(['title'], [
+                'weights' => 'invalid',
+            ]);
+        });
+    }
+
+    public function test_searchable_helper_rejects_invalid_column_weights()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout schema helper column weight for [title] must be one of: A, B, C, D.');
+
+        $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable(['title'], [
+                'weights' => [
+                    'title' => 'Z',
+                ],
+            ]);
+        });
+    }
+
     public function test_searchable_helper_can_create_trigram_extension()
     {
         $sql = $this->compilePgsqlBlueprint(function ($table) {
@@ -97,6 +182,24 @@ class PgsqlSchemaHelperTest extends TestCase
         $this->assertContains('alter table "posts" drop column "search_vector"', $sql);
     }
 
+    public function test_drop_searchable_helper_drops_prefixed_default_vector_index()
+    {
+        $connection = $this->makePgsqlConnection([
+            'prefix_indexes' => true,
+        ], 'prefix_');
+
+        $createSql = $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable(['title']);
+        }, $connection);
+
+        $dropSql = $this->compilePgsqlBlueprint(function ($table) {
+            $table->dropSearchable();
+        }, $connection);
+
+        $this->assertContains('create index "prefix_posts_search_vector_index" on "prefix_posts" using gin ("search_vector")', $createSql);
+        $this->assertContains('drop index "prefix_posts_search_vector_index"', $dropSql);
+    }
+
     public function test_drop_searchable_helper_uses_configured_vector_column_and_index()
     {
         $sql = $this->compilePgsqlBlueprint(function ($table) {
@@ -108,6 +211,20 @@ class PgsqlSchemaHelperTest extends TestCase
 
         $this->assertContains('drop index "posts_document_vector_index"', $sql);
         $this->assertContains('alter table "posts" drop column "document_vector"', $sql);
+    }
+
+    public function test_drop_searchable_helper_drops_custom_index_name_unchanged_with_prefixed_indexes()
+    {
+        $sql = $this->compilePgsqlBlueprint(function ($table) {
+            $table->dropSearchable([
+                'index' => 'custom_search_vector_index',
+            ]);
+        }, $this->makePgsqlConnection([
+            'prefix_indexes' => true,
+        ], 'prefix_'));
+
+        $this->assertContains('drop index "custom_search_vector_index"', $sql);
+        $this->assertNotContains('drop index "prefix_custom_search_vector_index"', $sql);
     }
 
     public function test_drop_searchable_helper_drops_trigram_indexes()
@@ -153,12 +270,21 @@ class PgsqlSchemaHelperTest extends TestCase
         }))->toSql();
     }
 
-    protected function compilePgsqlBlueprint($callback)
+    protected function compilePgsqlBlueprint($callback, $connection = null)
     {
-        $connection = new PostgresConnection(new PDO('sqlite::memory:'), 'database', '', ['driver' => 'pgsql']);
+        $connection ??= $this->makePgsqlConnection();
+
+        return (new Blueprint($connection, 'posts', $callback))->toSql();
+    }
+
+    protected function makePgsqlConnection(array $config = [], $prefix = '')
+    {
+        $connection = new PostgresConnection(new PDO('sqlite::memory:'), 'database', $prefix, array_merge([
+            'driver' => 'pgsql',
+        ], $config));
 
         $connection->useDefaultSchemaGrammar();
 
-        return (new Blueprint($connection, 'posts', $callback))->toSql();
+        return $connection;
     }
 }

--- a/tests/Feature/PgsqlSchemaHelperTest.php
+++ b/tests/Feature/PgsqlSchemaHelperTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Laravel\Scout\Tests\Feature;
+
+use Illuminate\Database\PostgresConnection;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\SQLiteConnection;
+use InvalidArgumentException;
+use Laravel\Scout\ScoutServiceProvider;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+use PDO;
+
+class PgsqlSchemaHelperTest extends TestCase
+{
+    use WithWorkbench;
+
+    protected function defineEnvironment($app)
+    {
+        $app['config']->set('scout.driver', 'pgsql');
+    }
+
+    public function test_searchable_blueprint_macro_is_registered()
+    {
+        $this->assertTrue(Blueprint::hasMacro('searchable'));
+    }
+
+    public function test_searchable_blueprint_macro_is_not_registered_for_other_scout_drivers()
+    {
+        Blueprint::flushMacros();
+
+        $this->app['config']->set('scout.driver', 'collection');
+
+        $this->app->getProvider(ScoutServiceProvider::class)->boot();
+
+        $this->assertFalse(Blueprint::hasMacro('searchable'));
+    }
+
+    public function test_searchable_helper_creates_generated_vector_column_and_gin_index()
+    {
+        $sql = $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable(['title', 'body'], [
+                'weights' => [
+                    'title' => 'A',
+                ],
+            ]);
+        });
+
+        $this->assertContains('alter table "posts" add column "search_vector" tsvector not null generated always as (setweight(to_tsvector(\'english\', coalesce(cast("title" as text), \'\')), \'A\') || setweight(to_tsvector(\'english\', coalesce(cast("body" as text), \'\')), \'D\')) stored', $sql);
+        $this->assertContains('create index "posts_search_vector_index" on "posts" using gin ("search_vector")', $sql);
+    }
+
+    public function test_searchable_helper_can_create_trigram_extension()
+    {
+        $sql = $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable(['title'], [
+                'trigram' => [
+                    'extension' => [
+                        'create' => true,
+                    ],
+                ],
+            ]);
+        });
+
+        $this->assertContains('create extension if not exists "pg_trgm"', $sql);
+    }
+
+    public function test_searchable_helper_skips_trigram_extension_when_disabled()
+    {
+        $sql = $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable(['title']);
+        });
+
+        $this->assertNotContains('create extension if not exists "pg_trgm"', $sql);
+    }
+
+    public function test_searchable_helper_creates_trigram_indexes()
+    {
+        $sql = $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable(['title', 'body'], [
+                'trigram' => [
+                    'columns' => ['title'],
+                ],
+            ]);
+        });
+
+        $this->assertContains('create index "posts_title_trigram_index" on "posts" using gin ("title" gin_trgm_ops)', $sql);
+    }
+
+    public function test_searchable_helper_rejects_non_postgresql_connections()
+    {
+        $connection = new SQLiteConnection(new PDO('sqlite::memory:'), ':memory:', '', []);
+
+        $connection->useDefaultSchemaGrammar();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout schema helper may only be used with PostgreSQL connections.');
+
+        (new Blueprint($connection, 'posts', function ($table) {
+            $table->searchable(['title']);
+        }))->toSql();
+    }
+
+    protected function compilePgsqlBlueprint($callback)
+    {
+        $connection = new PostgresConnection(new PDO('sqlite::memory:'), 'database', '', ['driver' => 'pgsql']);
+
+        $connection->useDefaultSchemaGrammar();
+
+        return (new Blueprint($connection, 'posts', $callback))->toSql();
+    }
+}

--- a/tests/Feature/PgsqlSchemaHelperTest.php
+++ b/tests/Feature/PgsqlSchemaHelperTest.php
@@ -5,6 +5,7 @@ namespace Laravel\Scout\Tests\Feature;
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\SQLiteConnection;
+use Illuminate\Support\Facades\Schema;
 use InvalidArgumentException;
 use Laravel\Scout\ScoutServiceProvider;
 use Orchestra\Testbench\Concerns\WithWorkbench;
@@ -19,6 +20,16 @@ class PgsqlSchemaHelperTest extends TestCase
     protected function defineEnvironment($app)
     {
         $app['config']->set('scout.driver', 'pgsql');
+        $app['config']->set('database.default', 'testing');
+        $app['config']->set('database.connections.pgsql_schema', [
+            'driver' => 'testing-pgsql-schema',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        $app['db']->extend('testing-pgsql-schema', function ($config) {
+            return new PgsqlSchemaHelperTestingConnection(new PDO('sqlite::memory:'), $config['database'], $config['prefix'], $config);
+        });
     }
 
     public function test_searchable_blueprint_macro_is_registered()
@@ -64,6 +75,33 @@ class PgsqlSchemaHelperTest extends TestCase
         $this->assertContains('create index "posts_search_vector_index" on "posts" using gin ("search_vector")', $sql);
     }
 
+    public function test_searchable_helper_uses_configured_vector_column()
+    {
+        $this->app['config']->set('scout.pgsql.vector_column', 'document_vector');
+
+        $sql = $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable(['title']);
+        });
+
+        $this->assertContains('alter table "posts" add column "document_vector" tsvector not null generated always as (setweight(to_tsvector(\'english\', coalesce(cast("title" as text), \'\')), \'D\')) stored', $sql);
+        $this->assertContains('create index "posts_document_vector_index" on "posts" using gin ("document_vector")', $sql);
+    }
+
+    public function test_searchable_helper_ignores_per_call_vector_column_and_language_options()
+    {
+        $sql = $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable(['title'], [
+                'language' => 'simple',
+                'vector_column' => 'document_vector',
+            ]);
+        });
+
+        $this->assertContains('alter table "posts" add column "search_vector" tsvector not null generated always as (setweight(to_tsvector(\'english\', coalesce(cast("title" as text), \'\')), \'D\')) stored', $sql);
+        $this->assertContains('create index "posts_search_vector_index" on "posts" using gin ("search_vector")', $sql);
+        $this->assertStringNotContainsString('document_vector', implode('\n', $sql));
+        $this->assertStringNotContainsString('simple', implode('\n', $sql));
+    }
+
     public function test_searchable_helper_uses_configured_column_weights()
     {
         $this->app['config']->set('scout.pgsql.column_weights', [
@@ -94,10 +132,10 @@ class PgsqlSchemaHelperTest extends TestCase
 
     public function test_searchable_helper_accepts_schema_qualified_languages()
     {
+        $this->app['config']->set('scout.pgsql.language', 'pg_catalog.english');
+
         $sql = $this->compilePgsqlBlueprint(function ($table) {
-            $table->searchable(['title'], [
-                'language' => 'pg_catalog.english',
-            ]);
+            $table->searchable(['title']);
         });
 
         $this->assertContains('alter table "posts" add column "search_vector" tsvector not null generated always as (setweight(to_tsvector(\'pg_catalog.english\', coalesce(cast("title" as text), \'\')), \'D\')) stored', $sql);
@@ -105,37 +143,37 @@ class PgsqlSchemaHelperTest extends TestCase
 
     public function test_searchable_helper_rejects_invalid_languages()
     {
+        $this->app['config']->set('scout.pgsql.language', 'english; --');
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The [pgsql] Scout schema helper language must be a valid PostgreSQL text search configuration name.');
 
         $this->compilePgsqlBlueprint(function ($table) {
-            $table->searchable(['title'], [
-                'language' => 'english; --',
-            ]);
+            $table->searchable(['title']);
         });
     }
 
     public function test_searchable_helper_rejects_invalid_vector_columns()
     {
+        $this->app['config']->set('scout.pgsql.vector_column', 'search_vector) desc; --');
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The [pgsql] Scout schema helper vector column must be a valid column name.');
 
         $this->compilePgsqlBlueprint(function ($table) {
-            $table->searchable(['title'], [
-                'vector_column' => 'search_vector) desc; --',
-            ]);
+            $table->searchable(['title']);
         });
     }
 
     public function test_searchable_helper_rejects_schema_qualified_vector_columns()
     {
+        $this->app['config']->set('scout.pgsql.vector_column', 'foo.bar');
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The [pgsql] Scout schema helper vector column must be a valid column name.');
 
         $this->compilePgsqlBlueprint(function ($table) {
-            $table->searchable(['title'], [
-                'vector_column' => 'foo.bar',
-            ]);
+            $table->searchable(['title']);
         });
     }
 
@@ -344,9 +382,10 @@ class PgsqlSchemaHelperTest extends TestCase
 
     public function test_drop_searchable_helper_uses_configured_vector_column_and_index()
     {
+        $this->app['config']->set('scout.pgsql.vector_column', 'document_vector');
+
         $sql = $this->compilePgsqlBlueprint(function ($table) {
             $table->dropSearchable([
-                'vector_column' => 'document_vector',
                 'index' => 'posts_document_vector_index',
             ]);
         });
@@ -430,6 +469,40 @@ class PgsqlSchemaHelperTest extends TestCase
         $this->assertContains('alter table "prefix_posts" drop column "search_vector"', $sql);
     }
 
+    public function test_searchable_helper_uses_named_schema_connection_when_default_connection_is_not_postgresql()
+    {
+        Schema::connection('pgsql_schema')->table('posts', function (Blueprint $table) {
+            $table->searchable(['title']);
+        });
+
+        $statements = $this->app['db']->connection('pgsql_schema')->statements;
+
+        $this->assertContains('alter table "posts" add column "search_vector" tsvector not null generated always as (setweight(to_tsvector(\'english\', coalesce(cast("title" as text), \'\')), \'D\')) stored', $statements);
+        $this->assertContains('create index "posts_search_vector_index" on "posts" using gin ("search_vector")', $statements);
+    }
+
+    public function test_drop_searchable_helper_uses_named_schema_connection_when_default_connection_is_not_postgresql()
+    {
+        Schema::connection('pgsql_schema')->table('posts', function (Blueprint $table) {
+            $table->dropSearchable();
+        });
+
+        $statements = $this->app['db']->connection('pgsql_schema')->statements;
+
+        $this->assertContains('drop index "posts_search_vector_index"', $statements);
+        $this->assertContains('alter table "posts" drop column "search_vector"', $statements);
+    }
+
+    public function test_searchable_helper_rejects_real_non_postgresql_schema_connections()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout schema helper may only be used with PostgreSQL connections.');
+
+        Schema::connection('testing')->table('posts', function (Blueprint $table) {
+            $table->searchable(['title']);
+        });
+    }
+
     public function test_searchable_helper_rejects_non_postgresql_connections()
     {
         $connection = new SQLiteConnection(new PDO('sqlite::memory:'), ':memory:', '', []);
@@ -492,5 +565,22 @@ class PgsqlSchemaHelperTest extends TestCase
         $connection->useDefaultSchemaGrammar();
 
         return $connection;
+    }
+}
+
+class PgsqlSchemaHelperTestingConnection extends PostgresConnection
+{
+    public array $statements = [];
+
+    public function getDriverName()
+    {
+        return 'pgsql';
+    }
+
+    public function statement($query, $bindings = [])
+    {
+        $this->statements[] = $query;
+
+        return true;
     }
 }

--- a/tests/Feature/PgsqlSchemaHelperTest.php
+++ b/tests/Feature/PgsqlSchemaHelperTest.php
@@ -10,6 +10,7 @@ use Laravel\Scout\ScoutServiceProvider;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
 use PDO;
+use ReflectionClass;
 
 class PgsqlSchemaHelperTest extends TestCase
 {
@@ -438,9 +439,9 @@ class PgsqlSchemaHelperTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The [pgsql] Scout schema helper may only be used with PostgreSQL connections.');
 
-        (new Blueprint($connection, 'posts', function ($table) {
+        $this->toSql($connection, function ($table) {
             $table->searchable(['title']);
-        }))->toSql();
+        });
     }
 
     public function test_drop_searchable_helper_rejects_non_postgresql_connections()
@@ -452,16 +453,32 @@ class PgsqlSchemaHelperTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The [pgsql] Scout schema helper may only be used with PostgreSQL connections.');
 
-        (new Blueprint($connection, 'posts', function ($table) {
+        $this->toSql($connection, function ($table) {
             $table->dropSearchable();
-        }))->toSql();
+        });
     }
 
     protected function compilePgsqlBlueprint($callback, $connection = null)
     {
         $connection ??= $this->makePgsqlConnection();
 
-        return (new Blueprint($connection, 'posts', $callback))->toSql();
+        return $this->toSql($connection, $callback);
+    }
+
+    protected function toSql($connection, $callback)
+    {
+        $ref = new ReflectionClass(Blueprint::class);
+        $params = $ref->getConstructor()->getParameters();
+
+        if ($params[0]->getName() === 'connection') {
+            $blueprint = new Blueprint($connection, 'posts', $callback);
+
+            return $blueprint->toSql();
+        }
+
+        $blueprint = new Blueprint('posts', $callback, $connection->getTablePrefix());
+
+        return $blueprint->toSql($connection, $connection->getSchemaGrammar());
     }
 
     protected function makePgsqlConnection(array $config = [], $prefix = '')

--- a/tests/Feature/PgsqlSchemaHelperTest.php
+++ b/tests/Feature/PgsqlSchemaHelperTest.php
@@ -23,6 +23,7 @@ class PgsqlSchemaHelperTest extends TestCase
     public function test_searchable_blueprint_macro_is_registered()
     {
         $this->assertTrue(Blueprint::hasMacro('searchable'));
+        $this->assertTrue(Blueprint::hasMacro('dropSearchable'));
     }
 
     public function test_searchable_blueprint_macro_is_not_registered_for_other_scout_drivers()
@@ -34,6 +35,7 @@ class PgsqlSchemaHelperTest extends TestCase
         $this->app->getProvider(ScoutServiceProvider::class)->boot();
 
         $this->assertFalse(Blueprint::hasMacro('searchable'));
+        $this->assertFalse(Blueprint::hasMacro('dropSearchable'));
     }
 
     public function test_searchable_helper_creates_generated_vector_column_and_gin_index()
@@ -55,9 +57,7 @@ class PgsqlSchemaHelperTest extends TestCase
         $sql = $this->compilePgsqlBlueprint(function ($table) {
             $table->searchable(['title'], [
                 'trigram' => [
-                    'extension' => [
-                        'create' => true,
-                    ],
+                    'create_extension' => true,
                 ],
             ]);
         });
@@ -87,6 +87,44 @@ class PgsqlSchemaHelperTest extends TestCase
         $this->assertContains('create index "posts_title_trigram_index" on "posts" using gin ("title" gin_trgm_ops)', $sql);
     }
 
+    public function test_drop_searchable_helper_drops_generated_vector_index_and_column()
+    {
+        $sql = $this->compilePgsqlBlueprint(function ($table) {
+            $table->dropSearchable();
+        });
+
+        $this->assertContains('drop index "posts_search_vector_index"', $sql);
+        $this->assertContains('alter table "posts" drop column "search_vector"', $sql);
+    }
+
+    public function test_drop_searchable_helper_uses_configured_vector_column_and_index()
+    {
+        $sql = $this->compilePgsqlBlueprint(function ($table) {
+            $table->dropSearchable([
+                'vector_column' => 'document_vector',
+                'index' => 'posts_document_vector_index',
+            ]);
+        });
+
+        $this->assertContains('drop index "posts_document_vector_index"', $sql);
+        $this->assertContains('alter table "posts" drop column "document_vector"', $sql);
+    }
+
+    public function test_drop_searchable_helper_drops_trigram_indexes()
+    {
+        $sql = $this->compilePgsqlBlueprint(function ($table) {
+            $table->dropSearchable([
+                'trigram' => [
+                    'columns' => ['title'],
+                ],
+            ]);
+        });
+
+        $this->assertContains('drop index "posts_search_vector_index"', $sql);
+        $this->assertContains('drop index "posts_title_trigram_index"', $sql);
+        $this->assertContains('alter table "posts" drop column "search_vector"', $sql);
+    }
+
     public function test_searchable_helper_rejects_non_postgresql_connections()
     {
         $connection = new SQLiteConnection(new PDO('sqlite::memory:'), ':memory:', '', []);
@@ -98,6 +136,20 @@ class PgsqlSchemaHelperTest extends TestCase
 
         (new Blueprint($connection, 'posts', function ($table) {
             $table->searchable(['title']);
+        }))->toSql();
+    }
+
+    public function test_drop_searchable_helper_rejects_non_postgresql_connections()
+    {
+        $connection = new SQLiteConnection(new PDO('sqlite::memory:'), ':memory:', '', []);
+
+        $connection->useDefaultSchemaGrammar();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout schema helper may only be used with PostgreSQL connections.');
+
+        (new Blueprint($connection, 'posts', function ($table) {
+            $table->dropSearchable();
         }))->toSql();
     }
 

--- a/tests/Feature/PgsqlSchemaHelperTest.php
+++ b/tests/Feature/PgsqlSchemaHelperTest.php
@@ -45,9 +45,9 @@ class PgsqlSchemaHelperTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The [pgsql] Scout schema helper may only be used with PostgreSQL connections.');
 
-        (new Blueprint($connection, 'posts', function ($table) {
+        $this->toSql($connection, function ($table) {
             $table->searchable(['title']);
-        }))->toSql();
+        });
     }
 
     public function test_searchable_helper_creates_generated_vector_column_and_gin_index()

--- a/tests/Feature/PgsqlSchemaHelperTest.php
+++ b/tests/Feature/PgsqlSchemaHelperTest.php
@@ -26,7 +26,7 @@ class PgsqlSchemaHelperTest extends TestCase
         $this->assertTrue(Blueprint::hasMacro('dropSearchable'));
     }
 
-    public function test_searchable_blueprint_macro_is_not_registered_for_other_scout_drivers()
+    public function test_searchable_blueprint_macro_is_registered_for_other_scout_drivers()
     {
         Blueprint::flushMacros();
 
@@ -34,8 +34,19 @@ class PgsqlSchemaHelperTest extends TestCase
 
         $this->app->getProvider(ScoutServiceProvider::class)->boot();
 
-        $this->assertFalse(Blueprint::hasMacro('searchable'));
-        $this->assertFalse(Blueprint::hasMacro('dropSearchable'));
+        $this->assertTrue(Blueprint::hasMacro('searchable'));
+        $this->assertTrue(Blueprint::hasMacro('dropSearchable'));
+
+        $connection = new SQLiteConnection(new PDO('sqlite::memory:'), ':memory:', '', []);
+
+        $connection->useDefaultSchemaGrammar();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout schema helper may only be used with PostgreSQL connections.');
+
+        (new Blueprint($connection, 'posts', function ($table) {
+            $table->searchable(['title']);
+        }))->toSql();
     }
 
     public function test_searchable_helper_creates_generated_vector_column_and_gin_index()
@@ -87,6 +98,18 @@ class PgsqlSchemaHelperTest extends TestCase
         });
     }
 
+    public function test_searchable_helper_rejects_schema_qualified_vector_columns()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout schema helper vector column must be a valid column name.');
+
+        $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable(['title'], [
+                'vector_column' => 'foo.bar',
+            ]);
+        });
+    }
+
     public function test_searchable_helper_rejects_invalid_searchable_columns()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -94,6 +117,16 @@ class PgsqlSchemaHelperTest extends TestCase
 
         $this->compilePgsqlBlueprint(function ($table) {
             $table->searchable(['title; --']);
+        });
+    }
+
+    public function test_searchable_helper_rejects_schema_qualified_searchable_columns()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout schema helper searchable column [posts.title] must be a valid column name.');
+
+        $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable(['posts.title']);
         });
     }
 
@@ -121,6 +154,20 @@ class PgsqlSchemaHelperTest extends TestCase
         });
     }
 
+    public function test_searchable_helper_rejects_schema_qualified_trigram_columns()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout schema helper trigram column [posts.title] must be a valid column name.');
+
+        $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable(['title'], [
+                'trigram' => [
+                    'columns' => ['posts.title'],
+                ],
+            ]);
+        });
+    }
+
     public function test_searchable_helper_rejects_non_array_column_weights()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -142,6 +189,20 @@ class PgsqlSchemaHelperTest extends TestCase
             $table->searchable(['title'], [
                 'weights' => [
                     'title' => 'Z',
+                ],
+            ]);
+        });
+    }
+
+    public function test_searchable_helper_rejects_schema_qualified_column_weights()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout schema helper column weight column [posts.title] must be a valid column name.');
+
+        $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable(['title'], [
+                'weights' => [
+                    'posts.title' => 'A',
                 ],
             ]);
         });
@@ -180,6 +241,33 @@ class PgsqlSchemaHelperTest extends TestCase
         });
 
         $this->assertContains('create index "posts_title_trigram_index" on "posts" using gin ("title" gin_trgm_ops)', $sql);
+    }
+
+    public function test_searchable_helper_creates_configured_trigram_indexes()
+    {
+        $this->app['config']->set('scout.pgsql.trigram.columns', ['title']);
+
+        $sql = $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable(['title', 'body']);
+        });
+
+        $this->assertContains('create index "posts_title_trigram_index" on "posts" using gin ("title" gin_trgm_ops)', $sql);
+    }
+
+    public function test_searchable_helper_trigram_options_override_configured_trigram_indexes()
+    {
+        $this->app['config']->set('scout.pgsql.trigram.columns', ['body']);
+
+        $sql = $this->compilePgsqlBlueprint(function ($table) {
+            $table->searchable(['title', 'body'], [
+                'trigram' => [
+                    'columns' => ['title'],
+                ],
+            ]);
+        });
+
+        $this->assertContains('create index "posts_title_trigram_index" on "posts" using gin ("title" gin_trgm_ops)', $sql);
+        $this->assertNotContains('create index "posts_body_trigram_index" on "posts" using gin ("body" gin_trgm_ops)', $sql);
     }
 
     public function test_searchable_helper_creates_prefixed_trigram_indexes()
@@ -265,6 +353,35 @@ class PgsqlSchemaHelperTest extends TestCase
         $this->assertContains('drop index "posts_search_vector_index"', $sql);
         $this->assertContains('drop index "posts_title_trigram_index"', $sql);
         $this->assertContains('alter table "posts" drop column "search_vector"', $sql);
+    }
+
+    public function test_drop_searchable_helper_drops_configured_trigram_indexes()
+    {
+        $this->app['config']->set('scout.pgsql.trigram.columns', ['title']);
+
+        $sql = $this->compilePgsqlBlueprint(function ($table) {
+            $table->dropSearchable();
+        });
+
+        $this->assertContains('drop index "posts_search_vector_index"', $sql);
+        $this->assertContains('drop index "posts_title_trigram_index"', $sql);
+        $this->assertContains('alter table "posts" drop column "search_vector"', $sql);
+    }
+
+    public function test_drop_searchable_helper_trigram_options_override_configured_trigram_indexes()
+    {
+        $this->app['config']->set('scout.pgsql.trigram.columns', ['body']);
+
+        $sql = $this->compilePgsqlBlueprint(function ($table) {
+            $table->dropSearchable([
+                'trigram' => [
+                    'columns' => ['title'],
+                ],
+            ]);
+        });
+
+        $this->assertContains('drop index "posts_title_trigram_index"', $sql);
+        $this->assertNotContains('drop index "posts_body_trigram_index"', $sql);
     }
 
     public function test_drop_searchable_helper_drops_prefixed_trigram_indexes()

--- a/tests/Integration/PgsqlSearchableTest.php
+++ b/tests/Integration/PgsqlSearchableTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Laravel\Scout\Tests\Integration;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Scout\Searchable;
+use Orchestra\Testbench\Attributes\RequiresEnv;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('pgsql')]
+#[RequiresEnv('SCOUT_PGSQL_TEST_DATABASE')]
+class PgsqlSearchableTest extends TestCase
+{
+    use WithWorkbench;
+
+    protected function defineEnvironment($app)
+    {
+        $app['config']->set('scout.driver', 'pgsql');
+        $app['config']->set('scout.pgsql.column_weights', [
+            'title' => 'A',
+            'body' => 'D',
+        ]);
+        $app['config']->set('database.default', 'pgsql_testing');
+        $app['config']->set('database.connections.pgsql_testing', [
+            'driver' => 'pgsql',
+            'host' => env('SCOUT_PGSQL_TEST_HOST', '127.0.0.1'),
+            'port' => env('SCOUT_PGSQL_TEST_PORT', 5432),
+            'database' => env('SCOUT_PGSQL_TEST_DATABASE'),
+            'username' => env('SCOUT_PGSQL_TEST_USERNAME', 'postgres'),
+            'password' => env('SCOUT_PGSQL_TEST_PASSWORD', ''),
+            'charset' => 'utf8',
+            'prefix' => '',
+            'schema' => 'public',
+            'sslmode' => env('SCOUT_PGSQL_TEST_SSLMODE', 'prefer'),
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->app?->bound('db.schema')) {
+            Schema::dropIfExists('scout_pgsql_posts');
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_generated_vector_index_and_ranked_search_results()
+    {
+        $this->createPostsTable();
+
+        PgsqlSearchPost::query()->create([
+            'title' => 'Laravel Scout',
+            'body' => 'Native PostgreSQL search driver',
+        ]);
+        PgsqlSearchPost::query()->create([
+            'title' => 'PostgreSQL Search',
+            'body' => 'Laravel Scout uses generated search vectors',
+        ]);
+        PgsqlSearchPost::query()->create([
+            'title' => 'Queues',
+            'body' => 'Background jobs and workers',
+        ]);
+
+        $this->assertHasPgsqlIndex('scout_pgsql_posts_search_vector_index', 'USING gin (search_vector)');
+
+        $results = PgsqlSearchPost::search('laravel')->get();
+
+        $this->assertSame(['Laravel Scout', 'PostgreSQL Search'], $results->pluck('title')->all());
+
+        $page = PgsqlSearchPost::search('laravel')->paginate(1, 'page', 1);
+
+        $this->assertSame(2, $page->total());
+        $this->assertSame(['Laravel Scout'], $page->getCollection()->pluck('title')->all());
+
+        $page = PgsqlSearchPost::search('laravel')->paginate(1, 'page', 2);
+
+        $this->assertSame(['PostgreSQL Search'], $page->getCollection()->pluck('title')->all());
+    }
+
+    public function test_trigram_extension_setup_and_similarity_search()
+    {
+        if (! env('SCOUT_PGSQL_TEST_TRIGRAM', false)) {
+            $this->markTestSkipped('Set SCOUT_PGSQL_TEST_TRIGRAM=true to run pg_trgm integration coverage.');
+        }
+
+        $this->app['config']->set('scout.pgsql.trigram.enabled', true);
+        $this->app['config']->set('scout.pgsql.trigram.threshold', 0.15);
+
+        $this->createPostsTable(true);
+
+        PgsqlSearchPost::query()->create([
+            'title' => 'Laravel Scout',
+            'body' => 'Native PostgreSQL search driver',
+        ]);
+        PgsqlSearchPost::query()->create([
+            'title' => 'Queues',
+            'body' => 'Background jobs and workers',
+        ]);
+
+        $this->assertTrue($this->pgTrgmExtensionExists());
+        $this->assertHasPgsqlIndex('scout_pgsql_posts_title_trigram_index', 'gin_trgm_ops');
+
+        $results = PgsqlSearchPost::search('laravle')->get();
+
+        $this->assertSame(['Laravel Scout'], $results->pluck('title')->all());
+    }
+
+    protected function createPostsTable($withTrigram = false)
+    {
+        Schema::dropIfExists('scout_pgsql_posts');
+
+        Schema::create('scout_pgsql_posts', function (Blueprint $table) use ($withTrigram) {
+            $table->id();
+            $table->string('title');
+            $table->text('body');
+            $table->searchable(['title', 'body'], [
+                'weights' => [
+                    'title' => 'A',
+                    'body' => 'D',
+                ],
+                'trigram' => $withTrigram ? [
+                    'extension' => [
+                        'create' => true,
+                    ],
+                    'columns' => ['title'],
+                ] : [],
+            ]);
+        });
+    }
+
+    protected function assertHasPgsqlIndex($name, $definition)
+    {
+        $index = DB::table('pg_indexes')
+            ->where('schemaname', 'public')
+            ->where('tablename', 'scout_pgsql_posts')
+            ->where('indexname', $name)
+            ->value('indexdef');
+
+        $this->assertNotNull($index);
+        $this->assertStringContainsString($definition, $index);
+    }
+
+    protected function pgTrgmExtensionExists()
+    {
+        return DB::table('pg_extension')->where('extname', 'pg_trgm')->exists();
+    }
+}
+
+class PgsqlSearchPost extends Model
+{
+    use Searchable;
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    protected $table = 'scout_pgsql_posts';
+
+    public function toSearchableArray()
+    {
+        return [
+            'title' => $this->title,
+            'body' => $this->body,
+        ];
+    }
+}

--- a/tests/Integration/PgsqlSearchableTest.php
+++ b/tests/Integration/PgsqlSearchableTest.php
@@ -13,7 +13,7 @@ use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\Group;
 
 #[Group('pgsql')]
-#[RequiresEnv('SCOUT_PGSQL_TEST_DATABASE')]
+#[RequiresEnv('PGSQL_TEST_DATABASE')]
 class PgsqlSearchableTest extends TestCase
 {
     use WithWorkbench;
@@ -28,15 +28,15 @@ class PgsqlSearchableTest extends TestCase
         $app['config']->set('database.default', 'pgsql_testing');
         $app['config']->set('database.connections.pgsql_testing', [
             'driver' => 'pgsql',
-            'host' => env('SCOUT_PGSQL_TEST_HOST', '127.0.0.1'),
-            'port' => env('SCOUT_PGSQL_TEST_PORT', 5432),
-            'database' => env('SCOUT_PGSQL_TEST_DATABASE'),
-            'username' => env('SCOUT_PGSQL_TEST_USERNAME', 'postgres'),
-            'password' => env('SCOUT_PGSQL_TEST_PASSWORD', ''),
+            'host' => env('PGSQL_TEST_HOST', '127.0.0.1'),
+            'port' => env('PGSQL_TEST_PORT', 5432),
+            'database' => env('PGSQL_TEST_DATABASE'),
+            'username' => env('PGSQL_TEST_USERNAME', 'postgres'),
+            'password' => env('PGSQL_TEST_PASSWORD', ''),
             'charset' => 'utf8',
             'prefix' => '',
             'schema' => 'public',
-            'sslmode' => env('SCOUT_PGSQL_TEST_SSLMODE', 'prefer'),
+            'sslmode' => env('PGSQL_TEST_SSLMODE', 'prefer'),
         ]);
     }
 
@@ -84,8 +84,8 @@ class PgsqlSearchableTest extends TestCase
 
     public function test_trigram_extension_setup_and_similarity_search()
     {
-        if (! env('SCOUT_PGSQL_TEST_TRIGRAM', false)) {
-            $this->markTestSkipped('Set SCOUT_PGSQL_TEST_TRIGRAM=true to run pg_trgm integration coverage.');
+        if (! env('PGSQL_TEST_TRIGRAM', false)) {
+            $this->markTestSkipped('Set PGSQL_TEST_TRIGRAM=true to run pg_trgm integration coverage.');
         }
 
         $this->app['config']->set('scout.pgsql.trigram.enabled', true);
@@ -113,8 +113,8 @@ class PgsqlSearchableTest extends TestCase
 
     public function test_trigram_search_honors_non_default_threshold()
     {
-        if (! env('SCOUT_PGSQL_TEST_TRIGRAM', false)) {
-            $this->markTestSkipped('Set SCOUT_PGSQL_TEST_TRIGRAM=true to run pg_trgm integration coverage.');
+        if (! env('PGSQL_TEST_TRIGRAM', false)) {
+            $this->markTestSkipped('Set PGSQL_TEST_TRIGRAM=true to run pg_trgm integration coverage.');
         }
 
         $this->app['config']->set('scout.pgsql.trigram.enabled', true);
@@ -134,7 +134,7 @@ class PgsqlSearchableTest extends TestCase
 
     public function test_drop_searchable_removes_generated_vector_column_and_indexes()
     {
-        $withTrigram = (bool) env('SCOUT_PGSQL_TEST_TRIGRAM', false);
+        $withTrigram = (bool) env('PGSQL_TEST_TRIGRAM', false);
 
         $this->createPostsTable($withTrigram);
 

--- a/tests/Integration/PgsqlSearchableTest.php
+++ b/tests/Integration/PgsqlSearchableTest.php
@@ -44,6 +44,9 @@ class PgsqlSearchableTest extends TestCase
     {
         if ($this->app?->bound('db.schema')) {
             Schema::dropIfExists('scout_pgsql_posts');
+            Schema::connection('pgsql_testing')->dropIfExists('scout_pgsql_custom_vector_posts');
+            Schema::connection('pgsql_testing')->dropIfExists('scout_pgsql_language_posts');
+            Schema::connection('pgsql_testing')->dropIfExists('scout_pgsql_named_connection_posts');
         }
 
         parent::tearDown();
@@ -111,6 +114,65 @@ class PgsqlSearchableTest extends TestCase
         $this->assertSame(['Laravel Scout'], $results->pluck('title')->all());
     }
 
+    public function test_custom_vector_column_from_global_config()
+    {
+        $this->app['config']->set('scout.pgsql.vector_column', 'document_vector');
+
+        Schema::dropIfExists('scout_pgsql_custom_vector_posts');
+        Schema::create('scout_pgsql_custom_vector_posts', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('body');
+            $table->searchable(['title', 'body']);
+        });
+
+        PgsqlCustomVectorPost::query()->create([
+            'title' => 'Laravel Scout',
+            'body' => 'Native PostgreSQL search driver',
+        ]);
+
+        $this->assertHasPgsqlColumn('document_vector', 'scout_pgsql_custom_vector_posts');
+        $this->assertHasPgsqlIndex('scout_pgsql_custom_vector_posts_document_vector_index', 'USING gin (document_vector)', 'scout_pgsql_custom_vector_posts');
+        $this->assertSame(['Laravel Scout'], PgsqlCustomVectorPost::search('laravel')->get()->pluck('title')->all());
+    }
+
+    public function test_custom_language_from_global_config()
+    {
+        $this->app['config']->set('scout.pgsql.language', 'simple');
+
+        Schema::dropIfExists('scout_pgsql_language_posts');
+        Schema::create('scout_pgsql_language_posts', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->searchable(['title']);
+        });
+
+        PgsqlLanguagePost::query()->create([
+            'title' => 'running',
+        ]);
+
+        $this->assertSame(['running'], PgsqlLanguagePost::search('running')->get()->pluck('title')->all());
+        $this->assertSame([], PgsqlLanguagePost::search('run')->get()->pluck('title')->all());
+    }
+
+    public function test_named_postgresql_schema_connection_when_default_connection_is_not_postgresql()
+    {
+        $this->app['config']->set('database.default', 'testing');
+
+        Schema::connection('pgsql_testing')->dropIfExists('scout_pgsql_named_connection_posts');
+        Schema::connection('pgsql_testing')->create('scout_pgsql_named_connection_posts', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->searchable(['title']);
+        });
+
+        PgsqlNamedConnectionPost::query()->create([
+            'title' => 'Laravel Scout',
+        ]);
+
+        $this->assertSame(['Laravel Scout'], PgsqlNamedConnectionPost::search('laravel')->get()->pluck('title')->all());
+    }
+
     public function test_trigram_search_honors_non_default_threshold()
     {
         if (! env('PGSQL_TEST_TRIGRAM', false)) {
@@ -130,6 +192,29 @@ class PgsqlSearchableTest extends TestCase
 
         $this->assertSame(['Laravel Scout'], PgsqlSearchPost::search('laravel scout')->get()->pluck('title')->all());
         $this->assertSame([], PgsqlSearchPost::search('laravle')->get()->pluck('title')->all());
+    }
+
+    public function test_trigram_threshold_does_not_leak_between_searches()
+    {
+        if (! env('PGSQL_TEST_TRIGRAM', false)) {
+            $this->markTestSkipped('Set PGSQL_TEST_TRIGRAM=true to run pg_trgm integration coverage.');
+        }
+
+        $this->app['config']->set('scout.pgsql.trigram.enabled', true);
+        $this->app['config']->set('scout.pgsql.trigram.threshold', 0.7);
+        $this->app['config']->set('scout.pgsql.trigram.columns', ['title']);
+
+        $this->createPostsTable(true);
+
+        PgsqlSearchPost::query()->create([
+            'title' => 'Laravel Scout',
+            'body' => 'Native PostgreSQL search driver',
+        ]);
+
+        DB::select("select set_config('pg_trgm.similarity_threshold', ?::text, false)", ['0.11']);
+
+        $this->assertSame([], PgsqlSearchPost::search('laravle')->get()->pluck('title')->all());
+        $this->assertSame('0.11', $this->currentTrigramThreshold());
     }
 
     public function test_drop_searchable_removes_generated_vector_column_and_indexes()
@@ -182,11 +267,11 @@ class PgsqlSearchableTest extends TestCase
         });
     }
 
-    protected function assertHasPgsqlIndex($name, $definition)
+    protected function assertHasPgsqlIndex($name, $definition, $table = 'scout_pgsql_posts')
     {
         $index = DB::table('pg_indexes')
             ->where('schemaname', 'public')
-            ->where('tablename', 'scout_pgsql_posts')
+            ->where('tablename', $table)
             ->where('indexname', $name)
             ->value('indexdef');
 
@@ -203,11 +288,11 @@ class PgsqlSearchableTest extends TestCase
             ->exists());
     }
 
-    protected function assertHasPgsqlColumn($name)
+    protected function assertHasPgsqlColumn($name, $table = 'scout_pgsql_posts')
     {
         $this->assertTrue(DB::table('information_schema.columns')
             ->where('table_schema', 'public')
-            ->where('table_name', 'scout_pgsql_posts')
+            ->where('table_name', $table)
             ->where('column_name', $name)
             ->exists());
     }
@@ -224,6 +309,11 @@ class PgsqlSearchableTest extends TestCase
     protected function pgTrgmExtensionExists()
     {
         return DB::table('pg_extension')->where('extname', 'pg_trgm')->exists();
+    }
+
+    protected function currentTrigramThreshold()
+    {
+        return DB::selectOne("select current_setting('pg_trgm.similarity_threshold') as threshold")->threshold;
     }
 }
 
@@ -244,4 +334,34 @@ class PgsqlSearchPost extends Model
             'body' => $this->body,
         ];
     }
+}
+
+class PgsqlCustomVectorPost extends PgsqlSearchPost
+{
+    protected $table = 'scout_pgsql_custom_vector_posts';
+}
+
+class PgsqlLanguagePost extends Model
+{
+    use Searchable;
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    protected $table = 'scout_pgsql_language_posts';
+
+    public function toSearchableArray()
+    {
+        return [
+            'title' => $this->title,
+        ];
+    }
+}
+
+class PgsqlNamedConnectionPost extends PgsqlLanguagePost
+{
+    protected $connection = 'pgsql_testing';
+
+    protected $table = 'scout_pgsql_named_connection_posts';
 }

--- a/tests/Integration/PgsqlSearchableTest.php
+++ b/tests/Integration/PgsqlSearchableTest.php
@@ -90,6 +90,7 @@ class PgsqlSearchableTest extends TestCase
 
         $this->app['config']->set('scout.pgsql.trigram.enabled', true);
         $this->app['config']->set('scout.pgsql.trigram.threshold', 0.15);
+        $this->app['config']->set('scout.pgsql.trigram.columns', ['title']);
 
         $this->createPostsTable(true);
 
@@ -99,7 +100,7 @@ class PgsqlSearchableTest extends TestCase
         ]);
         PgsqlSearchPost::query()->create([
             'title' => 'Queues',
-            'body' => 'Background jobs and workers',
+            'body' => 'Laravel Scout',
         ]);
 
         $this->assertTrue($this->pgTrgmExtensionExists());

--- a/tests/Integration/PgsqlSearchableTest.php
+++ b/tests/Integration/PgsqlSearchableTest.php
@@ -111,6 +111,27 @@ class PgsqlSearchableTest extends TestCase
         $this->assertSame(['Laravel Scout'], $results->pluck('title')->all());
     }
 
+    public function test_trigram_search_honors_non_default_threshold()
+    {
+        if (! env('SCOUT_PGSQL_TEST_TRIGRAM', false)) {
+            $this->markTestSkipped('Set SCOUT_PGSQL_TEST_TRIGRAM=true to run pg_trgm integration coverage.');
+        }
+
+        $this->app['config']->set('scout.pgsql.trigram.enabled', true);
+        $this->app['config']->set('scout.pgsql.trigram.threshold', 0.7);
+        $this->app['config']->set('scout.pgsql.trigram.columns', ['title']);
+
+        $this->createPostsTable(true);
+
+        PgsqlSearchPost::query()->create([
+            'title' => 'Laravel Scout',
+            'body' => 'Native PostgreSQL search driver',
+        ]);
+
+        $this->assertSame(['Laravel Scout'], PgsqlSearchPost::search('laravel scout')->get()->pluck('title')->all());
+        $this->assertSame([], PgsqlSearchPost::search('laravle')->get()->pluck('title')->all());
+    }
+
     public function test_drop_searchable_removes_generated_vector_column_and_indexes()
     {
         $withTrigram = (bool) env('SCOUT_PGSQL_TEST_TRIGRAM', false);

--- a/tests/Integration/PgsqlSearchableTest.php
+++ b/tests/Integration/PgsqlSearchableTest.php
@@ -124,9 +124,7 @@ class PgsqlSearchableTest extends TestCase
                     'body' => 'D',
                 ],
                 'trigram' => $withTrigram ? [
-                    'extension' => [
-                        'create' => true,
-                    ],
+                    'create_extension' => true,
                     'columns' => ['title'],
                 ] : [],
             ]);

--- a/tests/Integration/PgsqlSearchableTest.php
+++ b/tests/Integration/PgsqlSearchableTest.php
@@ -111,6 +111,35 @@ class PgsqlSearchableTest extends TestCase
         $this->assertSame(['Laravel Scout'], $results->pluck('title')->all());
     }
 
+    public function test_drop_searchable_removes_generated_vector_column_and_indexes()
+    {
+        $withTrigram = (bool) env('SCOUT_PGSQL_TEST_TRIGRAM', false);
+
+        $this->createPostsTable($withTrigram);
+
+        $this->assertHasPgsqlColumn('search_vector');
+        $this->assertHasPgsqlIndex('scout_pgsql_posts_search_vector_index', 'USING gin (search_vector)');
+
+        if ($withTrigram) {
+            $this->assertHasPgsqlIndex('scout_pgsql_posts_title_trigram_index', 'gin_trgm_ops');
+        }
+
+        Schema::table('scout_pgsql_posts', function (Blueprint $table) use ($withTrigram) {
+            $table->dropSearchable([
+                'trigram' => $withTrigram ? [
+                    'columns' => ['title'],
+                ] : [],
+            ]);
+        });
+
+        $this->assertMissingPgsqlColumn('search_vector');
+        $this->assertMissingPgsqlIndex('scout_pgsql_posts_search_vector_index');
+
+        if ($withTrigram) {
+            $this->assertMissingPgsqlIndex('scout_pgsql_posts_title_trigram_index');
+        }
+    }
+
     protected function createPostsTable($withTrigram = false)
     {
         Schema::dropIfExists('scout_pgsql_posts');
@@ -142,6 +171,33 @@ class PgsqlSearchableTest extends TestCase
 
         $this->assertNotNull($index);
         $this->assertStringContainsString($definition, $index);
+    }
+
+    protected function assertMissingPgsqlIndex($name)
+    {
+        $this->assertFalse(DB::table('pg_indexes')
+            ->where('schemaname', 'public')
+            ->where('tablename', 'scout_pgsql_posts')
+            ->where('indexname', $name)
+            ->exists());
+    }
+
+    protected function assertHasPgsqlColumn($name)
+    {
+        $this->assertTrue(DB::table('information_schema.columns')
+            ->where('table_schema', 'public')
+            ->where('table_name', 'scout_pgsql_posts')
+            ->where('column_name', $name)
+            ->exists());
+    }
+
+    protected function assertMissingPgsqlColumn($name)
+    {
+        $this->assertFalse(DB::table('information_schema.columns')
+            ->where('table_schema', 'public')
+            ->where('table_name', 'scout_pgsql_posts')
+            ->where('column_name', $name)
+            ->exists());
     }
 
     protected function pgTrgmExtensionExists()

--- a/tests/Unit/PgsqlEngineTest.php
+++ b/tests/Unit/PgsqlEngineTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Laravel\Scout\Tests\Unit;
+
+use InvalidArgumentException;
+use Laravel\Scout\Builder;
+use Laravel\Scout\Engines\PgsqlEngine;
+use PHPUnit\Framework\TestCase;
+
+class PgsqlEngineTest extends TestCase
+{
+    public function test_pgsql_engine_rejects_non_postgresql_connections()
+    {
+        $engine = new PgsqlEngine([]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [pgsql] Scout driver may only be used with PostgreSQL connections.');
+
+        $engine->search(new Builder(new class
+        {
+            public function getConnection()
+            {
+                return new class
+                {
+                    public function getDriverName()
+                    {
+                        return 'sqlite';
+                    }
+                };
+            }
+        }, 'Taylor'));
+    }
+}


### PR DESCRIPTION
This adds a native PostgreSQL search engine to Laravel Scout, giving applications that already run on PostgreSQL a way to perform full-text (and optional trigram similarity) search without standing up a separate search service.

The engine is registered as the `pgsql` driver and uses PostgreSQL's built-in `tsvector` / `tsrank` functions for indexing and ranking. It optionally blends trigram similarity when the `pg_trgm` extension is available, configurable via the same `scout.php` config file used by the other drivers.

Documentation: https://github.com/laravel/docs/pull/11235