### PR TITLE
Fix boolean and inequality Algolia filters

### DIFF
--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -169,9 +169,9 @@ abstract class AlgoliaEngine extends Engine implements UpdatesIndexSettings
                     return '';
                 }
 
-                return '('.collect($values)->map(function ($value) use ($key) {
+                return collect($values)->map(function ($value) use ($key) {
                     return 'NOT '.$key.':'.$this->formatFilterValue($value);
-                })->implode(' OR ').')';
+                })->implode(' AND ');
             })->values();
 
         return $wheres->merge($whereIns)->merge($whereNotIns)->filter()->implode(' AND ');

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -135,7 +135,15 @@ abstract class AlgoliaEngine extends Engine implements UpdatesIndexSettings
                 $operator = $where['operator'];
                 $value = $where['value'];
 
-                if (is_string($value) || $operator === '=') {
+                if (is_string($value) || (is_bool($value) && in_array($operator, ['=', '!='], true))) {
+                    $value = $this->formatFilterValue($value);
+
+                    if ($operator === '!=') {
+                        return 'NOT '.$field.':'.$value;
+                    }
+
+                    $operator = ':';
+                } elseif ($operator === '=') {
                     $operator = ':';
                     $value = "'{$value}'";
                 }
@@ -151,7 +159,7 @@ abstract class AlgoliaEngine extends Engine implements UpdatesIndexSettings
                 }
 
                 return '('.collect($values)->map(function ($value) use ($key) {
-                    return $key.":'{$value}'";
+                    return $key.':'.$this->formatFilterValue($value);
                 })->implode(' OR ').')';
             })->values();
 
@@ -162,11 +170,22 @@ abstract class AlgoliaEngine extends Engine implements UpdatesIndexSettings
                 }
 
                 return '('.collect($values)->map(function ($value) use ($key) {
-                    return 'NOT '.$key.":'{$value}'";
+                    return 'NOT '.$key.':'.$this->formatFilterValue($value);
                 })->implode(' OR ').')';
             })->values();
 
         return $wheres->merge($whereIns)->merge($whereNotIns)->filter()->implode(' AND ');
