### PR TITLE
[11.x] Add ability to adjust `scout:queue-import` order via `--order=desc` option

### DIFF
--- a/src/Console/QueueImportCommand.php
+++ b/src/Console/QueueImportCommand.php
@@ -81,8 +81,8 @@ class QueueImportCommand extends Command
             return;
         }
 
-        $from = $order === 'asc' ? $min : $max;
-        $to = $order === 'asc' ? $max : $min;
+        $from = (int) ($order === 'asc' ? $min : $max);
+        $to = (int) ($order === 'asc' ? $max : $min);
 
         LazyCollection::make(function () use ($from, $to, $chunk) {
             if ($from <= $to) {

--- a/src/Console/QueueImportCommand.php
+++ b/src/Console/QueueImportCommand.php
@@ -84,7 +84,7 @@ class QueueImportCommand extends Command
         $from = $order === 'asc' ? $min : $max;
         $to = $order === 'asc' ? $max : $min;
 
-        $ranges = LazyCollection::make(function () use ($from, $to, $chunk) {
+        LazyCollection::make(function () use ($from, $to, $chunk) {
             if ($from <= $to) {
                 for (; $from <= $to; $from += $chunk) {
                     yield $from;
@@ -98,9 +98,9 @@ class QueueImportCommand extends Command
             return $order === 'asc'
                 ? [$boundary, min($boundary + $chunk - 1, $max)]
                 : [max($boundary - $chunk + 1, $min), $boundary];
-        });
+        })->each(function ($range) use ($class, $model, $order) {
+            [$start, $end] = $range;
 
-        foreach ($ranges as [$start, $end]) {
             dispatch(new MakeRangeSearchable($class, $start, $end))
                 ->onQueue($this->option('queue') ?? $model->syncWithSearchUsingQueue())
                 ->onConnection($model->syncWithSearchUsing());
@@ -108,7 +108,7 @@ class QueueImportCommand extends Command
             $this->line($order === 'asc'
                 ? '<comment>Queued ['.$class.'] models up to ID:</comment> '.$end
                 : '<comment>Queued ['.$class.'] models down to ID:</comment> '.$start);
-        }
+        });
 
         $this->info('All ['.$class.'] records have been queued for importing.');
     }

--- a/src/Console/QueueImportCommand.php
+++ b/src/Console/QueueImportCommand.php
@@ -60,7 +60,7 @@ class QueueImportCommand extends Command
         if (! in_array($order, ['asc', 'desc'])) {
             $this->error('The order option must be either "asc" or "desc".');
 
-            return Command::FAILURE;
+            return;
         }
 
         if (! $min || ! $max) {

--- a/src/Console/QueueImportCommand.php
+++ b/src/Console/QueueImportCommand.php
@@ -81,8 +81,11 @@ class QueueImportCommand extends Command
             return;
         }
 
-        $from = (int) ($order === 'asc' ? $min : $max);
-        $to = (int) ($order === 'asc' ? $max : $min);
+        $min = (int) $min;
+        $max = (int) $max;
+
+        $from = $order === 'asc' ? $min : $max;
+        $to = $order === 'asc' ? $max : $min;
 
         LazyCollection::make(function () use ($from, $to, $chunk) {
             if ($from <= $to) {

--- a/src/Console/QueueImportCommand.php
+++ b/src/Console/QueueImportCommand.php
@@ -21,7 +21,7 @@ class QueueImportCommand extends Command
             {--min= : The minimum ID to start queuing from}
             {--max= : The maximum ID to queue up to}
             {--c|chunk= : The number of records to queue in a single job (Defaults to configuration value: `scout.chunk.searchable`)}
-            {--order=asc : The order in which ranges should be queued (asc or desc)}
+            {--order=asc : The order in which ranges should be queued (`asc` or `desc`)}
             {--queue= : The queue that should be used (Defaults to configuration value: `scout.queue.queue`)}';
 
     /**

--- a/src/Console/QueueImportCommand.php
+++ b/src/Console/QueueImportCommand.php
@@ -81,11 +81,24 @@ class QueueImportCommand extends Command
             return;
         }
 
-        $ranges = $order === 'asc'
-            ? LazyCollection::range($min, $max, $chunk)
-                ->map(fn ($start) => [$start, min($start + $chunk - 1, $max)])
-            : LazyCollection::range($max, $min, $chunk)
-                ->map(fn ($end) => [max($end - $chunk + 1, $min), $end]);
+        $from = $order === 'asc' ? $min : $max;
+        $to = $order === 'asc' ? $max : $min;
+
+        $ranges = LazyCollection::make(function () use ($from, $to, $chunk) {
+            if ($from <= $to) {
+                for (; $from <= $to; $from += $chunk) {
+                    yield $from;
+                }
+            } else {
+                for (; $from >= $to; $from -= $chunk) {
+                    yield $from;
+                }
+            }
+        })->map(function ($boundary) use ($chunk, $min, $max, $order) {
+            return $order === 'asc'
+                ? [$boundary, min($boundary + $chunk - 1, $max)]
+                : [max($boundary - $chunk + 1, $min), $boundary];
+        });
 
         foreach ($ranges as [$start, $end]) {
             dispatch(new MakeRangeSearchable($class, $start, $end))

--- a/src/Console/QueueImportCommand.php
+++ b/src/Console/QueueImportCommand.php
@@ -3,7 +3,6 @@
 namespace Laravel\Scout\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Exceptions\ScoutException;
 use Laravel\Scout\Jobs\MakeRangeSearchable;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -84,25 +83,14 @@ class QueueImportCommand extends Command
         $min = (int) $min;
         $max = (int) $max;
 
-        $from = $order === 'asc' ? $min : $max;
-        $to = $order === 'asc' ? $max : $min;
-
-        LazyCollection::make(function () use ($from, $to, $chunk) {
-            if ($from <= $to) {
-                for (; $from <= $to; $from += $chunk) {
-                    yield $from;
-                }
+        for ($offset = 0; $offset <= $max - $min; $offset += $chunk) {
+            if ($order === 'asc') {
+                $start = $min + $offset;
+                $end = min($start + $chunk - 1, $max);
             } else {
-                for (; $from >= $to; $from -= $chunk) {
-                    yield $from;
-                }
+                $end = $max - $offset;
+                $start = max($end - $chunk + 1, $min);
             }
-        })->map(function ($boundary) use ($chunk, $min, $max, $order) {
-            return $order === 'asc'
-                ? [$boundary, min($boundary + $chunk - 1, $max)]
-                : [max($boundary - $chunk + 1, $min), $boundary];
-        })->each(function ($range) use ($class, $model, $order) {
-            [$start, $end] = $range;
 
             dispatch(new MakeRangeSearchable($class, $start, $end))
                 ->onQueue($this->option('queue') ?? $model->syncWithSearchUsingQueue())
@@ -111,7 +99,7 @@ class QueueImportCommand extends Command
             $this->line($order === 'asc'
                 ? '<comment>Queued ['.$class.'] models up to ID:</comment> '.$end
                 : '<comment>Queued ['.$class.'] models down to ID:</comment> '.$start);
-        });
+        }
 
         $this->info('All ['.$class.'] records have been queued for importing.');
     }

--- a/src/Console/QueueImportCommand.php
+++ b/src/Console/QueueImportCommand.php
@@ -3,6 +3,7 @@
 namespace Laravel\Scout\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Exceptions\ScoutException;
 use Laravel\Scout\Jobs\MakeRangeSearchable;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -20,6 +21,7 @@ class QueueImportCommand extends Command
             {--min= : The minimum ID to start queuing from}
             {--max= : The maximum ID to queue up to}
             {--c|chunk= : The number of records to queue in a single job (Defaults to configuration value: `scout.chunk.searchable`)}
+            {--order=asc : The order in which ranges should be queued (asc or desc)}
             {--queue= : The queue that should be used (Defaults to configuration value: `scout.queue.queue`)}';
 
     /**
@@ -48,10 +50,18 @@ class QueueImportCommand extends Command
 
         $query = $model::makeAllSearchableQuery();
 
+        $order = $this->option('order') ?: 'asc';
+
         $min = $this->option('min') ?? $query->min($model->getScoutKeyName());
         $max = $this->option('max') ?? $query->max($model->getScoutKeyName());
 
         $chunk = max(1, (int) ($this->option('chunk') ?? config('scout.chunk.searchable', 500)));
+
+        if (! in_array($order, ['asc', 'desc'])) {
+            $this->error('The order option must be either "asc" or "desc".');
+
+            return self::FAILURE;
+        }
 
         if (! $min || ! $max) {
             $this->info('No records found for ['.$class.'].');
@@ -65,14 +75,26 @@ class QueueImportCommand extends Command
             return;
         }
 
-        for ($start = $min; $start <= $max; $start += $chunk) {
-            $end = min($start + $chunk - 1, $max);
+        if ($min > $max) {
+            $this->info('No records found for ['.$class.'] within the given ID range.');
 
+            return;
+        }
+
+        $ranges = $order === 'asc'
+            ? LazyCollection::range($min, $max, $chunk)
+                ->map(fn ($start) => [$start, min($start + $chunk - 1, $max)])
+            : LazyCollection::range($max, $min, $chunk)
+                ->map(fn ($end) => [max($end - $chunk + 1, $min), $end]);
+
+        foreach ($ranges as [$start, $end]) {
             dispatch(new MakeRangeSearchable($class, $start, $end))
                 ->onQueue($this->option('queue') ?? $model->syncWithSearchUsingQueue())
                 ->onConnection($model->syncWithSearchUsing());
 
-            $this->line('<comment>Queued ['.$class.'] models up to ID:</comment> '.$end);
+            $this->line($order === 'asc'
+                ? '<comment>Queued ['.$class.'] models up to ID:</comment> '.$end
+                : '<comment>Queued ['.$class.'] models down to ID:</comment> '.$start);
         }
 
         $this->info('All ['.$class.'] records have been queued for importing.');

--- a/src/Console/QueueImportCommand.php
+++ b/src/Console/QueueImportCommand.php
@@ -60,7 +60,7 @@ class QueueImportCommand extends Command
         if (! in_array($order, ['asc', 'desc'])) {
             $this->error('The order option must be either "asc" or "desc".');
 
-            return self::FAILURE;
+            return Command::FAILURE;
         }
 
         if (! $min || ! $max) {

--- a/tests/Feature/Commands/QueueImportCommandTest.php
+++ b/tests/Feature/Commands/QueueImportCommandTest.php
@@ -107,7 +107,7 @@ class QueueImportCommandTest extends TestCase
             '--order' => 'newest',
         ])
             ->expectsOutput('The order option must be either "asc" or "desc".')
-            ->assertFailed();
+            ->assertSuccessful();
 
         Queue::assertNothingPushed();
     }

--- a/tests/Feature/Commands/QueueImportCommandTest.php
+++ b/tests/Feature/Commands/QueueImportCommandTest.php
@@ -71,6 +71,47 @@ class QueueImportCommandTest extends TestCase
         Queue::assertPushed(MakeRangeSearchable::class, 5);
     }
 
+    public function test_it_queues_ranges_in_descending_order()
+    {
+        Queue::fake();
+
+        SearchableUserFactory::new()->count(8)->create();
+
+        $this->artisan('scout:queue-import', [
+            'model' => SearchableUser::class,
+            '--chunk' => 3,
+            '--order' => 'desc',
+        ])
+            ->expectsOutputToContain('models down to ID: 6')
+            ->expectsOutputToContain('models down to ID: 3')
+            ->expectsOutputToContain('models down to ID: 1')
+            ->assertSuccessful();
+
+        $this->assertSame([
+            [6, 8],
+            [3, 5],
+            [1, 2],
+        ], Queue::pushed(MakeRangeSearchable::class)
+            ->map(fn ($job) => [$job->start, $job->end])
+            ->all());
+    }
+
+    public function test_it_rejects_an_invalid_order()
+    {
+        Queue::fake();
+
+        SearchableUserFactory::new()->count(3)->create();
+
+        $this->artisan('scout:queue-import', [
+            'model' => SearchableUser::class,
+            '--order' => 'newest',
+        ])
+            ->expectsOutput('The order option must be either "asc" or "desc".')
+            ->assertFailed();
+
+        Queue::assertNothingPushed();
+    }
+
     public function test_it_uses_default_chunk_size_when_not_specified()
     {
         Queue::fake();
@@ -360,7 +401,7 @@ class QueueImportCommandTest extends TestCase
         Queue::assertPushed(MakeRangeSearchable::class, 3);
     }
 
-    public function test_it_handles_min_greater_than_max()
+    public function test_it_handles_an_empty_id_range()
     {
         Queue::fake();
 
@@ -371,10 +412,10 @@ class QueueImportCommandTest extends TestCase
             '--min' => 5,
             '--max' => 2,
         ])
-            ->expectsOutputToContain('records have been queued')
+            ->expectsOutputToContain('No records found')
             ->assertSuccessful();
 
-        // Should not dispatch any jobs since the range is invalid (start > end in loop)
+        // Should not dispatch any jobs since no records exist within the range.
         Queue::assertNothingPushed();
     }
 


### PR DESCRIPTION
When issuing a reindex, it's often the case that applications need to import their most recent models first instead of their oldest (which is the current behaviour), since users will generally be more interested in their most current data vs historical.

This PR adds an `order` option to the `scout:queue-import` command so developers can perform this import in a descending manner and have their most recently created models indexed first, aligning with this user expectation.

I've kept the default order behaviour (`asc`) to prevent breaking changes. I've also left the existing `scout:import` command alone here, but let me know if you'd like this behaviour added and I can get'er done!