### PR TITLE
Allow job timeout and fail on timeout to be configured

### DIFF
--- a/src/Traits/ConfiguresJobOptions.php
+++ b/src/Traits/ConfiguresJobOptions.php
@@ -26,6 +26,20 @@ trait ConfiguresJobOptions
     public $maxExceptions;
 
     /**
+     * The number of seconds the job can run before timing out.
+     *
+     * @var int|null
+     */
+    public $timeout;
+
+    /**
+     * Indicates if the job should be marked as failed on timeout.
+     *
+     * @var bool|null
+     */
+    public $failOnTimeout;
+
+    /**
      * Configure the job.
      *
      * @return void
@@ -45,6 +59,16 @@ trait ConfiguresJobOptions
         if (! isset($this->maxExceptions) &&
             ! is_null($maxExceptions = config('scout.jobs.max_exceptions'))) {
             $this->maxExceptions = $maxExceptions;
+        }
+
+        if (! isset($this->timeout) &&
+            ! is_null($timeout = config('scout.jobs.timeout'))) {
+            $this->timeout = $timeout;
+        }
+
+        if (! isset($this->failOnTimeout) &&
+            ! is_null($failOnTimeout = config('scout.jobs.fail_on_timeout'))) {
+            $this->failOnTimeout = $failOnTimeout;
         }
     }
 }

--- a/tests/Feature/Jobs/MakeSearchableTest.php
+++ b/tests/Feature/Jobs/MakeSearchableTest.php
@@ -37,6 +37,8 @@ class MakeSearchableTest extends TestCase
     #[WithConfig('scout.jobs.tries', 3)]
     #[WithConfig('scout.jobs.backoff', [1, 5, 10])]
     #[WithConfig('scout.jobs.max_exceptions', 2)]
+    #[WithConfig('scout.jobs.timeout', 30)]
+    #[WithConfig('scout.jobs.fail_on_timeout', true)]
     public function test_job_properties_are_set_from_config()
     {
         $model = SearchableUserFactory::new()->create();
@@ -46,6 +48,8 @@ class MakeSearchableTest extends TestCase
         $this->assertSame(3, $job->tries);
         $this->assertSame([1, 5, 10], $job->backoff);
         $this->assertSame(2, $job->maxExceptions);
+        $this->assertSame(30, $job->timeout);
+        $this->assertTrue($job->failOnTimeout);
     }
 
     public function test_job_properties_are_not_set_without_config()
@@ -57,11 +61,15 @@ class MakeSearchableTest extends TestCase
         $this->assertNull($job->tries);
         $this->assertNull($job->backoff);
         $this->assertNull($job->maxExceptions);
+        $this->assertNull($job->timeout);
+        $this->assertNull($job->failOnTimeout);
     }
 
     #[WithConfig('scout.jobs.tries', 1)]
     #[WithConfig('scout.jobs.backoff', [1, 5, 10])]
     #[WithConfig('scout.jobs.max_exceptions', 1)]
+    #[WithConfig('scout.jobs.timeout', 30)]
+    #[WithConfig('scout.jobs.fail_on_timeout', true)]
     public function test_subclass_job_properties_are_not_overridden_by_config()
     {
         $model = SearchableUserFactory::new()->create();
@@ -71,6 +79,8 @@ class MakeSearchableTest extends TestCase
         $this->assertSame(5, $job->tries);
         $this->assertSame([2, 4, 8, 16, 32], $job->backoff());
         $this->assertSame(3, $job->maxExceptions);
+        $this->assertSame(90, $job->timeout);
+        $this->assertFalse($job->failOnTimeout);
     }
 
     public function test_unique_id_is_based_on_the_class_and_scout_keys()

--- a/tests/Feature/Jobs/RemoveFromSearchTest.php
+++ b/tests/Feature/Jobs/RemoveFromSearchTest.php
@@ -71,6 +71,8 @@ class RemoveFromSearchTest extends TestCase
     #[WithConfig('scout.jobs.tries', 3)]
     #[WithConfig('scout.jobs.backoff', [1, 5, 10])]
     #[WithConfig('scout.jobs.max_exceptions', 2)]
+    #[WithConfig('scout.jobs.timeout', 30)]
+    #[WithConfig('scout.jobs.fail_on_timeout', true)]
     public function test_job_properties_are_set_from_config()
     {
         $model = SearchableUserFactory::new()->create();
@@ -80,6 +82,8 @@ class RemoveFromSearchTest extends TestCase
         $this->assertSame(3, $job->tries);
         $this->assertSame([1, 5, 10], $job->backoff);
         $this->assertSame(2, $job->maxExceptions);
+        $this->assertSame(30, $job->timeout);
+        $this->assertTrue($job->failOnTimeout);
     }
 
     public function test_job_properties_are_not_set_without_config()
@@ -91,11 +95,15 @@ class RemoveFromSearchTest extends TestCase
         $this->assertNull($job->tries);
         $this->assertNull($job->backoff);
         $this->assertNull($job->maxExceptions);
+        $this->assertNull($job->timeout);
+        $this->assertNull($job->failOnTimeout);
     }
 
     #[WithConfig('scout.jobs.tries', 1)]
     #[WithConfig('scout.jobs.backoff', [1, 5, 10])]
     #[WithConfig('scout.jobs.max_exceptions', 1)]
+    #[WithConfig('scout.jobs.timeout', 30)]
+    #[WithConfig('scout.jobs.fail_on_timeout', true)]
     public function test_subclass_job_properties_are_not_overridden_by_config()
     {
         $model = SearchableUserFactory::new()->create();
@@ -105,6 +113,8 @@ class RemoveFromSearchTest extends TestCase
         $this->assertSame(5, $job->tries);
         $this->assertSame([2, 4, 8, 16, 32], $job->backoff());
         $this->assertSame(3, $job->maxExceptions);
+        $this->assertSame(90, $job->timeout);
+        $this->assertFalse($job->failOnTimeout);
     }
 
     public function test_unique_id_is_based_on_the_class_and_scout_keys()

--- a/tests/Fixtures/OverriddenMakeSearchable.php
+++ b/tests/Fixtures/OverriddenMakeSearchable.php
@@ -10,6 +10,10 @@ class OverriddenMakeSearchable extends MakeSearchable
 
     public $maxExceptions = 3;
 
+    public $timeout = 90;
+
+    public $failOnTimeout = false;
+
     public function backoff(): array
     {
         return [2, 4, 8, 16, 32];

--- a/tests/Fixtures/OverriddenRemoveFromSearch.php
+++ b/tests/Fixtures/OverriddenRemoveFromSearch.php
@@ -10,6 +10,10 @@ class OverriddenRemoveFromSearch extends RemoveFromSearch
 
     public $maxExceptions = 3;
 
+    public $timeout = 90;
+
+    public $failOnTimeout = false;
+
     public function backoff(): array
     {
         return [2, 4, 8, 16, 32];


### PR DESCRIPTION
This PR extends the `scout.jobs` config options introduced in #962 with `timeout` and `fail_on_timeout`, applied to `MakeSearchable` and `RemoveFromSearch` through the existing `ConfiguresJobOptions` trait.

Fixes #957.

When a Scout job exceeds its timeout on a queue with unlimited tries (`'tries' => 0`, common in Horizon supervisor configs), the worker is killed but the job is never marked as failed: it is released back onto the queue after `retry_after` and picked up again, indefinitely. `horizon:forget` does not help because the job never reaches `failed_jobs`. That is the behavior described in #957.

I reproduced this against a fresh Laravel 12 app with the database queue driver and a deliberately slow `toSearchableArray()`:

- Without these options (`queue:work --tries=0 --timeout=5`): the worker was killed six times in 50 seconds, the job stayed pending with `attempts = 6`, and `failed_jobs` stayed empty.
- With `'jobs' => ['timeout' => 5, 'fail_on_timeout' => true]` and no `--timeout` flag on the worker: the payload carries `timeout: 5` / `failOnTimeout: true`, and the job failed after five seconds with a `TimeoutExceededException` in `failed_jobs`, unblocking the queue.

Both options default to `null`, so existing behavior is unchanged unless they are explicitly configured, and explicit properties on job subclasses take precedence over config, consistent with #962.

One caveat worth being explicit about: the job timeout relies on `pcntl_alarm`, which cannot interrupt a single blocking I/O call, since PHP only processes signals between instructions. A search engine request that hangs forever will still hang the worker regardless of these options — client-level timeouts on the engine remain the right tool for that case. What `fail_on_timeout` closes is the gap for jobs whose timeout does fire but that are then retried forever under unlimited tries.