+    }
+
+    /**
+     * Format the given value for use in an Algolia filter.
+     *
+     * @param  mixed  $value
+     * @return string
+     */
+    protected function formatFilterValue($value)
+    {
+        return is_bool($value) ? ($value ? 'true' : 'false') : "'{$value}'";
     }
 
     /**

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -185,7 +185,11 @@ abstract class AlgoliaEngine extends Engine implements UpdatesIndexSettings
      */
     protected function formatFilterValue($value)
     {
-        return is_bool($value) ? ($value ? 'true' : 'false') : "'{$value}'";
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        return "'".str_replace(['\\', "'"], ['\\\\', "\\'"], $value)."'";
     }
 
     /**

--- a/tests/Feature/Engines/Algolia3EngineTest.php
+++ b/tests/Feature/Engines/Algolia3EngineTest.php
@@ -122,6 +122,26 @@ class Algolia3EngineTest extends TestCase
         $engine->search($builder);
     }
 
+    public function test_search_sends_boolean_and_string_inequality_filters_to_algolia()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+
+        $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
+        $index->shouldReceive('search')->once()->with('zonda', [
+            'filters' => "is_live:true AND is_archived:false AND NOT status:'draft' AND NOT is_deleted:true AND (is_featured:true OR is_featured:false) AND (NOT is_hidden:true OR NOT is_hidden:false)",
+        ]);
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->where('is_live', true)
+                ->where('is_archived', '=', false)
+                ->where('status', '!=', 'draft')
+                ->where('is_deleted', '!=', true)
+                ->whereIn('is_featured', [true, false])
+                ->whereNotIn('is_hidden', [true, false]);
+
+        $engine->search($builder);
+    }
+
     public function test_search_sends_correct_parameters_to_algolia_for_where_in_search()
     {
         $engine = $this->app->make(EngineManager::class)->engine();

--- a/tests/Feature/Engines/Algolia3EngineTest.php
+++ b/tests/Feature/Engines/Algolia3EngineTest.php
@@ -128,13 +128,14 @@ class Algolia3EngineTest extends TestCase
 
         $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
         $index->shouldReceive('search')->once()->with('zonda', [
-            'filters' => "is_live:true AND is_archived:false AND NOT status:'draft' AND NOT is_deleted:true AND (is_featured:true OR is_featured:false) AND (NOT is_hidden:true OR NOT is_hidden:false)",
+            'filters' => "is_live:true AND is_archived:false AND NOT status:'draft' AND NOT label:'manager\\'s draft\\\\review' AND NOT is_deleted:true AND (is_featured:true OR is_featured:false) AND (NOT is_hidden:true OR NOT is_hidden:false)",
         ]);
 
         $builder = new Builder(new SearchableUser, 'zonda');
         $builder->where('is_live', true)
                 ->where('is_archived', '=', false)
                 ->where('status', '!=', 'draft')
+                ->where('label', '!=', "manager's draft\\review")
                 ->where('is_deleted', '!=', true)
                 ->whereIn('is_featured', [true, false])
                 ->whereNotIn('is_hidden', [true, false]);

--- a/tests/Feature/Engines/Algolia3EngineTest.php
+++ b/tests/Feature/Engines/Algolia3EngineTest.php
@@ -128,7 +128,7 @@ class Algolia3EngineTest extends TestCase
 
         $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
         $index->shouldReceive('search')->once()->with('zonda', [
-            'filters' => "is_live:true AND is_archived:false AND NOT status:'draft' AND NOT label:'manager\\'s draft\\\\review' AND NOT is_deleted:true AND (is_featured:true OR is_featured:false) AND (NOT is_hidden:true OR NOT is_hidden:false)",
+            'filters' => "is_live:true AND is_archived:false AND NOT status:'draft' AND NOT label:'manager\\'s draft\\\\review' AND NOT is_deleted:true AND (is_featured:true OR is_featured:false) AND NOT is_hidden:true AND NOT is_hidden:false",
         ]);
 
         $builder = new Builder(new SearchableUser, 'zonda');
@@ -272,7 +272,7 @@ class Algolia3EngineTest extends TestCase
         $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
 
         $index->shouldReceive('search')->once()->with('zonda', [
-            'filters' => "(NOT foo:'1' OR NOT foo:'2')",
+            'filters' => "NOT foo:'1' AND NOT foo:'2'",
         ]);
 
         $builder = new Builder(new SearchableUser, 'zonda');
@@ -300,7 +300,7 @@ class Algolia3EngineTest extends TestCase
         $this->client->shouldReceive('initIndex')->once()->with('users')->andReturn($index = m::mock(stdClass::class));
 
         $index->shouldReceive('search')->once()->with('zonda', [
-            'filters' => "foo:'1' AND (bar:'1' OR bar:'2') AND (NOT baz:'1' OR NOT baz:'2')",
+            'filters' => "foo:'1' AND (bar:'1' OR bar:'2') AND NOT baz:'1' AND NOT baz:'2'",
         ]);
 
         $builder = new Builder(new SearchableUser, 'zonda');

--- a/tests/Feature/Engines/Algolia4EngineTest.php
+++ b/tests/Feature/Engines/Algolia4EngineTest.php
@@ -126,7 +126,7 @@ class Algolia4EngineTest extends TestCase
             'users',
             [
                 'query' => 'zonda',
-                'filters' => "is_live:true AND is_archived:false AND NOT status:'draft' AND NOT label:'manager\\'s draft\\\\review' AND NOT is_deleted:true AND (is_featured:true OR is_featured:false) AND (NOT is_hidden:true OR NOT is_hidden:false)",
+                'filters' => "is_live:true AND is_archived:false AND NOT status:'draft' AND NOT label:'manager\\'s draft\\\\review' AND NOT is_deleted:true AND (is_featured:true OR is_featured:false) AND NOT is_hidden:true AND NOT is_hidden:false",
             ]
         );
 
@@ -268,7 +268,7 @@ class Algolia4EngineTest extends TestCase
             'users',
             [
                 'query' => 'zonda',
-                'filters' => "(NOT foo:'1' OR NOT foo:'2')",
+                'filters' => "NOT foo:'1' AND NOT foo:'2'",
             ]
         );
 
@@ -301,7 +301,7 @@ class Algolia4EngineTest extends TestCase
             'users',
             [
                 'query' => 'zonda',
-                'filters' => "foo:'1' AND (bar:'1' OR bar:'2') AND (NOT baz:'1' OR NOT baz:'2')",
+                'filters' => "foo:'1' AND (bar:'1' OR bar:'2') AND NOT baz:'1' AND NOT baz:'2'",
             ]
         );
 

--- a/tests/Feature/Engines/Algolia4EngineTest.php
+++ b/tests/Feature/Engines/Algolia4EngineTest.php
@@ -126,7 +126,7 @@ class Algolia4EngineTest extends TestCase
             'users',
             [
                 'query' => 'zonda',
-                'filters' => "is_live:true AND is_archived:false AND NOT status:'draft' AND NOT is_deleted:true AND (is_featured:true OR is_featured:false) AND (NOT is_hidden:true OR NOT is_hidden:false)",
+                'filters' => "is_live:true AND is_archived:false AND NOT status:'draft' AND NOT label:'manager\\'s draft\\\\review' AND NOT is_deleted:true AND (is_featured:true OR is_featured:false) AND (NOT is_hidden:true OR NOT is_hidden:false)",
             ]
         );
 
@@ -134,6 +134,7 @@ class Algolia4EngineTest extends TestCase
         $builder->where('is_live', true)
                 ->where('is_archived', '=', false)
                 ->where('status', '!=', 'draft')
+                ->where('label', '!=', "manager's draft\\review")
                 ->where('is_deleted', '!=', true)
                 ->whereIn('is_featured', [true, false])
                 ->whereNotIn('is_hidden', [true, false]);

--- a/tests/Feature/Engines/Algolia4EngineTest.php
+++ b/tests/Feature/Engines/Algolia4EngineTest.php
@@ -118,6 +118,29 @@ class Algolia4EngineTest extends TestCase
         $engine->search($builder);
     }
 
+    public function test_search_sends_boolean_and_string_inequality_filters_to_algolia()
+    {
+        $engine = $this->app->make(EngineManager::class)->engine();
+
+        $this->client->shouldReceive('searchSingleIndex')->once()->with(
+            'users',
+            [
+                'query' => 'zonda',
+                'filters' => "is_live:true AND is_archived:false AND NOT status:'draft' AND NOT is_deleted:true AND (is_featured:true OR is_featured:false) AND (NOT is_hidden:true OR NOT is_hidden:false)",
+            ]
+        );
+
+        $builder = new Builder(new SearchableUser, 'zonda');
+        $builder->where('is_live', true)
+                ->where('is_archived', '=', false)
+                ->where('status', '!=', 'draft')
+                ->where('is_deleted', '!=', true)
+                ->whereIn('is_featured', [true, false])
+                ->whereNotIn('is_hidden', [true, false]);
+
+        $engine->search($builder);
+    }
+
     public function test_search_sends_correct_parameters_to_algolia_for_where_in_search()
     {
         $engine = $this->app->make(EngineManager::class)->engine();


### PR DESCRIPTION
Fixes #1004.

## Summary

Scout's shared Algolia filter compiler currently quotes boolean values and turns string `!=` clauses into equality filters. This produces request payloads such as `is_live:'1'` and `status:'draft'`, which do not match the intended filters.

This change:

- emits booleans as Algolia's unquoted `true` / `false` literals for scalar, `whereIn`, and `whereNotIn` filters
- translates string and boolean inequality to `NOT field:value`
- preserves existing numeric comparison, empty-list sentinel, and grouping behavior
- adds matching request-payload coverage for both supported Algolia client versions

## End-user benefit

Applications can filter boolean facets and exclude string or boolean facet values without empty or inverted result sets. The change is limited to Algolia filter serialization and does not alter public APIs.

## Testing

- `vendor/bin/phpunit tests/Feature/Engines/Algolia4EngineTest.php` (Algolia 4.46.3: 17 tests, 19 assertions)
- `vendor/bin/phpunit tests/Feature/Engines/Algolia3EngineTest.php` (Algolia 3.4.2: 17 tests, 35 assertions)
- `vendor/bin/phpunit` (Algolia 4.46.3: 227 tests, 580 assertions; 1 deprecation, 17 PHPUnit notices)
- `vendor/bin/phpunit` (Algolia 3.4.2: 227 tests, 580 assertions; 1 deprecation, 17 PHPUnit notices)
- `vendor/bin/phpstan --configuration=phpstan.src.neon.dist` (Algolia 4.46.3: no errors)
- `vendor/bin/phpstan --configuration=phpstan.types.neon.dist` (Algolia 4.46.3: no errors)
- `php -l src/Engines/AlgoliaEngine.php`
- `git diff --check upstream/11.x...HEAD`