### PR TITLE
Mark Scout jobs as failed on timeout by default

### DIFF
--- a/src/Jobs/MakeRangeSearchable.php
+++ b/src/Jobs/MakeRangeSearchable.php
@@ -11,6 +11,13 @@ class MakeRangeSearchable implements ShouldQueue
     use Queueable;
 
     /**
+     * Indicates if the job should be marked as failed on timeout.
+     *
+     * @var bool
+     */
+    public $failOnTimeout = true;
+
+    /**
      * The model to be made searchable.
      *
      * @var string

--- a/src/Jobs/MakeRangeSearchable.php
+++ b/src/Jobs/MakeRangeSearchable.php
@@ -11,13 +11,6 @@ class MakeRangeSearchable implements ShouldQueue
     use Queueable;
 
     /**
-     * Indicates if the job should be marked as failed on timeout.
-     *
-     * @var bool
-     */
-    public $failOnTimeout = true;
-
-    /**
      * The model to be made searchable.
      *
      * @var string
@@ -37,6 +30,13 @@ class MakeRangeSearchable implements ShouldQueue
      * @var int
      */
     public $end;
+
+    /**
+     * Indicates if the job should be marked as failed on timeout.
+     *
+     * @var bool
+     */
+    public $failOnTimeout = true;
 
     /**
      * Create a new job instance.

--- a/src/Traits/ConfiguresJobOptions.php
+++ b/src/Traits/ConfiguresJobOptions.php
@@ -26,6 +26,13 @@ trait ConfiguresJobOptions
     public $maxExceptions;
 
     /**
+     * Indicates if the job should be marked as failed on timeout.
+     *
+     * @var bool
+     */
+    public $failOnTimeout = true;
+
+    /**
      * Configure the job.
      *
      * @return void

--- a/tests/Feature/Jobs/MakeSearchableTest.php
+++ b/tests/Feature/Jobs/MakeSearchableTest.php
@@ -73,6 +73,24 @@ class MakeSearchableTest extends TestCase
         $this->assertSame(3, $job->maxExceptions);
     }
 
+    public function test_job_fails_on_timeout_by_default()
+    {
+        $model = SearchableUserFactory::new()->create();
+
+        $job = new MakeSearchable(Collection::make([$model]));
+
+        $this->assertTrue($job->failOnTimeout);
+    }
+
+    public function test_subclass_can_opt_out_of_failing_on_timeout()
+    {
+        $model = SearchableUserFactory::new()->create();
+
+        $job = new OverriddenMakeSearchable(Collection::make([$model]));
+
+        $this->assertFalse($job->failOnTimeout);
+    }
+
     public function test_unique_id_is_based_on_the_class_and_scout_keys()
     {
         $models = SearchableUserFactory::new()->count(2)->create();

--- a/tests/Feature/Jobs/RemoveFromSearchTest.php
+++ b/tests/Feature/Jobs/RemoveFromSearchTest.php
@@ -107,6 +107,24 @@ class RemoveFromSearchTest extends TestCase
         $this->assertSame(3, $job->maxExceptions);
     }
 
+    public function test_job_fails_on_timeout_by_default()
+    {
+        $model = SearchableUserFactory::new()->create();
+
+        $job = new RemoveFromSearch(Collection::make([$model]));
+
+        $this->assertTrue($job->failOnTimeout);
+    }
+
+    public function test_subclass_can_opt_out_of_failing_on_timeout()
+    {
+        $model = SearchableUserFactory::new()->create();
+
+        $job = new OverriddenRemoveFromSearch(Collection::make([$model]));
+
+        $this->assertFalse($job->failOnTimeout);
+    }
+
     public function test_unique_id_is_based_on_the_class_and_scout_keys()
     {
         $models = SearchableUserFactory::new()->count(2)->create();

--- a/tests/Fixtures/OverriddenMakeSearchable.php
+++ b/tests/Fixtures/OverriddenMakeSearchable.php
@@ -10,6 +10,8 @@ class OverriddenMakeSearchable extends MakeSearchable
 
     public $maxExceptions = 3;
 
+    public $failOnTimeout = false;
+
     public function backoff(): array
     {
         return [2, 4, 8, 16, 32];

--- a/tests/Fixtures/OverriddenRemoveFromSearch.php
+++ b/tests/Fixtures/OverriddenRemoveFromSearch.php
@@ -10,6 +10,8 @@ class OverriddenRemoveFromSearch extends RemoveFromSearch
 
     public $maxExceptions = 3;
 
+    public $failOnTimeout = false;
+
     public function backoff(): array
     {
         return [2, 4, 8, 16, 32];


### PR DESCRIPTION
Follow-up to #1001, implementing the approach you suggested when closing it: no configuration, just `failOnTimeout = true` on the Scout jobs.

Fixes #957.

The property is set on the `ConfiguresJobOptions` trait, which covers `MakeSearchable`, `RemoveFromSearch` and their `*Uniquely` subclasses, and directly on `MakeRangeSearchable` since that job does not use the trait.

## Why

When a Scout job exceeds its timeout on a queue with unlimited tries (`'tries' => 0`, common in Horizon supervisor configs), the job is never marked as failed: the worker is killed, the job is released back onto the queue after `retry_after` and picked up again, indefinitely. `horizon:forget` cannot help because the job never reaches `failed_jobs`. I verified this end-to-end on a fresh Laravel 12 app with the database queue driver and a deliberately slow `toSearchableArray()`: without this change the job stayed pending forever (six worker kills in 50 seconds, `attempts` climbing, `failed_jobs` empty); with this change the exact same scenario fails on the first timeout with a `TimeoutExceededException` in `failed_jobs` and the queue moves on.

## Behavioral change

Scout jobs now fail on the first timeout — including under the default 60 second worker timeout — instead of being released for another attempt. Since indexing is idempotent, a failed job can simply be retried with `queue:retry`, and a job subclass can opt out by declaring `public $failOnTimeout = false`. One edge to be aware of: userland classes that use `ConfiguresJobOptions` directly and declare their own `$failOnTimeout` property (or redeclare it with a `bool` type) will hit PHP's trait property conflict and need a small adjustment.

Worth noting for completeness: a request that blocks forever inside a single I/O call is not interruptible by `pcntl_alarm`, so client-level timeouts on the search engine remain necessary for that case — this change closes the queue-side gap where a fired timeout still never failed the job.