### PR TITLE
Turbopuffer Engine + Semantic/Hybrid Search with Database Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
     },
     "suggest": {
         "algolia/algoliasearch-client-php": "Required to use the Algolia engine (^3.2).",
+        "laravel/ai": "Required to generate embeddings for semantic and hybrid search.",
         "meilisearch/meilisearch-php": "Required to use the Meilisearch engine (^1.0).",
         "typesense/typesense-php": "Required to use the Typesense engine (^4.9)."
     },

--- a/config/scout.php
+++ b/config/scout.php
@@ -11,7 +11,7 @@ return [
     | using Laravel Scout. This connection is used when syncing all models
     | to the search service. You should adjust this based on your needs.
     |
-    | Supported: "algolia", "meilisearch", "typesense",
+    | Supported: "algolia", "meilisearch", "typesense", "turbopuffer",
     |            "database", "collection", "null"
     |
     */
@@ -205,6 +205,37 @@ return [
             // ],
         ],
         'import_action' => env('TYPESENSE_IMPORT_ACTION', 'upsert'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Turbopuffer Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your Turbopuffer connection and the schema and
+    | searchable attributes used by each of your application's models.
+    |
+    */
+
+    'turbopuffer' => [
+        'api_key' => env('TURBOPUFFER_API_KEY'),
+        'region' => env('TURBOPUFFER_REGION', 'gcp-us-central1'),
+        'base_url' => env('TURBOPUFFER_BASE_URL'),
+        'timeout' => env('TURBOPUFFER_TIMEOUT', 60),
+        'connect_timeout' => env('TURBOPUFFER_CONNECT_TIMEOUT', 5),
+        'retries' => env('TURBOPUFFER_RETRIES', 3),
+        'model-settings' => [
+            // User::class => [
+            //     'searchable-attributes' => [
+            //         'name' => 2,
+            //         'email' => 1,
+            //     ],
+            //     'schema' => [
+            //         'name' => ['type' => 'string', 'full_text_search' => true],
+            //         'email' => ['type' => 'string', 'full_text_search' => true],
+            //     ],
+            // ],
+        ],
     ],
 
 ];

--- a/config/scout.php
+++ b/config/scout.php
@@ -213,7 +213,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | Here you may configure your Turbopuffer connection and the schema and
-    | searchable attributes used by each of your application's models.
+    | searchable attributes defined by each of your application's models.
+    | Turbopuffer is a scalable engine with full-text + vector search.
     |
     */
 

--- a/config/scout.php
+++ b/config/scout.php
@@ -231,9 +231,14 @@ return [
             //         'name' => 2,
             //         'email' => 1,
             //     ],
+            //     'embedding' => [
+            //         'attribute' => 'embedding',
+            //         'dimensions' => 1536,
+            //     ],
             //     'schema' => [
             //         'name' => ['type' => 'string', 'full_text_search' => true],
             //         'email' => ['type' => 'string', 'full_text_search' => true],
+            //         'embedding' => ['type' => '[1536]f32', 'ann' => true],
             //     ],
             // ],
         ],

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -107,6 +107,13 @@ class Builder
     public $semanticSearch = false;
 
     /**
+     * The minimum similarity for semantic search results.
+     *
+     * @var int|float|null
+     */
+    public $minimumSimilarity;
+
+    /**
      * The hybrid search ranking weights.
      *
      * @var array|null
@@ -314,15 +321,17 @@ class Builder
     /**
      * Perform a semantic search for the query expression.
      *
+     * @param  int|float|null  $minSimilarity
      * @return $this
      */
-    public function semantic()
+    public function semantic($minSimilarity = null)
     {
         if (trim($this->query) === '') {
             throw new ScoutException('Semantic searches require a non-empty query.');
         }
 
         $this->semanticSearch = true;
+        $this->minimumSimilarity = $minSimilarity;
         $this->hybridSearch = null;
 
         return $this;
@@ -333,9 +342,10 @@ class Builder
      *
      * @param  int|float  $textWeight
      * @param  int|float  $semanticWeight
+     * @param  int|float|null  $minSimilarity
      * @return $this
      */
-    public function hybrid($textWeight = 1, $semanticWeight = 1)
+    public function hybrid($textWeight = 1, $semanticWeight = 1, $minSimilarity = null)
     {
         if (trim($this->query) === '') {
             throw new ScoutException('Hybrid searches require a non-empty query.');
@@ -346,6 +356,7 @@ class Builder
         }
 
         $this->semanticSearch = false;
+        $this->minimumSimilarity = $minSimilarity;
 
         $this->hybridSearch = [
             'text_weight' => $textWeight,

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -11,7 +11,6 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\Tappable;
 use Laravel\Scout\Contracts\PaginatesEloquentModels;
 use Laravel\Scout\Contracts\PaginatesEloquentModelsUsingDatabase;
-use Laravel\Scout\Contracts\SupportsHybridSearch;
 use Laravel\Scout\Contracts\SupportsSemanticSearch;
 use Laravel\Scout\Exceptions\NotSupportedException;
 use Laravel\Scout\Exceptions\ScoutException;
@@ -656,10 +655,6 @@ class Builder
 
         if ($this->semanticSearch && ! $engine instanceof SupportsSemanticSearch) {
             throw new NotSupportedException('The configured Scout engine does not support semantic search.');
-        }
-
-        if (! is_null($this->hybridSearch) && ! $engine instanceof SupportsHybridSearch) {
-            throw new NotSupportedException('The configured Scout engine does not support hybrid search.');
         }
 
         return $engine;

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -11,6 +11,10 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\Tappable;
 use Laravel\Scout\Contracts\PaginatesEloquentModels;
 use Laravel\Scout\Contracts\PaginatesEloquentModelsUsingDatabase;
+use Laravel\Scout\Contracts\SupportsHybridSearch;
+use Laravel\Scout\Contracts\SupportsSemanticSearch;
+use Laravel\Scout\Exceptions\NotSupportedException;
+use Laravel\Scout\Exceptions\ScoutException;
 
 /**
  * @template TModel of \Illuminate\Database\Eloquent\Model
@@ -95,6 +99,20 @@ class Builder
      * @var array
      */
     public $orders = [];
+
+    /**
+     * Indicates that the query should use semantic search.
+     *
+     * @var bool
+     */
+    public $semanticSearch = false;
+
+    /**
+     * The hybrid search ranking weights.
+     *
+     * @var array|null
+     */
+    public $hybridSearch;
 
     /**
      * Extra options that should be applied to the search.
@@ -292,6 +310,50 @@ class Builder
         }
 
         return $this->orderBy($column, 'asc');
+    }
+
+    /**
+     * Perform a semantic search for the query expression.
+     *
+     * @return $this
+     */
+    public function semantic()
+    {
+        if (trim($this->query) === '') {
+            throw new ScoutException('Semantic searches require a non-empty query.');
+        }
+
+        $this->semanticSearch = true;
+        $this->hybridSearch = null;
+
+        return $this;
+    }
+
+    /**
+     * Perform a hybrid full-text and semantic search for the query expression.
+     *
+     * @param  int|float  $textWeight
+     * @param  int|float  $semanticWeight
+     * @return $this
+     */
+    public function hybrid($textWeight = 1, $semanticWeight = 1)
+    {
+        if (trim($this->query) === '') {
+            throw new ScoutException('Hybrid searches require a non-empty query.');
+        }
+
+        if (! is_numeric($textWeight) || $textWeight <= 0 || ! is_numeric($semanticWeight) || $semanticWeight <= 0) {
+            throw new ScoutException('Hybrid search weights must be positive numbers.');
+        }
+
+        $this->semanticSearch = false;
+
+        $this->hybridSearch = [
+            'text_weight' => $textWeight,
+            'semantic_weight' => $semanticWeight,
+        ];
+
+        return $this;
     }
 
     /**
@@ -590,7 +652,17 @@ class Builder
      */
     protected function engine()
     {
-        return $this->model->searchableUsing();
+        $engine = $this->model->searchableUsing();
+
+        if ($this->semanticSearch && ! $engine instanceof SupportsSemanticSearch) {
+            throw new NotSupportedException('The configured Scout engine does not support semantic search.');
+        }
+
+        if (! is_null($this->hybridSearch) && ! $engine instanceof SupportsHybridSearch) {
+            throw new NotSupportedException('The configured Scout engine does not support hybrid search.');
+        }
+
+        return $engine;
     }
 
     /**

--- a/src/Contracts/SupportsHybridSearch.php
+++ b/src/Contracts/SupportsHybridSearch.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Laravel\Scout\Contracts;
+
+interface SupportsHybridSearch
+{
+    //
+}

--- a/src/Contracts/SupportsHybridSearch.php
+++ b/src/Contracts/SupportsHybridSearch.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Laravel\Scout\Contracts;
-
-interface SupportsHybridSearch
-{
-    //
-}

--- a/src/Contracts/SupportsSemanticSearch.php
+++ b/src/Contracts/SupportsSemanticSearch.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Laravel\Scout\Contracts;
+
+interface SupportsSemanticSearch
+{
+    //
+}

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -13,7 +13,9 @@ use Laravel\Scout\Engines\CollectionEngine;
 use Laravel\Scout\Engines\DatabaseEngine;
 use Laravel\Scout\Engines\MeilisearchEngine;
 use Laravel\Scout\Engines\NullEngine;
+use Laravel\Scout\Engines\TurbopufferEngine;
 use Laravel\Scout\Engines\TypesenseEngine;
+use Laravel\Scout\Services\Turbopuffer\TurbopufferClient;
 use Meilisearch\Client as MeilisearchClient;
 use Meilisearch\Meilisearch;
 use Typesense\Client as Typesense;
@@ -160,9 +162,27 @@ class EngineManager extends Manager
     public function createTypesenseDriver()
     {
         $config = config('scout.typesense');
+
         $this->ensureTypesenseClientIsInstalled();
 
-        return new TypesenseEngine(new Typesense($config['client-settings']), $config['max_total_results'] ?? 1000);
+        return new TypesenseEngine(
+            new Typesense($config['client-settings']),
+            $config['max_total_results'] ?? 1000
+        );
+    }
+
+    /**
+     * Create a Turbopuffer engine instance.
+     *
+     * @return \Laravel\Scout\Engines\TurbopufferEngine
+     */
+    public function createTurbopufferDriver()
+    {
+        return new TurbopufferEngine(
+            $this->container->make(TurbopufferClient::class),
+            config('scout.turbopuffer', []),
+            config('scout.soft_delete', false),
+        );
     }
 
     /**

--- a/src/Engines/Concerns/PaginatesDatabaseVectorSearch.php
+++ b/src/Engines/Concerns/PaginatesDatabaseVectorSearch.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Laravel\Scout\Engines\Concerns;
+
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
+use Laravel\Scout\Builder;
+use Laravel\Scout\Exceptions\ScoutException;
+
+trait PaginatesDatabaseVectorSearch
+{
+    /**
+     * Paginate a hybrid search using a bounded fused result window.
+     */
+    protected function paginateHybridSearch(Builder $builder, $perPage, $pageName, $page)
+    {
+        [$page, $perPage, $maximum] = $this->hybridPaginationWindow(
+            $builder, $perPage, $pageName, $page
+        );
+
+        $models = $this->hybridSearchModels($builder, $maximum);
+
+        return new LengthAwarePaginator(
+            $models->slice(($page - 1) * $perPage, $perPage)->values(),
+            $models->count(),
+            $perPage,
+            $page,
+            ['path' => Paginator::resolveCurrentPath(), 'pageName' => $pageName]
+        );
+    }
+
+    /**
+     * Simply paginate a hybrid search using a bounded fused result window.
+     */
+    protected function simplePaginateHybridSearch(Builder $builder, $perPage, $pageName, $page)
+    {
+        [$page, $perPage, $maximum] = $this->hybridPaginationWindow(
+            $builder, $perPage, $pageName, $page
+        );
+
+        $models = $this->hybridSearchModels($builder, $maximum);
+
+        $paginator = new Paginator(
+            $models->slice(($page - 1) * $perPage, $perPage)->values(),
+            $perPage,
+            $page,
+            ['path' => Paginator::resolveCurrentPath(), 'pageName' => $pageName]
+        );
+
+        return $paginator->hasMorePagesWhen(($page * $perPage) < $models->count());
+    }
+
+    /**
+     * Resolve and validate a hybrid pagination window.
+     */
+    protected function hybridPaginationWindow(Builder $builder, $perPage, $pageName, $page): array
+    {
+        [$page, $perPage, $offset] = $this->resolvePaginationState(
+            $builder, $perPage, $pageName, $page
+        );
+
+        if ($offset + $perPage > 1000) {
+            throw new ScoutException('Database hybrid search results may not be paginated beyond 1,000 records.');
+        }
+
+        return [$page, $perPage, min((int) ($builder->limit ?? 1000), 1000)];
+    }
+
+    /**
+     * Paginate a semantic search while respecting Scout's result limit.
+     */
+    protected function paginateSemanticSearch(Builder $builder, $perPage, $pageName, $page)
+    {
+        [$page, $perPage, $offset] = $this->resolvePaginationState(
+            $builder, $perPage, $pageName, $page
+        );
+
+        $maximum = $this->resolveResultLimit($builder);
+
+        $query = $this->buildSemanticSearchQuery($builder);
+
+        $total = min(
+            (int) (clone $query)->toBase()->getCountForPagination(),
+            $maximum
+        );
+
+        $models = $offset >= $maximum
+            ? $builder->model->newCollection()
+            : $query->offset($offset)->limit(min($perPage, $maximum - $offset))->get();
+
+        return new LengthAwarePaginator(
+            $models,
+            $total,
+            $perPage,
+            $page,
+            ['path' => Paginator::resolveCurrentPath(), 'pageName' => $pageName]
+        );
+    }
+
+    /**
+     * Simply paginate a semantic search while respecting Scout's result limit.
+     */
+    protected function simplePaginateSemanticSearch(Builder $builder, $perPage, $pageName, $page)
+    {
+        [$page, $perPage, $offset] = $this->resolvePaginationState(
+            $builder, $perPage, $pageName, $page
+        );
+
+        $limit = min(
+            $perPage + 1,
+            max(0, $this->resolveResultLimit($builder) - $offset)
+        );
+
+        $models = $limit === 0
+            ? $builder->model->newCollection()
+            : $this->buildSemanticSearchQuery($builder)->offset($offset)->limit($limit)->get();
+
+        $hasMorePages = $models->count() > $perPage;
+
+        return (new Paginator(
+            $models->take($perPage)->values(),
+            $perPage,
+            $page,
+            ['path' => Paginator::resolveCurrentPath(), 'pageName' => $pageName]
+        ))->hasMorePagesWhen($hasMorePages);
+    }
+
+    /**
+     * Resolve the current pagination values.
+     */
+    protected function resolvePaginationState(Builder $builder, $perPage, $pageName, $page): array
+    {
+        [$page, $perPage] = [
+            max(1, (int) ($page ?: Paginator::resolveCurrentPage($pageName))),
+            max(1, (int) ($perPage ?: $builder->model->getPerPage())),
+        ];
+
+        return [$page, $perPage, ($page - 1) * $perPage];
+    }
+
+    /**
+     * Resolve the maximum number of results for the search.
+     */
+    protected function resolveResultLimit(Builder $builder): int
+    {
+        return is_null($builder->limit)
+            ? PHP_INT_MAX
+            : max(0, (int) $builder->limit);
+    }
+}

--- a/src/Engines/Concerns/PerformsDatabaseVectorSearch.php
+++ b/src/Engines/Concerns/PerformsDatabaseVectorSearch.php
@@ -1,0 +1,276 @@
+<?php
+
+namespace Laravel\Scout\Engines\Concerns;
+
+use Laravel\Scout\Builder;
+use Laravel\Scout\Exceptions\NotSupportedException;
+use Laravel\Scout\Exceptions\ScoutException;
+
+trait PerformsDatabaseVectorSearch
+{
+    /**
+     * Update the searchable embeddings for the given models.
+     */
+    protected function updateSearchableEmbeddings($models): void
+    {
+        if ($models->isEmpty()) {
+            return;
+        }
+
+        $model = $models->first();
+
+        if (! $this->supportsVectorSearch($model) || ! method_exists($model, 'toSearchableEmbedding')) {
+            return;
+        }
+
+        foreach (array_chunk($models->all(), 100) as $batch) {
+            $inputs = [];
+            $vectors = [];
+
+            foreach ($batch as $index => $model) {
+                $input = $model->toSearchableEmbedding();
+
+                // If it's already an embedding, skip it...
+                if (is_array($input)) {
+                    $vectors[$index] = $input;
+
+                    continue;
+                }
+
+                if (! is_string($input) || trim($input) === '') {
+                    throw new ScoutException('The [toSearchableEmbedding] method must return a non-empty string or an embedding array.');
+                }
+
+                $inputs[$index] = $input;
+            }
+
+            if (! empty($inputs)) {
+                $generatedVectors = $this->generateEmbeddings(array_values($inputs));
+
+                foreach (array_keys($inputs) as $position => $index) {
+                    $vectors[$index] = $generatedVectors[$position];
+                }
+            }
+
+            foreach ($batch as $index => $model) {
+                $column = $this->embeddingColumn($model);
+                $vector = $vectors[$index];
+
+                $model->newModelQuery()
+                    ->where($model->getKeyName(), $model->getKey())
+                    ->toBase()
+                    ->update([$column => json_encode($vector, JSON_THROW_ON_ERROR)]);
+
+                $model->setAttribute($column, $vector);
+            }
+        }
+    }
+
+    /**
+     * Get hybrid search results using weighted reciprocal rank fusion.
+     */
+    protected function hybridSearchModels(Builder $builder, int $limit)
+    {
+        if (! empty($builder->orders)) {
+            throw new ScoutException('Database order clauses cannot be combined with hybrid search.');
+        }
+
+        if ($limit <= 0) {
+            return $builder->model->newCollection();
+        }
+
+        // Generatee embeddings for the query...
+        $vector = $this->generateEmbeddings([$builder->query])[0];
+
+        $column = $builder->model->qualifyColumn(
+            $this->embeddingColumn($builder->model)
+        );
+
+        $baseQuery = $this->newSearchQuery($builder);
+
+        // Build the text query...
+        $textQuery = $this->constrainSearchQuery($builder, $this->addTextSearchConstraints(
+            clone $baseQuery,
+            $builder,
+            array_keys($builder->model->toSearchableArray()),
+            $this->getPrefixColumns($builder),
+            $this->getFullTextColumns($builder)
+        )->take(1000));
+
+        // Order the text query...
+        if (! $this->getFullTextColumns($builder)) {
+            $textQuery->orderBy($builder->model->getTable().'.'.$builder->model->getScoutKeyName(), 'desc');
+        } elseif ($this->shouldOrderByRelevance($builder)) {
+            $this->orderByRelevance($builder, $textQuery);
+
+            $textQuery->orderBy($builder->model->getQualifiedKeyName());
+        }
+
+        // Build the semantic query...
+        $semanticQuery = $this->constrainSearchQuery($builder, (clone $baseQuery)
+            ->whereVectorSimilarTo($column, $vector, $this->minimumSimilarity($builder), false)
+            ->orderByVectorDistance($column, $vector)
+            ->orderBy($builder->model->getQualifiedKeyName())
+            ->take(1000));
+
+        return $this->fuseSearchResults(
+            $builder,
+            $textQuery->get(),
+            $semanticQuery->get()
+        )->take($limit)->values();
+    }
+
+    /**
+     * Fuse text and semantic results using weighted reciprocal rank fusion.
+     */
+    protected function fuseSearchResults(Builder $builder, $textModels, $semanticModels)
+    {
+        [$scores, $models] = [[], []];
+
+        foreach ([
+            [$textModels, $builder->hybridSearch['text_weight']],
+            [$semanticModels, $builder->hybridSearch['semantic_weight']],
+        ] as [$rankedModels, $weight]) {
+            $seen = [];
+
+            foreach ($rankedModels->values() as $position => $model) {
+                $key = (string) $model->getScoutKey();
+
+                if (isset($seen[$key])) {
+                    continue;
+                }
+
+                $seen[$key] = true;
+                $models[$key] = $model;
+                $scores[$key] = ($scores[$key] ?? 0) + ($weight / (60 + $position + 1));
+            }
+        }
+
+        uksort($scores, function ($left, $right) use ($scores) {
+            return $scores[$right] <=> $scores[$left] ?: strcmp($left, $right);
+        });
+
+        return $builder->model->newCollection(
+            array_map(fn ($key) => $models[$key], array_keys($scores))
+        );
+    }
+
+    /**
+     * Build a semantic search query.
+     */
+    protected function buildSemanticSearchQuery(Builder $builder)
+    {
+        $this->ensureSemanticSearchIsSupported($builder);
+
+        if (! empty($builder->orders)) {
+            throw new ScoutException('Database order clauses cannot be combined with semantic search.');
+        }
+
+        $vector = $this->generateEmbeddings([$builder->query])[0];
+
+        $column = $builder->model->qualifyColumn(
+            $this->embeddingColumn($builder->model)
+        );
+
+        $query = $this->newSearchQuery($builder)
+            ->whereVectorSimilarTo($column, $vector, $this->minimumSimilarity($builder), false)
+            ->orderByVectorDistance($column, $vector)
+            ->orderBy($builder->model->getQualifiedKeyName())
+            ->take($builder->limit);
+
+        return $this->constrainSearchQuery($builder, $query);
+    }
+
+    /**
+     * Get the minimum similarity for a semantic search.
+     */
+    protected function minimumSimilarity(Builder $builder): float
+    {
+        $similarity = $builder->minimumSimilarity ?? 0.6;
+
+        if (! is_numeric($similarity) || $similarity < 0 || $similarity > 1) {
+            throw new ScoutException('The minimum similarity must be between 0 and 1.');
+        }
+
+        return (float) $similarity;
+    }
+
+    /**
+     * Apply Scout's non-search constraints to a query.
+     */
+    protected function constrainSearchQuery(Builder $builder, $query)
+    {
+        return $this->constrainForSoftDeletes($builder, $this->addAdditionalConstraints($builder, $query));
+    }
+
+    /**
+     * Generate embeddings using the optional Laravel AI SDK.
+     */
+    protected function generateEmbeddings(array $inputs): array
+    {
+        $embeddingsClass = 'Laravel\\Ai\\Embeddings';
+
+        if (! class_exists($embeddingsClass)) {
+            throw new ScoutException('Semantic search requires the Laravel AI SDK. Please install the [laravel/ai] package.');
+        }
+
+        $embeddings = $embeddingsClass::for(array_values($inputs))
+            ->cache()
+            ->generate()->embeddings;
+
+        if (! is_array($embeddings) || count($embeddings) !== count($inputs)) {
+            throw new ScoutException('Laravel AI returned an unexpected number of embeddings.');
+        }
+
+        return $embeddings;
+    }
+
+    /**
+     * Get the model's embedding column.
+     */
+    protected function embeddingColumn($model): string
+    {
+        $column = method_exists($model, 'searchableEmbeddingColumn')
+            ? $model->searchableEmbeddingColumn()
+            : 'embedding';
+
+        if (! is_string($column) || trim($column) === '') {
+            throw new ScoutException('The [searchableEmbeddingColumn] method must return a non-empty string.');
+        }
+
+        return $column;
+    }
+
+    /**
+     * Determine if a hybrid search should use vector search.
+     */
+    protected function shouldPerformHybridSearch(Builder $builder): bool
+    {
+        return ! is_null($builder->hybridSearch) &&
+            method_exists($builder->model, 'toSearchableEmbedding') &&
+            $this->supportsVectorSearch($builder->model);
+    }
+
+    /**
+     * Determine if the model's database supports vector queries.
+     */
+    protected function supportsVectorSearch($model): bool
+    {
+        return $model->getConnection()->getDriverName() === 'pgsql' &&
+            method_exists($model->newQuery()->getQuery(), 'whereVectorSimilarTo');
+    }
+
+    /**
+     * Ensure semantic search is supported by the model's database.
+     */
+    protected function ensureSemanticSearchIsSupported(Builder $builder): void
+    {
+        if (! $this->supportsVectorSearch($builder->model)) {
+            throw new NotSupportedException('Database semantic search requires Laravel 13 and PostgreSQL with pgvector.');
+        }
+
+        if (! method_exists($builder->model, 'toSearchableEmbedding')) {
+            throw new NotSupportedException('Database semantic search requires the model to define a [toSearchableEmbedding] method.');
+        }
+    }
+}

--- a/src/Engines/DatabaseEngine.php
+++ b/src/Engines/DatabaseEngine.php
@@ -9,10 +9,16 @@ use Laravel\Scout\Attributes\SearchUsingFullText;
 use Laravel\Scout\Attributes\SearchUsingPrefix;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Contracts\PaginatesEloquentModelsUsingDatabase;
+use Laravel\Scout\Contracts\SupportsSemanticSearch;
+use Laravel\Scout\Engines\Concerns\PaginatesDatabaseVectorSearch;
+use Laravel\Scout\Engines\Concerns\PerformsDatabaseVectorSearch;
 use ReflectionMethod;
 
-class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatabase
+class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatabase, SupportsSemanticSearch
 {
+    use PaginatesDatabaseVectorSearch;
+    use PerformsDatabaseVectorSearch;
+
     /**
      * Create a new engine instance.
      *
@@ -31,7 +37,7 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
      */
     public function update($models)
     {
-        //
+        $this->updateSearchableEmbeddings($models);
     }
 
     /**
@@ -53,6 +59,18 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
      */
     public function search(Builder $builder)
     {
+        if ($this->shouldPerformHybridSearch($builder)) {
+            $models = $this->hybridSearchModels(
+                $builder,
+                min((int) ($builder->limit ?? 1000), 1000)
+            );
+
+            return [
+                'results' => $models,
+                'total' => $models->count(),
+            ];
+        }
+
         $models = $this->searchModels($builder);
 
         return [
@@ -71,6 +89,14 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
      */
     protected function searchModels(Builder $builder, $page = null, $perPage = null)
     {
+        if ($builder->semanticSearch) {
+            return $this->buildSemanticSearchQuery($builder)
+                ->when(! is_null($page) && ! is_null($perPage), function ($query) use ($page, $perPage) {
+                    $query->forPage($page, $perPage);
+                })
+                ->get();
+        }
+
         return $this->buildSearchQuery($builder)
             ->when(! is_null($page) && ! is_null($perPage), function ($query) use ($page, $perPage) {
                 $query->forPage($page, $perPage);
@@ -113,6 +139,14 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
      */
     public function paginateUsingDatabase(Builder $builder, $perPage, $pageName, $page)
     {
+        if ($this->shouldPerformHybridSearch($builder)) {
+            return $this->paginateHybridSearch($builder, $perPage, $pageName, $page);
+        }
+
+        if ($builder->semanticSearch) {
+            return $this->paginateSemanticSearch($builder, $perPage, $pageName, $page);
+        }
+
         return $this->buildSearchQuery($builder)
             ->when($builder->orders, function ($query) use ($builder) {
                 foreach ($builder->orders as $order) {
@@ -151,6 +185,14 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
      */
     public function simplePaginateUsingDatabase(Builder $builder, $perPage, $pageName, $page)
     {
+        if ($this->shouldPerformHybridSearch($builder)) {
+            return $this->simplePaginateHybridSearch($builder, $perPage, $pageName, $page);
+        }
+
+        if ($builder->semanticSearch) {
+            return $this->simplePaginateSemanticSearch($builder, $perPage, $pageName, $page);
+        }
+
         return $this->buildSearchQuery($builder)
             ->when($builder->orders, function ($query) use ($builder) {
                 foreach ($builder->orders as $order) {
@@ -197,9 +239,35 @@ class DatabaseEngine extends Engine implements PaginatesEloquentModelsUsingDatab
      */
     protected function initializeSearchQuery(Builder $builder, array $columns, array $prefixColumns = [], array $fullTextColumns = [])
     {
-        $query = method_exists($builder->model, 'newScoutQuery')
+        $query = $this->newSearchQuery($builder);
+
+        return $this->addTextSearchConstraints(
+            $query, $builder, $columns, $prefixColumns, $fullTextColumns
+        );
+    }
+
+    /**
+     * Create the model query used for a Scout search.
+     */
+    protected function newSearchQuery(Builder $builder)
+    {
+        return method_exists($builder->model, 'newScoutQuery')
             ? $builder->model->newScoutQuery($builder)
             : $builder->model->newQuery();
+    }
+
+    /**
+     * Add text search constraints to the given query.
+     */
+    protected function addTextSearchConstraints($query, Builder $builder, array $columns, array $prefixColumns = [], array $fullTextColumns = [])
+    {
+        if (method_exists($builder->model, 'toSearchableEmbedding')) {
+            $embeddingColumn = $this->embeddingColumn($builder->model);
+
+            $columns = array_values(array_diff($columns, [$embeddingColumn]));
+            $prefixColumns = array_values(array_diff($prefixColumns, [$embeddingColumn]));
+            $fullTextColumns = array_values(array_diff($fullTextColumns, [$embeddingColumn]));
+        }
 
         if (blank($builder->query)) {
             return $query;

--- a/src/Engines/TurbopufferEngine.php
+++ b/src/Engines/TurbopufferEngine.php
@@ -1,0 +1,439 @@
+<?php
+
+namespace Laravel\Scout\Engines;
+
+use BackedEnum;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\LazyCollection;
+use Laravel\Scout\Builder;
+use Laravel\Scout\Exceptions\NotSupportedException;
+use Laravel\Scout\Exceptions\ScoutException;
+use Laravel\Scout\Jobs\RemoveableScoutCollection;
+use Laravel\Scout\Services\Turbopuffer\TurbopufferClient;
+
+class TurbopufferEngine extends Engine
+{
+    /**
+     * Create a new Turbopuffer engine instance.
+     */
+    public function __construct(
+        protected TurbopufferClient $turbopuffer,
+        protected array $config = [],
+        protected bool $softDelete = false
+    ) {
+        //
+    }
+
+    /**
+     * Update the given models in the index.
+     */
+    public function update($models)
+    {
+        if ($models->isEmpty()) {
+            return;
+        }
+
+        $model = $models->first();
+
+        if ($this->usesSoftDelete($model) && $this->softDelete) {
+            $models->each->pushSoftDeleteMetadata();
+        }
+
+        $rows = $models->map(function ($model) {
+            if (empty($searchableData = $model->toSearchableArray())) {
+                return;
+            }
+
+            return array_merge(
+                $searchableData,
+                $model->scoutMetadata(),
+                ['id' => $model->getScoutKey()],
+            );
+        })->filter()->values()->all();
+
+        if (empty($rows)) {
+            return;
+        }
+
+        $settings = $this->modelSettings($model);
+
+        $parameters = ['upsert_rows' => $rows];
+
+        foreach (['schema', 'distance_metric'] as $option) {
+            if (isset($settings[$option])) {
+                $parameters[$option] = $settings[$option];
+            }
+        }
+
+        $this->turbopuffer->namespace($model->indexableAs())->write($parameters);
+    }
+
+    /**
+     * Remove the given models from the index.
+     */
+    public function delete($models)
+    {
+        if ($models->isEmpty()) {
+            return;
+        }
+
+        $keys = $models instanceof RemoveableScoutCollection
+            ? $models->pluck($models->first()->getScoutKeyName())
+            : $models->map->getScoutKey();
+
+        $this->turbopuffer
+            ->namespace($models->first()->indexableAs())
+            ->write(['deletes' => $keys->values()->all()]);
+    }
+
+    /**
+     * Perform the given search on the engine.
+     */
+    public function search(Builder $builder)
+    {
+        return $this->performSearch(
+            $builder,
+            $builder->limit ?? $builder->model->getPerPage()
+        );
+    }
+
+    /**
+     * Perform the given paginated search on the engine.
+     */
+    public function paginate(Builder $builder, $perPage, $page)
+    {
+        $page = max(1, (int) $page);
+        $perPage = max(1, (int) $perPage);
+        $maximum = min((int) ($builder->limit ?? 10000), 10000);
+        $window = $page * $perPage;
+
+        if ($window > 10000) {
+            throw new ScoutException('Turbopuffer search results may not be paginated beyond 10,000 records.');
+        }
+
+        $results = $this->performSearch($builder, min($window, $maximum));
+
+        $results['rows'] = array_slice(
+            $results['rows'] ?? [],
+            ($page - 1) * $perPage,
+            $perPage
+        );
+
+        $parameters = $this->buildSearchParameters($builder, 1);
+
+        $count = $this->namespace($builder)->query(array_filter([
+            'aggregate_by' => ['count' => ['Count']],
+            'filters' => $parameters['filters'] ?? null,
+            'consistency' => $parameters['consistency'] ?? null,
+        ], fn ($value) => ! is_null($value)));
+
+        $results['total'] = min((int) ($count['aggregations']['count'] ?? 0), $maximum);
+
+        return $results;
+    }
+
+    /**
+     * Perform a search against Turbopuffer.
+     */
+    protected function performSearch(Builder $builder, int $limit): array
+    {
+        $namespace = $this->namespace($builder);
+
+        $parameters = $this->buildSearchParameters($builder, $limit);
+
+        if ($builder->callback) {
+            return call_user_func($builder->callback, $namespace, $builder->query, $parameters);
+        }
+
+        $results = $namespace->query($parameters);
+
+        $results['total'] = count($results['rows'] ?? []);
+
+        return $results;
+    }
+
+    /**
+     * Build Turbopuffer search parameters for the query.
+     */
+    public function buildSearchParameters(Builder $builder, int $limit): array
+    {
+        if (isset($builder->options['queries'])) {
+            throw new ScoutException('Turbopuffer multi-query searches are not supported by this Scout engine.');
+        }
+
+        $parameters = $builder->options;
+        $nativeFilters = $parameters['filters'] ?? null;
+        $scoutFilters = $this->filters($builder);
+
+        unset($parameters['filters']);
+
+        if (! isset($parameters['rank_by'])) {
+            $parameters['rank_by'] = $this->rankBy($builder);
+        } elseif (! empty($builder->orders)) {
+            throw new ScoutException('Turbopuffer order clauses cannot be combined with a custom ranking expression.');
+        }
+
+        if ($filters = $this->combineFilters($nativeFilters, $scoutFilters)) {
+            $parameters['filters'] = $filters;
+        }
+
+        if (isset($parameters['include_attributes']) && is_array($parameters['include_attributes'])) {
+            $parameters['include_attributes'] = array_values(array_unique([
+                ...$parameters['include_attributes'],
+                'id',
+            ]));
+        }
+
+        if (isset($parameters['exclude_attributes']) && is_array($parameters['exclude_attributes'])) {
+            $parameters['exclude_attributes'] = array_values(array_diff($parameters['exclude_attributes'], ['id']));
+        }
+
+        $parameters['limit'] = min(max(1, $limit), 10000);
+
+        return $parameters;
+    }
+
+    /**
+     * Build the ranking expression for the query.
+     */
+    protected function rankBy(Builder $builder): array
+    {
+        if ($builder->query === '' || $builder->query === '*') {
+            if (count($builder->orders) > 1) {
+                throw new ScoutException('Turbopuffer supports one order clause per search.');
+            }
+
+            $order = $builder->orders[0] ?? ['column' => 'id', 'direction' => 'asc'];
+
+            return [$this->field($builder, $order['column']), $order['direction']];
+        }
+
+        if (! empty($builder->orders)) {
+            throw new ScoutException('Turbopuffer order clauses cannot be combined with full-text search.');
+        }
+
+        $attributes = $this->modelSettings($builder->model)['searchable-attributes'] ?? [];
+
+        if (empty($attributes)) {
+            throw new ScoutException('No Turbopuffer searchable attributes have been configured for ['.get_class($builder->model).'].');
+        }
+
+        $expressions = [];
+
+        foreach ($attributes as $key => $value) {
+            [$attribute, $weight] = is_int($key) ? [$value, 1] : [$key, $value];
+
+            if (! is_string($attribute) || ! is_numeric($weight) || $weight < 0) {
+                throw new ScoutException('Turbopuffer searchable attributes must contain attribute names with non-negative numeric weights.');
+            }
+
+            $expression = [$attribute, 'BM25', $builder->query];
+
+            $expressions[] = (float) $weight === 1.0
+                ? $expression
+                : ['Product', $weight, $expression];
+        }
+
+        return count($expressions) === 1
+            ? $expressions[0]
+            : ['Sum', $expressions];
+    }
+
+    /**
+     * Build filters for the query.
+     */
+    protected function filters(Builder $builder): ?array
+    {
+        $filters = [];
+
+        $operators = [
+            '=' => 'Eq',
+            '!=' => 'NotEq',
+            '<' => 'Lt',
+            '<=' => 'Lte',
+            '>' => 'Gt',
+            '>=' => 'Gte',
+        ];
+
+        foreach ($builder->wheres as $where) {
+            if (! isset($operators[$where['operator']])) {
+                throw new ScoutException("The [{$where['operator']}] operator is not supported by the Turbopuffer engine.");
+            }
+
+            $filters[] = [
+                $this->field($builder, $where['field']),
+                $operators[$where['operator']],
+                $this->filterValue($where['value']),
+            ];
+        }
+
+        foreach ($builder->whereIns as $field => $values) {
+            $filters[] = [$this->field($builder, $field), 'In', array_map([$this, 'filterValue'], $values)];
+        }
+
+        foreach ($builder->whereNotIns as $field => $values) {
+            $filters[] = [$this->field($builder, $field), 'NotIn', array_map([$this, 'filterValue'], $values)];
+        }
+
+        return match (count($filters)) {
+            0 => null,
+            1 => $filters[0],
+            default => ['And', $filters],
+        };
+    }
+
+    /**
+     * Combine native and Scout filters.
+     */
+    protected function combineFilters(?array $nativeFilters, ?array $scoutFilters): ?array
+    {
+        if (is_null($nativeFilters)) {
+            return $scoutFilters;
+        }
+
+        if (is_null($scoutFilters)) {
+            return $nativeFilters;
+        }
+
+        return ['And', [$nativeFilters, $scoutFilters]];
+    }
+
+    /**
+     * Normalize a filter value.
+     */
+    protected function filterValue($value)
+    {
+        return $value instanceof BackedEnum ? $value->value : $value;
+    }
+
+    /**
+     * Resolve a Scout field name to a Turbopuffer field name.
+     */
+    protected function field(Builder $builder, string $field): string
+    {
+        return $field === $builder->model->getScoutKeyName() ? 'id' : $field;
+    }
+
+    /**
+     * Pluck and return the primary keys of the given results.
+     */
+    public function mapIds($results)
+    {
+        return collect($results['rows'] ?? [])->pluck('id')->values();
+    }
+
+    /**
+     * Map the given results to model instances.
+     */
+    public function map(Builder $builder, $results, $model)
+    {
+        if (empty($results['rows'])) {
+            return $model->newCollection();
+        }
+
+        $rows = collect($results['rows']);
+        $objectIds = $rows->pluck('id')->values()->all();
+        $objectIdPositions = array_flip($objectIds);
+
+        return $model->getScoutModelsByIds($builder, $objectIds)
+            ->filter(fn ($model) => in_array($model->getScoutKey(), $objectIds, false))
+            ->map(function ($model) use ($rows, $objectIdPositions) {
+                $row = $rows[$objectIdPositions[$model->getScoutKey()]];
+
+                if (array_key_exists('$dist', $row)) {
+                    $model->withScoutMetadata('_turbopuffer_dist', $row['$dist']);
+                }
+
+                return $model;
+            })
+            ->sortBy(fn ($model) => $objectIdPositions[$model->getScoutKey()])
+            ->values();
+    }
+
+    /**
+     * Map the given results to model instances via a lazy collection.
+     */
+    public function lazyMap(Builder $builder, $results, $model)
+    {
+        if (empty($results['rows'])) {
+            return LazyCollection::make($model->newCollection());
+        }
+
+        $rows = collect($results['rows']);
+        $objectIds = $rows->pluck('id')->values()->all();
+        $objectIdPositions = array_flip($objectIds);
+
+        return $model->queryScoutModelsByIds($builder, $objectIds)
+            ->cursor()
+            ->filter(fn ($model) => in_array($model->getScoutKey(), $objectIds, false))
+            ->map(function ($model) use ($rows, $objectIdPositions) {
+                $row = $rows[$objectIdPositions[$model->getScoutKey()]];
+
+                if (array_key_exists('$dist', $row)) {
+                    $model->withScoutMetadata('_turbopuffer_dist', $row['$dist']);
+                }
+
+                return $model;
+            })
+            ->sortBy(fn ($model) => $objectIdPositions[$model->getScoutKey()])
+            ->values();
+    }
+
+    /**
+     * Get the total count from the raw results.
+     */
+    public function getTotalCount($results)
+    {
+        return (int) ($results['total'] ?? count($results['rows'] ?? []));
+    }
+
+    /**
+     * Flush all of the model's records from the engine.
+     */
+    public function flush($model)
+    {
+        return $this->deleteIndex($model->indexableAs());
+    }
+
+    /**
+     * Create a search index.
+     */
+    public function createIndex($name, array $options = [])
+    {
+        throw new NotSupportedException('Turbopuffer namespaces are created automatically upon adding documents.');
+    }
+
+    /**
+     * Delete a search index.
+     */
+    public function deleteIndex($name)
+    {
+        return $this->turbopuffer->namespace($name)->delete();
+    }
+
+    /**
+     * Get the configured settings for a model.
+     */
+    protected function modelSettings($model): array
+    {
+        return $this->config['model-settings'][get_class($model)] ?? [];
+    }
+
+    /**
+     * Get the Turbopuffer namespace for a search.
+     */
+    protected function namespace(Builder $builder)
+    {
+        return $this->turbopuffer->namespace(
+            $builder->index ?: $builder->model->searchableAs()
+        );
+    }
+
+    /**
+     * Determine if the model uses soft deletes.
+     */
+    protected function usesSoftDelete($model): bool
+    {
+        return in_array(SoftDeletes::class, class_uses_recursive($model), true);
+    }
+}

--- a/src/Engines/TurbopufferEngine.php
+++ b/src/Engines/TurbopufferEngine.php
@@ -6,12 +6,14 @@ use BackedEnum;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;
+use Laravel\Scout\Contracts\SupportsHybridSearch;
+use Laravel\Scout\Contracts\SupportsSemanticSearch;
 use Laravel\Scout\Exceptions\NotSupportedException;
 use Laravel\Scout\Exceptions\ScoutException;
 use Laravel\Scout\Jobs\RemoveableScoutCollection;
 use Laravel\Scout\Services\Turbopuffer\TurbopufferClient;
 
-class TurbopufferEngine extends Engine
+class TurbopufferEngine extends Engine implements SupportsHybridSearch, SupportsSemanticSearch
 {
     /**
      * Create a new Turbopuffer engine instance.
@@ -39,23 +41,30 @@ class TurbopufferEngine extends Engine
             $models->each->pushSoftDeleteMetadata();
         }
 
-        $rows = $models->map(function ($model) {
+        $records = $models->map(function ($model) {
             if (empty($searchableData = $model->toSearchableArray())) {
                 return;
             }
 
-            return array_merge(
-                $searchableData,
-                $model->scoutMetadata(),
-                ['id' => $model->getScoutKey()],
-            );
+            return [
+                'model' => $model,
+                'row' => array_merge(
+                    $searchableData,
+                    $model->scoutMetadata(),
+                    ['id' => $model->getScoutKey()],
+                ),
+            ];
         })->filter()->values()->all();
 
-        if (empty($rows)) {
+        if (empty($records)) {
             return;
         }
 
         $settings = $this->modelSettings($model);
+
+        $rows = isset($settings['embedding'])
+            ? $this->addEmbeddingsToRecords($records, $settings['embedding'])
+            : array_column($records, 'row');
 
         $parameters = ['upsert_rows' => $rows];
 
@@ -65,7 +74,46 @@ class TurbopufferEngine extends Engine
             }
         }
 
+        if (isset($settings['embedding']) && ! isset($parameters['distance_metric'])) {
+            $parameters['distance_metric'] = 'cosine_distance';
+        }
+
         $this->turbopuffer->namespace($model->indexableAs())->write($parameters);
+    }
+
+    /**
+     * Add generated embeddings to searchable records.
+     */
+    protected function addEmbeddingsToRecords(array $records, array $settings): array
+    {
+        $settings = $this->validateEmbeddingSettings($settings);
+
+        $rows = [];
+
+        foreach (array_chunk($records, 100) as $batch) {
+            $inputs = array_map(function ($record) {
+                if (! method_exists($record['model'], 'toSearchableEmbedding')) {
+                    throw new ScoutException('Searchable models using generated embeddings must define a [toSearchableEmbedding] method.');
+                }
+
+                $input = $record['model']->toSearchableEmbedding();
+
+                if (! is_string($input) || trim($input) === '') {
+                    throw new ScoutException('The [toSearchableEmbedding] method must return a non-empty string.');
+                }
+
+                return $input;
+            }, $batch);
+
+            $vectors = $this->generateEmbeddings($inputs, $settings);
+
+            foreach ($batch as $index => $record) {
+                $record['row'][$settings['attribute']] = $vectors[$index];
+                $rows[] = $record['row'];
+            }
+        }
+
+        return $rows;
     }
 
     /**
@@ -119,12 +167,14 @@ class TurbopufferEngine extends Engine
             $perPage
         );
 
-        $parameters = $this->buildSearchParameters($builder, 1);
+        $nativeFilters = $builder->options['filters'] ?? null;
+
+        $filters = $this->combineFilters($nativeFilters, $this->filters($builder));
 
         $count = $this->namespace($builder)->query(array_filter([
             'aggregate_by' => ['count' => ['Count']],
-            'filters' => $parameters['filters'] ?? null,
-            'consistency' => $parameters['consistency'] ?? null,
+            'filters' => $filters,
+            'consistency' => $builder->options['consistency'] ?? null,
         ], fn ($value) => ! is_null($value)));
 
         $results['total'] = min((int) ($count['aggregations']['count'] ?? 0), $maximum);
@@ -141,11 +191,13 @@ class TurbopufferEngine extends Engine
 
         $parameters = $this->buildSearchParameters($builder, $limit);
 
-        if ($builder->callback) {
-            return call_user_func($builder->callback, $namespace, $builder->query, $parameters);
-        }
+        $results = $builder->callback
+            ? call_user_func($builder->callback, $namespace, $builder->query, $parameters)
+            : $namespace->query($parameters);
 
-        $results = $namespace->query($parameters);
+        if (! is_null($builder->hybridSearch)) {
+            $results['rows'] = array_slice($results['results'][0]['rows'] ?? [], 0, $limit);
+        }
 
         $results['total'] = count($results['rows'] ?? []);
 
@@ -161,11 +213,19 @@ class TurbopufferEngine extends Engine
             throw new ScoutException('Turbopuffer multi-query searches are not supported by this Scout engine.');
         }
 
+        if (! is_null($builder->hybridSearch)) {
+            return $this->buildHybridSearchParameters($builder, $limit);
+        }
+
         $parameters = $builder->options;
         $nativeFilters = $parameters['filters'] ?? null;
         $scoutFilters = $this->filters($builder);
 
         unset($parameters['filters']);
+
+        if ($builder->semanticSearch && isset($parameters['rank_by'])) {
+            throw new ScoutException('Turbopuffer semantic searches cannot be combined with a custom ranking expression.');
+        }
 
         if (! isset($parameters['rank_by'])) {
             $parameters['rank_by'] = $this->rankBy($builder);
@@ -177,20 +237,52 @@ class TurbopufferEngine extends Engine
             $parameters['filters'] = $filters;
         }
 
-        if (isset($parameters['include_attributes']) && is_array($parameters['include_attributes'])) {
-            $parameters['include_attributes'] = array_values(array_unique([
-                ...$parameters['include_attributes'],
-                'id',
-            ]));
-        }
-
-        if (isset($parameters['exclude_attributes']) && is_array($parameters['exclude_attributes'])) {
-            $parameters['exclude_attributes'] = array_values(array_diff($parameters['exclude_attributes'], ['id']));
-        }
-
+        $parameters = $this->ensureIdIsReturned($parameters);
         $parameters['limit'] = min(max(1, $limit), 10000);
 
         return $parameters;
+    }
+
+    /**
+     * Build a hybrid full-text and semantic query.
+     */
+    protected function buildHybridSearchParameters(Builder $builder, int $limit): array
+    {
+        if (! empty($builder->orders)) {
+            throw new ScoutException('Turbopuffer order clauses cannot be combined with hybrid search.');
+        }
+
+        foreach (['rank_by', 'rerank_by'] as $option) {
+            if (isset($builder->options[$option])) {
+                throw new ScoutException("Turbopuffer hybrid searches cannot be combined with a custom [{$option}] option.");
+            }
+        }
+
+        $parameters = $builder->options;
+        $nativeFilters = $parameters['filters'] ?? null;
+        $rootParameters = array_intersect_key($parameters, array_flip(['consistency', 'vector_encoding']));
+
+        unset($parameters['consistency'], $parameters['filters'], $parameters['vector_encoding']);
+
+        if ($filters = $this->combineFilters($nativeFilters, $this->filters($builder))) {
+            $parameters['filters'] = $filters;
+        }
+
+        $parameters = $this->ensureIdIsReturned($parameters);
+        $parameters['limit'] = min(max(1, $limit), 10000);
+
+        return array_merge($rootParameters, [
+            'queries' => [
+                array_merge($parameters, ['rank_by' => $this->fullTextRankBy($builder)]),
+                array_merge($parameters, ['rank_by' => $this->semanticRankBy($builder)]),
+            ],
+            'rerank_by' => ['RRF', [
+                'weights' => [
+                    $builder->hybridSearch['text_weight'],
+                    $builder->hybridSearch['semantic_weight'],
+                ],
+            ]],
+        ]);
     }
 
     /**
@@ -198,6 +290,14 @@ class TurbopufferEngine extends Engine
      */
     protected function rankBy(Builder $builder): array
     {
+        if ($builder->semanticSearch) {
+            if (! empty($builder->orders)) {
+                throw new ScoutException('Turbopuffer order clauses cannot be combined with semantic search.');
+            }
+
+            return $this->semanticRankBy($builder);
+        }
+
         if ($builder->query === '' || $builder->query === '*') {
             if (count($builder->orders) > 1) {
                 throw new ScoutException('Turbopuffer supports one order clause per search.');
@@ -212,6 +312,14 @@ class TurbopufferEngine extends Engine
             throw new ScoutException('Turbopuffer order clauses cannot be combined with full-text search.');
         }
 
+        return $this->fullTextRankBy($builder);
+    }
+
+    /**
+     * Build the full-text ranking expression for a query.
+     */
+    protected function fullTextRankBy(Builder $builder): array
+    {
         $attributes = $this->modelSettings($builder->model)['searchable-attributes'] ?? [];
 
         if (empty($attributes)) {
@@ -237,6 +345,20 @@ class TurbopufferEngine extends Engine
         return count($expressions) === 1
             ? $expressions[0]
             : ['Sum', $expressions];
+    }
+
+    /**
+     * Build the semantic ranking expression for a query.
+     */
+    protected function semanticRankBy(Builder $builder): array
+    {
+        $settings = $this->embeddingSettings($builder->model);
+
+        return [
+            $settings['attribute'],
+            'ANN',
+            $this->generateEmbeddings([$builder->query], $settings)[0],
+        ];
     }
 
     /**
@@ -304,6 +426,25 @@ class TurbopufferEngine extends Engine
     protected function filterValue($value)
     {
         return $value instanceof BackedEnum ? $value->value : $value;
+    }
+
+    /**
+     * Ensure the Scout key is returned for model hydration.
+     */
+    protected function ensureIdIsReturned(array $parameters): array
+    {
+        if (isset($parameters['include_attributes']) && is_array($parameters['include_attributes'])) {
+            $parameters['include_attributes'] = array_values(array_unique([
+                ...$parameters['include_attributes'],
+                'id',
+            ]));
+        }
+
+        if (isset($parameters['exclude_attributes']) && is_array($parameters['exclude_attributes'])) {
+            $parameters['exclude_attributes'] = array_values(array_diff($parameters['exclude_attributes'], ['id']));
+        }
+
+        return $parameters;
     }
 
     /**
@@ -417,6 +558,62 @@ class TurbopufferEngine extends Engine
     protected function modelSettings($model): array
     {
         return $this->config['model-settings'][get_class($model)] ?? [];
+    }
+
+    /**
+     * Get the validated embedding settings for a model.
+     */
+    protected function embeddingSettings($model): array
+    {
+        $settings = $this->modelSettings($model)['embedding'] ?? null;
+
+        if (! is_array($settings)) {
+            throw new ScoutException('No Turbopuffer embedding settings have been configured for ['.get_class($model).'].');
+        }
+
+        return $this->validateEmbeddingSettings($settings);
+    }
+
+    /**
+     * Validate embedding configuration shared by indexing and querying.
+     */
+    protected function validateEmbeddingSettings(array $settings): array
+    {
+        if (! isset($settings['attribute']) || ! is_string($settings['attribute']) || trim($settings['attribute']) === '') {
+            throw new ScoutException('Turbopuffer embedding settings must contain an [attribute].');
+        }
+
+        if (! isset($settings['dimensions']) || filter_var($settings['dimensions'], FILTER_VALIDATE_INT) === false || $settings['dimensions'] < 1) {
+            throw new ScoutException('Turbopuffer embedding settings must contain positive [dimensions].');
+        }
+
+        $settings['dimensions'] = (int) $settings['dimensions'];
+
+        return $settings;
+    }
+
+    /**
+     * Generate and validate embeddings using the optional Laravel AI SDK.
+     */
+    protected function generateEmbeddings(array $inputs, array $settings): array
+    {
+        $embeddingsClass = 'Laravel\\Ai\\Embeddings';
+
+        if (! class_exists($embeddingsClass)) {
+            throw new ScoutException('Semantic search requires the Laravel AI SDK. Please install the [laravel/ai] package.');
+        }
+
+        $response = $embeddingsClass::for(array_values($inputs))
+            ->dimensions($settings['dimensions'])
+            ->generate($settings['provider'] ?? null, $settings['model'] ?? null);
+
+        $embeddings = $response->embeddings;
+
+        if (! is_array($embeddings) || count($embeddings) !== count($inputs)) {
+            throw new ScoutException('Laravel AI returned an unexpected number of embeddings.');
+        }
+
+        return $embeddings;
     }
 
     /**

--- a/src/Engines/TurbopufferEngine.php
+++ b/src/Engines/TurbopufferEngine.php
@@ -61,15 +61,37 @@ class TurbopufferEngine extends Engine implements SupportsSemanticSearch
 
         $settings = $this->modelSettings($model);
 
-        $rows = isset($settings['embedding'])
-            ? $this->addEmbeddingsToRecords($records, $settings['embedding'])
+        $embeddingSettings = isset($settings['embedding'])
+            ? $this->embeddingSettings($model)
+            : null;
+
+        $rows = $embeddingSettings && ! $this->usesNativeEmbeddings($embeddingSettings)
+            ? $this->addEmbeddingsToRecords($records, $embeddingSettings)
             : array_column($records, 'row');
+
+        if ($embeddingSettings && $this->usesNativeEmbeddings($embeddingSettings)) {
+            $rows = array_map(function ($row) use ($embeddingSettings) {
+                unset($row[$embeddingSettings['generated_attribute']]);
+
+                return $row;
+            }, $rows);
+        }
 
         $parameters = ['upsert_rows' => $rows];
 
         foreach (['schema', 'distance_metric'] as $option) {
             if (isset($settings[$option])) {
                 $parameters[$option] = $settings[$option];
+            }
+        }
+
+        if ($embeddingSettings && $this->usesNativeEmbeddings($embeddingSettings)) {
+            $embed = &$parameters['schema'][$embeddingSettings['attribute']]['embed'];
+
+            if (is_array($embed) && isset($embed['dimensions'])) {
+                $embed['dims'] = (int) $embed['dimensions'];
+
+                unset($embed['dimensions']);
             }
         }
 
@@ -371,7 +393,9 @@ class TurbopufferEngine extends Engine implements SupportsSemanticSearch
         return [
             $settings['attribute'],
             'ANN',
-            $this->generateEmbeddings([$builder->query], $settings)[0],
+            $this->usesNativeEmbeddings($settings)
+                ? ['Embed', $builder->query]
+                : $this->generateEmbeddings([$builder->query], $settings)[0],
         ];
     }
 
@@ -579,13 +603,27 @@ class TurbopufferEngine extends Engine implements SupportsSemanticSearch
      */
     protected function embeddingSettings($model): array
     {
-        $settings = $this->modelSettings($model)['embedding'] ?? null;
+        $modelSettings = $this->modelSettings($model);
+
+        $settings = $modelSettings['embedding'] ?? null;
 
         if (! is_array($settings)) {
             throw new ScoutException('No Turbopuffer embedding settings have been configured for ['.get_class($model).'].');
         }
 
-        return $this->validateEmbeddingSettings($settings);
+        $settings = $this->validateEmbeddingSettings($settings);
+
+        if ($this->usesNativeEmbeddings($settings)) {
+            $schema = $modelSettings['schema'][$settings['attribute']] ?? null;
+
+            if (! is_array($schema) || ($schema['type'] ?? null) !== 'string') {
+                throw new ScoutException("Turbopuffer native embeddings require a string schema configuration for the [{$settings['attribute']}] attribute.");
+            }
+
+            $settings['generated_attribute'] = $this->validateNativeEmbeddingSchema($settings['attribute'], $schema['embed'] ?? null);
+        }
+
+        return $settings;
     }
 
     /**
@@ -597,13 +635,59 @@ class TurbopufferEngine extends Engine implements SupportsSemanticSearch
             throw new ScoutException('Turbopuffer embedding settings must contain an [attribute].');
         }
 
-        if (! isset($settings['dimensions']) || filter_var($settings['dimensions'], FILTER_VALIDATE_INT) === false || $settings['dimensions'] < 1) {
+        $driver = $settings['driver'] ?? 'laravel-ai';
+
+        if (! in_array($driver, ['laravel-ai', 'turbopuffer'], true)) {
+            throw new ScoutException("The [{$driver}] Turbopuffer embedding driver is not supported.");
+        }
+
+        $settings['driver'] = $driver;
+
+        if ($this->usesNativeEmbeddings($settings)) {
+            return $settings;
+        }
+
+        if (! isset($settings['dimensions']) ||
+            filter_var($settings['dimensions'], FILTER_VALIDATE_INT) === false ||
+            $settings['dimensions'] < 1) {
             throw new ScoutException('Turbopuffer embedding settings must contain positive [dimensions].');
         }
 
         $settings['dimensions'] = (int) $settings['dimensions'];
 
         return $settings;
+    }
+
+    /**
+     * Determine if Turbopuffer should generate embeddings natively.
+     */
+    protected function usesNativeEmbeddings(array $settings): bool
+    {
+        return ($settings['driver'] ?? null) === 'turbopuffer';
+    }
+
+    /**
+     * Validate a native embedding schema and return its vector attribute.
+     */
+    protected function validateNativeEmbeddingSchema(string $attribute, $embed): string
+    {
+        if (is_string($embed) && trim($embed) !== '') {
+            return 'embed_'.$attribute;
+        }
+
+        if (! is_array($embed) || ! isset($embed['model']) || ! is_string($embed['model']) || trim($embed['model']) === '') {
+            throw new ScoutException("Turbopuffer native embeddings require a valid [embed] schema configuration for the [{$attribute}] attribute.");
+        }
+
+        if (isset($embed['dimensions']) && (filter_var($embed['dimensions'], FILTER_VALIDATE_INT) === false || $embed['dimensions'] < 1)) {
+            throw new ScoutException('Turbopuffer native embedding [dimensions] must be a positive integer.');
+        }
+
+        if (isset($embed['attribute']) && (! is_string($embed['attribute']) || trim($embed['attribute']) === '')) {
+            throw new ScoutException('Turbopuffer native embedding [attribute] must be a non-empty string.');
+        }
+
+        return $embed['attribute'] ?? 'embed_'.$attribute;
     }
 
     /**

--- a/src/Engines/TurbopufferEngine.php
+++ b/src/Engines/TurbopufferEngine.php
@@ -90,21 +90,36 @@ class TurbopufferEngine extends Engine implements SupportsSemanticSearch
         $rows = [];
 
         foreach (array_chunk($records, 100) as $batch) {
-            $inputs = array_map(function ($record) {
+            $inputs = [];
+            $vectors = [];
+
+            foreach ($batch as $index => $record) {
                 if (! method_exists($record['model'], 'toSearchableEmbedding')) {
                     throw new ScoutException('Searchable models using generated embeddings must define a [toSearchableEmbedding] method.');
                 }
 
                 $input = $record['model']->toSearchableEmbedding();
 
-                if (! is_string($input) || trim($input) === '') {
-                    throw new ScoutException('The [toSearchableEmbedding] method must return a non-empty string.');
+                if (is_array($input)) {
+                    $vectors[$index] = $input;
+
+                    continue;
                 }
 
-                return $input;
-            }, $batch);
+                if (! is_string($input) || trim($input) === '') {
+                    throw new ScoutException('The [toSearchableEmbedding] method must return a non-empty string or an embedding array.');
+                }
 
-            $vectors = $this->generateEmbeddings($inputs, $settings);
+                $inputs[$index] = $input;
+            }
+
+            if (! empty($inputs)) {
+                $generatedVectors = $this->generateEmbeddings(array_values($inputs), $settings);
+
+                foreach (array_keys($inputs) as $position => $index) {
+                    $vectors[$index] = $generatedVectors[$position];
+                }
+            }
 
             foreach ($batch as $index => $record) {
                 $record['row'][$settings['attribute']] = $vectors[$index];

--- a/src/Engines/TurbopufferEngine.php
+++ b/src/Engines/TurbopufferEngine.php
@@ -6,14 +6,13 @@ use BackedEnum;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;
-use Laravel\Scout\Contracts\SupportsHybridSearch;
 use Laravel\Scout\Contracts\SupportsSemanticSearch;
 use Laravel\Scout\Exceptions\NotSupportedException;
 use Laravel\Scout\Exceptions\ScoutException;
 use Laravel\Scout\Jobs\RemoveableScoutCollection;
 use Laravel\Scout\Services\Turbopuffer\TurbopufferClient;
 
-class TurbopufferEngine extends Engine implements SupportsHybridSearch, SupportsSemanticSearch
+class TurbopufferEngine extends Engine implements SupportsSemanticSearch
 {
     /**
      * Create a new Turbopuffer engine instance.

--- a/src/Engines/TurbopufferEngine.php
+++ b/src/Engines/TurbopufferEngine.php
@@ -619,6 +619,7 @@ class TurbopufferEngine extends Engine implements SupportsSemanticSearch
 
         $response = $embeddingsClass::for(array_values($inputs))
             ->dimensions($settings['dimensions'])
+            ->cache()
             ->generate($settings['provider'] ?? null, $settings['model'] ?? null);
 
         $embeddings = $response->embeddings;

--- a/src/ScoutServiceProvider.php
+++ b/src/ScoutServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Scout;
 
+use Illuminate\Http\Client\Factory as HttpFactory;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Scout\Console\DeleteAllIndexesCommand;
 use Laravel\Scout\Console\DeleteIndexCommand;
@@ -10,6 +11,7 @@ use Laravel\Scout\Console\ImportCommand;
 use Laravel\Scout\Console\IndexCommand;
 use Laravel\Scout\Console\QueueImportCommand;
 use Laravel\Scout\Console\SyncIndexSettingsCommand;
+use Laravel\Scout\Services\Turbopuffer\TurbopufferClient;
 use Meilisearch\Client as Meilisearch;
 
 class ScoutServiceProvider extends ServiceProvider
@@ -34,6 +36,13 @@ class ScoutServiceProvider extends ServiceProvider
                 );
             });
         }
+
+        $this->app->singleton(TurbopufferClient::class, function ($app) {
+            return new TurbopufferClient(
+                $app->make(HttpFactory::class),
+                $app['config']->get('scout.turbopuffer', []),
+            );
+        });
 
         $this->app->singleton(EngineManager::class, function ($app) {
             return new EngineManager($app);

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -396,6 +396,16 @@ trait Searchable
     }
 
     /**
+     * Get the database column that stores the searchable embedding.
+     *
+     * @return string
+     */
+    public function searchableEmbeddingColumn()
+    {
+        return 'embedding';
+    }
+
+    /**
      * Get the indexable data array for the model.
      *
      * @return array

--- a/src/Services/Turbopuffer/TurbopufferClient.php
+++ b/src/Services/Turbopuffer/TurbopufferClient.php
@@ -49,7 +49,7 @@ class TurbopufferClient
         $request = $this->http
             ->baseUrl(rtrim($baseUrl, '/'))
             ->withToken($this->config['api_key'] ?? '')
-            ->withHeader('X-Laravel-Scout', Scout::VERSION)
+            ->withHeaders(['X-Laravel-Scout' => Scout::VERSION])
             ->acceptJson()
             ->asJson()
             ->timeout($this->config['timeout'] ?? 60)

--- a/src/Services/Turbopuffer/TurbopufferClient.php
+++ b/src/Services/Turbopuffer/TurbopufferClient.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Laravel\Scout\Services\Turbopuffer;
+
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\Factory;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\RequestException;
+use Laravel\Scout\Exceptions\ScoutException;
+
+class TurbopufferClient
+{
+    /**
+     * Create a new Turbopuffer client instance.
+     */
+    public function __construct(
+        protected Factory $http,
+        protected array $config
+    ) {
+        //
+    }
+
+    /**
+     * Send a request to Turbopuffer.
+     */
+    public function request(string $method, string $uri, array $options = []): array
+    {
+        $response = $this->pendingRequest()->send($method, $uri, $options);
+
+        if ($response->status() === 202) {
+            throw new ScoutException('The Turbopuffer index required by this operation is still building.');
+        }
+
+        return $response->throw()->json() ?? [];
+    }
+
+    /**
+     * Create a pending HTTP request.
+     */
+    protected function pendingRequest(): PendingRequest
+    {
+        $baseUrl = $this->config['base_url'] ?? null;
+
+        if (empty($baseUrl)) {
+            $baseUrl = sprintf('https://%s.turbopuffer.com', $this->config['region'] ?? 'gcp-us-central1');
+        }
+
+        $request = $this->http
+            ->baseUrl(rtrim($baseUrl, '/'))
+            ->withToken($this->config['api_key'] ?? '')
+            ->acceptJson()
+            ->asJson()
+            ->timeout($this->config['timeout'] ?? 60)
+            ->connectTimeout($this->config['connect_timeout'] ?? 5);
+
+        $retries = (int) ($this->config['retries'] ?? 3);
+
+        if ($retries > 0) {
+            $request->retry($retries + 1, 250, function ($exception) {
+                return $exception instanceof ConnectionException ||
+                    ($exception instanceof RequestException && in_array($exception->response->status(), [408, 409, 429, 500, 502, 503, 504], true));
+            });
+        }
+
+        return $request;
+    }
+
+    /**
+     * Get a Turbopuffer namespace instance.
+     */
+    public function namespace(string $name): TurbopufferNamespace
+    {
+        if (! preg_match('/^[A-Za-z0-9_.-]{1,128}$/', $name)) {
+            throw new ScoutException("Invalid Turbopuffer namespace [{$name}].");
+        }
+
+        return new TurbopufferNamespace($this, $name);
+    }
+}

--- a/src/Services/Turbopuffer/TurbopufferClient.php
+++ b/src/Services/Turbopuffer/TurbopufferClient.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Client\Factory;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\RequestException;
 use Laravel\Scout\Exceptions\ScoutException;
+use Laravel\Scout\Scout;
 
 class TurbopufferClient
 {
@@ -48,6 +49,7 @@ class TurbopufferClient
         $request = $this->http
             ->baseUrl(rtrim($baseUrl, '/'))
             ->withToken($this->config['api_key'] ?? '')
+            ->withHeader('X-Laravel-Scout', Scout::VERSION)
             ->acceptJson()
             ->asJson()
             ->timeout($this->config['timeout'] ?? 60)

--- a/src/Services/Turbopuffer/TurbopufferNamespace.php
+++ b/src/Services/Turbopuffer/TurbopufferNamespace.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Laravel\Scout\Services\Turbopuffer;
+
+class TurbopufferNamespace
+{
+    /**
+     * Create a new Turbopuffer namespace instance.
+     */
+    public function __construct(
+        protected TurbopufferClient $client,
+        protected string $name
+    ) {
+        //
+    }
+
+    /**
+     * Query the namespace.
+     */
+    public function query(array $parameters): array
+    {
+        return $this->client->request('POST', $this->uri().'/query', ['json' => $parameters]);
+    }
+
+    /**
+     * Write documents to the namespace.
+     */
+    public function write(array $parameters): array
+    {
+        return $this->client->request('POST', $this->uri(), ['json' => $parameters]);
+    }
+
+    /**
+     * Delete the namespace.
+     */
+    public function delete(): array
+    {
+        return $this->client->request('DELETE', $this->uri());
+    }
+
+    /**
+     * Get the namespace API URI.
+     */
+    protected function uri(): string
+    {
+        return '/v2/namespaces/'.rawurlencode($this->name);
+    }
+}

--- a/tests/Feature/DatabaseEngineTest.php
+++ b/tests/Feature/DatabaseEngineTest.php
@@ -4,6 +4,7 @@ namespace Laravel\Scout\Tests\Feature;
 
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
+use Laravel\Scout\Exceptions\NotSupportedException;
 use Orchestra\Testbench\Concerns\WithLaravelMigrations;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
@@ -40,6 +41,22 @@ class DatabaseEngineTest extends TestCase
         $models = SearchableUser::search()->get();
 
         $this->assertCount(2, $models);
+    }
+
+    public function test_semantic_search_requires_postgres_and_laravel_13()
+    {
+        $this->expectException(NotSupportedException::class);
+        $this->expectExceptionMessage('requires Laravel 13 and PostgreSQL with pgvector');
+
+        SearchableUser::search('Taylor')->semantic()->get();
+    }
+
+    public function test_hybrid_search_falls_back_to_normal_text_search_when_vectors_are_not_supported()
+    {
+        $models = SearchableUser::search('Taylor')->hybrid()->get();
+
+        $this->assertCount(1, $models);
+        $this->assertSame('Taylor Otwell', $models->first()->name);
     }
 
     public function test_it_does_not_add_search_where_clauses_with_empty_search()

--- a/tests/Feature/Engines/TurbopufferEngineTest.php
+++ b/tests/Feature/Engines/TurbopufferEngineTest.php
@@ -11,6 +11,7 @@ use Laravel\Scout\Exceptions\NotSupportedException;
 use Laravel\Scout\Exceptions\ScoutException;
 use Laravel\Scout\Tests\Fixtures\FakeEmbeddings;
 use Laravel\Scout\Tests\Fixtures\SearchableModel;
+use Laravel\Scout\Tests\Fixtures\SearchableModelWithPrecomputedEmbedding;
 use Laravel\Scout\Tests\Fixtures\SearchableModelWithSoftDeletes;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
@@ -134,6 +135,27 @@ class TurbopufferEngineTest extends TestCase
                 $request['schema']['embedding'] === ['type' => '[2]f32', 'ann' => true] &&
                 $request['distance_metric'] === 'cosine_distance';
         });
+    }
+
+    public function test_update_accepts_precomputed_embeddings_and_only_generates_missing_vectors()
+    {
+        $this->configureEmbeddings([], SearchableModelWithPrecomputedEmbedding::class);
+        $this->fakeEmbeddings([[[0.3, 0.4]]]);
+        Http::fake(['*' => Http::response(['rows_affected' => 2])]);
+
+        $precomputed = new SearchableModelWithPrecomputedEmbedding(['id' => 10, 'name' => 'Precomputed']);
+        $precomputed->setAttribute('embedding', [0.1, 0.2]);
+
+        $generated = new SearchableModelWithPrecomputedEmbedding(['id' => 20, 'name' => 'Generate this']);
+
+        $this->engine()->update($precomputed->newCollection([$precomputed, $generated]));
+
+        $this->assertSame(['Generate this'], FakeEmbeddings::$requests[0]['inputs']);
+
+        Http::assertSent(fn (Request $request) => $request['upsert_rows'] === [
+            ['id' => 10, 'name' => 'Precomputed', 'embedding' => [0.1, 0.2]],
+            ['id' => 20, 'name' => 'Generate this', 'embedding' => [0.3, 0.4]],
+        ]);
     }
 
     public function test_delete_sends_one_batched_request()
@@ -396,7 +418,7 @@ class TurbopufferEngineTest extends TestCase
         return $this->app->make(EngineManager::class)->engine('turbopuffer');
     }
 
-    protected function configureEmbeddings(array $overrides = []): void
+    protected function configureEmbeddings(array $overrides = [], string $model = SearchableModel::class): void
     {
         $config = $this->app['config']->get('scout.turbopuffer');
         $settings = $config['model-settings'][SearchableModel::class];
@@ -407,7 +429,7 @@ class TurbopufferEngineTest extends TestCase
         ], $overrides);
         $settings['schema']['embedding'] = ['type' => '[2]f32', 'ann' => true];
 
-        $config['model-settings'][SearchableModel::class] = $settings;
+        $config['model-settings'][$model] = $settings;
 
         $this->app['config']->set('scout.turbopuffer', $config);
     }

--- a/tests/Feature/Engines/TurbopufferEngineTest.php
+++ b/tests/Feature/Engines/TurbopufferEngineTest.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace Laravel\Scout\Tests\Feature\Engines;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Scout\Builder;
+use Laravel\Scout\EngineManager;
+use Laravel\Scout\Engines\TurbopufferEngine;
+use Laravel\Scout\Exceptions\NotSupportedException;
+use Laravel\Scout\Exceptions\ScoutException;
+use Laravel\Scout\Tests\Fixtures\SearchableModel;
+use Laravel\Scout\Tests\Fixtures\SearchableModelWithSoftDeletes;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+
+class TurbopufferEngineTest extends TestCase
+{
+    use WithWorkbench;
+
+    protected function defineEnvironment($app)
+    {
+        $app['config']->set('scout.driver', 'turbopuffer');
+        $app['config']->set('scout.soft_delete', true);
+        $app['config']->set('scout.turbopuffer', [
+            'api_key' => 'tpuf-test-key',
+            'region' => 'gcp-us-central1',
+            'base_url' => 'https://turbopuffer.test',
+            'retries' => 0,
+            'model-settings' => [
+                SearchableModel::class => [
+                    'searchable-attributes' => [
+                        'name' => 3,
+                        'description' => 1,
+                    ],
+                    'schema' => [
+                        'name' => ['type' => 'string', 'full_text_search' => true],
+                        'description' => ['type' => 'string', 'full_text_search' => true],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function test_driver_is_registered()
+    {
+        $this->assertInstanceOf(
+            TurbopufferEngine::class,
+            $this->app->make(EngineManager::class)->engine()
+        );
+    }
+
+    public function test_update_upserts_models_with_schema_and_scout_ids()
+    {
+        Http::fake(['*' => Http::response(['rows_affected' => 1])]);
+
+        $model = new SearchableModel(['id' => 10, 'name' => 'Taylor']);
+
+        $this->engine()->update($model->newCollection([$model]));
+
+        Http::assertSent(function (Request $request) {
+            return $request->method() === 'POST' &&
+                $request->url() === 'https://turbopuffer.test/v2/namespaces/table' &&
+                $request->hasHeader('Authorization', 'Bearer tpuf-test-key') &&
+                $request['upsert_rows'] === [['id' => 10, 'name' => 'Taylor']] &&
+                $request['schema'] === [
+                    'name' => ['type' => 'string', 'full_text_search' => true],
+                    'description' => ['type' => 'string', 'full_text_search' => true],
+                ];
+        });
+    }
+
+    public function test_update_adds_soft_delete_metadata()
+    {
+        Http::fake(['*' => Http::response(['rows_affected' => 1])]);
+
+        $model = new SearchableModelWithSoftDeletes;
+        $model->setAttribute('id', 10);
+
+        $this->engine()->update($model->newCollection([$model]));
+
+        Http::assertSent(fn (Request $request) => $request['upsert_rows'][0] === [
+            'id' => 10,
+            '__soft_deleted' => 0,
+        ]);
+    }
+
+    public function test_delete_sends_one_batched_request()
+    {
+        Http::fake(['*' => Http::response(['rows_affected' => 2])]);
+
+        $models = (new SearchableModel)->newCollection([
+            new SearchableModel(['id' => 10]),
+            new SearchableModel(['id' => 20]),
+        ]);
+
+        $this->engine()->delete($models);
+
+        Http::assertSent(fn (Request $request) => $request['deletes'] === [10, 20]);
+    }
+
+    public function test_search_builds_weighted_bm25_and_scout_filters()
+    {
+        Http::fake(['*' => Http::response([
+            'rows' => [['id' => 10, '$dist' => 1.25]],
+            'billing' => ['billable_logical_bytes_queried' => 100],
+        ])]);
+
+        $builder = (new Builder(new SearchableModel, 'laravel'))
+            ->where('status', 'published')
+            ->where('age', '>=', 18)
+            ->whereIn('language', ['en', 'fr'])
+            ->whereNotIn('category', ['archived'])
+            ->take(25);
+
+        $results = $this->engine()->search($builder);
+
+        $this->assertSame(10, $results['rows'][0]['id']);
+        $this->assertSame(100, $results['billing']['billable_logical_bytes_queried']);
+
+        Http::assertSent(function (Request $request) {
+            return $request->url() === 'https://turbopuffer.test/v2/namespaces/table/query' &&
+                $request['rank_by'] === ['Sum', [
+                    ['Product', 3, ['name', 'BM25', 'laravel']],
+                    ['description', 'BM25', 'laravel'],
+                ]] &&
+                $request['filters'] === ['And', [
+                    ['status', 'Eq', 'published'],
+                    ['age', 'Gte', 18],
+                    ['language', 'In', ['en', 'fr']],
+                    ['category', 'NotIn', ['archived']],
+                ]] &&
+                $request['limit'] === 25;
+        });
+    }
+
+    public function test_search_accepts_a_native_vector_ranking_expression()
+    {
+        Http::fake(['*' => Http::response(['rows' => []])]);
+
+        $builder = (new Builder(new SearchableModel, ''))
+            ->options([
+                'rank_by' => ['embedding', 'ANN', [0.1, 0.2]],
+                'include_attributes' => ['name'],
+                'consistency' => ['level' => 'eventual'],
+            ]);
+
+        $this->engine()->search($builder);
+
+        Http::assertSent(fn (Request $request) =>
+            $request['rank_by'] === ['embedding', 'ANN', [0.1, 0.2]] &&
+            $request['include_attributes'] === ['name', 'id'] &&
+            $request['consistency'] === ['level' => 'eventual']
+        );
+    }
+
+    public function test_match_all_search_uses_the_requested_order()
+    {
+        Http::fake(['*' => Http::response(['rows' => []])]);
+
+        $builder = (new Builder(new SearchableModel, '*'))->orderByDesc('created_at');
+
+        $this->engine()->search($builder);
+
+        Http::assertSent(fn (Request $request) => $request['rank_by'] === ['created_at', 'desc']);
+    }
+
+    public function test_paginate_slices_the_ranked_window_and_reports_a_capped_candidate_count()
+    {
+        Http::fake(function (Request $request) {
+            if (isset($request['aggregate_by'])) {
+                return Http::response(['aggregations' => ['count' => 12000]]);
+            }
+
+            return Http::response(['rows' => [
+                ['id' => 1],
+                ['id' => 2],
+                ['id' => 3],
+                ['id' => 4],
+            ]]);
+        });
+
+        $builder = (new Builder(new SearchableModel, 'laravel'))->where('status', 'published');
+        $results = $this->engine()->paginate($builder, 2, 2);
+
+        $this->assertSame([3, 4], array_column($results['rows'], 'id'));
+        $this->assertSame(10000, $results['total']);
+
+        Http::assertSent(fn (Request $request) =>
+            isset($request['aggregate_by']) &&
+            $request['filters'] === ['status', 'Eq', 'published']
+        );
+    }
+
+    public function test_pagination_rejects_windows_above_turbopuffer_limit()
+    {
+        Http::preventStrayRequests();
+
+        $this->expectException(ScoutException::class);
+        $this->expectExceptionMessage('10,000');
+
+        $this->engine()->paginate(new Builder(new SearchableModel, 'laravel'), 100, 101);
+    }
+
+    public function test_flush_deletes_the_namespace()
+    {
+        Http::fake(['*' => Http::response([])]);
+
+        $this->engine()->flush(new SearchableModel);
+
+        Http::assertSent(fn (Request $request) =>
+            $request->method() === 'DELETE' &&
+            $request->url() === 'https://turbopuffer.test/v2/namespaces/table'
+        );
+    }
+
+    public function test_create_index_is_not_supported()
+    {
+        $this->expectException(NotSupportedException::class);
+
+        $this->engine()->createIndex('table');
+    }
+
+    public function test_an_index_building_response_throws_a_scout_exception()
+    {
+        Http::fake(['*' => Http::response([], 202)]);
+
+        $this->expectException(ScoutException::class);
+        $this->expectExceptionMessage('still building');
+
+        $this->engine()->search(new Builder(new SearchableModel, 'laravel'));
+    }
+
+    public function test_invalid_namespaces_are_rejected_before_a_request_is_sent()
+    {
+        Http::preventStrayRequests();
+
+        $this->expectException(ScoutException::class);
+        $this->expectExceptionMessage('Invalid Turbopuffer namespace');
+
+        $this->engine()->search(
+            (new Builder(new SearchableModel, 'laravel'))->within('invalid namespace')
+        );
+    }
+
+    protected function engine(): TurbopufferEngine
+    {
+        return $this->app->make(EngineManager::class)->engine('turbopuffer');
+    }
+}

--- a/tests/Feature/Engines/TurbopufferEngineTest.php
+++ b/tests/Feature/Engines/TurbopufferEngineTest.php
@@ -233,7 +233,7 @@ class TurbopufferEngineTest extends TestCase
         Http::fake(['*' => Http::response(['rows' => [['id' => 10, '$dist' => 0.1]]])]);
 
         $builder = (new Builder(new SearchableModel, 'conceptual query'))
-            ->semantic()
+            ->semantic(minSimilarity: 0.9)
             ->where('status', 'published')
             ->take(10);
 
@@ -242,6 +242,7 @@ class TurbopufferEngineTest extends TestCase
         $this->assertSame(10, $results['rows'][0]['id']);
         $this->assertSame([[
             'inputs' => ['conceptual query'],
+            'cache' => null,
             'dimensions' => 2,
             'provider' => null,
             'model' => null,

--- a/tests/Feature/Engines/TurbopufferEngineTest.php
+++ b/tests/Feature/Engines/TurbopufferEngineTest.php
@@ -11,6 +11,7 @@ use Laravel\Scout\Exceptions\NotSupportedException;
 use Laravel\Scout\Exceptions\ScoutException;
 use Laravel\Scout\Tests\Fixtures\FakeEmbeddings;
 use Laravel\Scout\Tests\Fixtures\SearchableModel;
+use Laravel\Scout\Tests\Fixtures\SearchableModelWithNativeEmbedding;
 use Laravel\Scout\Tests\Fixtures\SearchableModelWithPrecomputedEmbedding;
 use Laravel\Scout\Tests\Fixtures\SearchableModelWithSoftDeletes;
 use Orchestra\Testbench\Concerns\WithWorkbench;
@@ -158,6 +159,39 @@ class TurbopufferEngineTest extends TestCase
         ]);
     }
 
+    public function test_update_can_use_turbopuffer_native_embeddings()
+    {
+        $this->configureNativeEmbeddings();
+        Http::fake(['*' => Http::response(['rows_affected' => 1])]);
+
+        $model = new SearchableModelWithNativeEmbedding([
+            'id' => 10,
+            'name' => 'Native embedding source',
+            'embedding' => [0.1, 0.2],
+        ]);
+
+        $this->engine()->update($model->newCollection([$model]));
+
+        Http::assertSent(function (Request $request) {
+            $this->assertSame([[
+                'id' => 10,
+                'name' => 'Native embedding source',
+            ]], $request['upsert_rows']);
+            $this->assertEquals([
+                'type' => 'string',
+                'full_text_search' => true,
+                'embed' => [
+                    'model' => 'turbopuffer/native-test',
+                    'dims' => 2,
+                    'attribute' => 'embedding',
+                ],
+            ], $request['schema']['name']);
+            $this->assertSame('cosine_distance', $request['distance_metric']);
+
+            return true;
+        });
+    }
+
     public function test_delete_sends_one_batched_request()
     {
         Http::fake(['*' => Http::response(['rows_affected' => 2])]);
@@ -251,6 +285,83 @@ class TurbopufferEngineTest extends TestCase
         Http::assertSent(fn (Request $request) => $request['rank_by'] === ['embedding', 'ANN', [0.25, 0.75]] &&
             $request['filters'] === ['status', 'Eq', 'published'] &&
             $request['limit'] === 10
+        );
+    }
+
+    public function test_semantic_search_can_use_turbopuffer_native_query_embeddings()
+    {
+        $this->configureNativeEmbeddings();
+        Http::fake(['*' => Http::response(['rows' => [['id' => 10, '$dist' => 0.1]]])]);
+
+        $results = $this->engine()->search(
+            (new Builder(new SearchableModelWithNativeEmbedding, 'conceptual query'))
+                ->semantic()
+                ->where('status', 'published')
+                ->take(10)
+        );
+
+        $this->assertSame(10, $results['rows'][0]['id']);
+
+        Http::assertSent(fn (Request $request) => $request['rank_by'] === [
+            'name',
+            'ANN',
+            ['Embed', 'conceptual query'],
+        ] && $request['filters'] === ['status', 'Eq', 'published'] &&
+            $request['limit'] === 10);
+    }
+
+    public function test_hybrid_search_can_use_turbopuffer_native_query_embeddings()
+    {
+        $this->configureNativeEmbeddings();
+        Http::fake(['*' => Http::response(['results' => [['rows' => []]]])]);
+
+        $this->engine()->search(
+            (new Builder(new SearchableModelWithNativeEmbedding, 'combined query'))->hybrid()
+        );
+
+        Http::assertSent(fn (Request $request) => $request['queries'][1]['rank_by'] === [
+            'name',
+            'ANN',
+            ['Embed', 'combined query'],
+        ]);
+    }
+
+    public function test_native_embeddings_accept_a_string_embed_schema()
+    {
+        $this->configureNativeEmbeddings();
+
+        $config = $this->app['config']->get('scout.turbopuffer');
+        $config['model-settings'][SearchableModelWithNativeEmbedding::class]['schema']['name']['embed'] = 'turbopuffer/native-test';
+        $this->app['config']->set('scout.turbopuffer', $config);
+
+        Http::fake(['*' => Http::response(['rows' => []])]);
+
+        $this->engine()->search(
+            (new Builder(new SearchableModelWithNativeEmbedding, 'conceptual query'))->semantic()
+        );
+
+        Http::assertSent(fn (Request $request) => $request['rank_by'] === [
+            'name',
+            'ANN',
+            ['Embed', 'conceptual query'],
+        ]);
+    }
+
+    public function test_native_embeddings_require_an_embed_schema()
+    {
+        $this->configureNativeEmbeddings();
+
+        $config = $this->app['config']->get('scout.turbopuffer');
+        unset($config['model-settings'][SearchableModelWithNativeEmbedding::class]['schema']['name']['embed']);
+        $this->app['config']->set('scout.turbopuffer', $config);
+
+        Http::preventStrayRequests();
+
+        $this->expectException(ScoutException::class);
+        $this->expectExceptionMessage('require a valid [embed] schema configuration');
+
+        $this->engine()->search(
+            (new Builder(new SearchableModelWithNativeEmbedding, 'conceptual query'))->semantic()
         );
     }
 
@@ -431,6 +542,26 @@ class TurbopufferEngineTest extends TestCase
         $settings['schema']['embedding'] = ['type' => '[2]f32', 'ann' => true];
 
         $config['model-settings'][$model] = $settings;
+
+        $this->app['config']->set('scout.turbopuffer', $config);
+    }
+
+    protected function configureNativeEmbeddings(): void
+    {
+        $config = $this->app['config']->get('scout.turbopuffer');
+        $settings = $config['model-settings'][SearchableModel::class];
+
+        $settings['embedding'] = [
+            'driver' => 'turbopuffer',
+            'attribute' => 'name',
+        ];
+        $settings['schema']['name']['embed'] = [
+            'model' => 'turbopuffer/native-test',
+            'dimensions' => '2',
+            'attribute' => 'embedding',
+        ];
+
+        $config['model-settings'][SearchableModelWithNativeEmbedding::class] = $settings;
 
         $this->app['config']->set('scout.turbopuffer', $config);
     }

--- a/tests/Feature/Engines/TurbopufferEngineTest.php
+++ b/tests/Feature/Engines/TurbopufferEngineTest.php
@@ -9,6 +9,7 @@ use Laravel\Scout\EngineManager;
 use Laravel\Scout\Engines\TurbopufferEngine;
 use Laravel\Scout\Exceptions\NotSupportedException;
 use Laravel\Scout\Exceptions\ScoutException;
+use Laravel\Scout\Tests\Fixtures\FakeEmbeddings;
 use Laravel\Scout\Tests\Fixtures\SearchableModel;
 use Laravel\Scout\Tests\Fixtures\SearchableModelWithSoftDeletes;
 use Orchestra\Testbench\Concerns\WithWorkbench;
@@ -85,6 +86,55 @@ class TurbopufferEngineTest extends TestCase
         ]);
     }
 
+    public function test_semantic_search_requires_the_laravel_ai_sdk()
+    {
+        if (class_exists('Laravel\\Ai\\Embeddings')) {
+            $this->markTestSkipped('The Laravel AI SDK is installed.');
+        }
+
+        $this->configureEmbeddings();
+        Http::preventStrayRequests();
+
+        $this->expectException(ScoutException::class);
+        $this->expectExceptionMessage('install the [laravel/ai] package');
+
+        $this->engine()->search(
+            (new Builder(new SearchableModel, 'conceptual query'))->semantic()
+        );
+    }
+
+    public function test_update_generates_and_upserts_embeddings_in_batches()
+    {
+        $this->configureEmbeddings([
+            'provider' => 'openai',
+            'model' => 'text-embedding-test',
+        ]);
+        $this->fakeEmbeddings([
+            array_fill(0, 100, [0.1, 0.2]),
+            [[0.3, 0.4]],
+        ]);
+        Http::fake(['*' => Http::response(['rows_affected' => 101])]);
+
+        $models = (new SearchableModel)->newCollection(array_map(
+            fn ($id) => new SearchableModel(['id' => $id, 'name' => "Document {$id}"]),
+            range(1, 101)
+        ));
+
+        $this->engine()->update($models);
+
+        $this->assertCount(2, FakeEmbeddings::$requests);
+        $this->assertCount(100, FakeEmbeddings::$requests[0]['inputs']);
+        $this->assertSame(['Document 101'], FakeEmbeddings::$requests[1]['inputs']);
+
+        Http::assertSent(function (Request $request) {
+            return count($request['upsert_rows']) === 101 &&
+                $request['upsert_rows'][0]['embedding'] === [0.1, 0.2] &&
+                $request['upsert_rows'][100]['embedding'] === [0.3, 0.4] &&
+                $request['schema']['embedding'] === ['type' => '[2]f32', 'ann' => true] &&
+                $request['distance_metric'] === 'cosine_distance';
+        });
+    }
+
     public function test_delete_sends_one_batched_request()
     {
         Http::fake(['*' => Http::response(['rows_affected' => 2])]);
@@ -153,6 +203,80 @@ class TurbopufferEngineTest extends TestCase
         );
     }
 
+    public function test_semantic_search_generates_a_query_embedding()
+    {
+        $this->configureEmbeddings();
+        $this->fakeEmbeddings([[[0.25, 0.75]]]);
+        Http::fake(['*' => Http::response(['rows' => [['id' => 10, '$dist' => 0.1]]])]);
+
+        $builder = (new Builder(new SearchableModel, 'conceptual query'))
+            ->semantic()
+            ->where('status', 'published')
+            ->take(10);
+
+        $results = $this->engine()->search($builder);
+
+        $this->assertSame(10, $results['rows'][0]['id']);
+        $this->assertSame([[
+            'inputs' => ['conceptual query'],
+            'dimensions' => 2,
+            'provider' => null,
+            'model' => null,
+        ]], FakeEmbeddings::$requests);
+
+        Http::assertSent(fn (Request $request) => $request['rank_by'] === ['embedding', 'ANN', [0.25, 0.75]] &&
+            $request['filters'] === ['status', 'Eq', 'published'] &&
+            $request['limit'] === 10
+        );
+    }
+
+    public function test_hybrid_search_uses_weighted_rrf_and_normalizes_results()
+    {
+        $this->configureEmbeddings();
+        $this->fakeEmbeddings([[[0.4, 0.6]]]);
+        Http::fake(['*' => Http::response([
+            'results' => [[
+                'rows' => [
+                    ['id' => 20, '$dist' => 0.03],
+                    ['id' => 10, '$dist' => 0.02],
+                    ['id' => 30, '$dist' => 0.01],
+                ],
+            ]],
+        ])]);
+
+        $builder = (new Builder(new SearchableModel, 'combined query'))
+            ->hybrid(textWeight: 1, semanticWeight: 2)
+            ->where('status', 'published')
+            ->options([
+                'include_attributes' => ['name'],
+                'consistency' => ['level' => 'eventual'],
+            ])
+            ->take(2);
+
+        $results = $this->engine()->search($builder);
+
+        $this->assertSame([20, 10], array_column($results['rows'], 'id'));
+        $this->assertSame(2, $results['total']);
+
+        Http::assertSent(function (Request $request) {
+            $queries = $request['queries'];
+
+            return $request['consistency'] === ['level' => 'eventual'] &&
+                $request['rerank_by'] === ['RRF', ['weights' => [1, 2]]] &&
+                $queries[0]['rank_by'] === ['Sum', [
+                    ['Product', 3, ['name', 'BM25', 'combined query']],
+                    ['description', 'BM25', 'combined query'],
+                ]] &&
+                $queries[1]['rank_by'] === ['embedding', 'ANN', [0.4, 0.6]] &&
+                $queries[0]['filters'] === ['status', 'Eq', 'published'] &&
+                $queries[1]['filters'] === ['status', 'Eq', 'published'] &&
+                $queries[0]['include_attributes'] === ['name', 'id'] &&
+                $queries[1]['include_attributes'] === ['name', 'id'] &&
+                $queries[0]['limit'] === 2 &&
+                $queries[1]['limit'] === 2;
+        });
+    }
+
     public function test_match_all_search_uses_the_requested_order()
     {
         Http::fake(['*' => Http::response(['rows' => []])]);
@@ -188,6 +312,32 @@ class TurbopufferEngineTest extends TestCase
         Http::assertSent(fn (Request $request) => isset($request['aggregate_by']) &&
             $request['filters'] === ['status', 'Eq', 'published']
         );
+    }
+
+    public function test_semantic_pagination_only_generates_the_query_embedding_once()
+    {
+        $this->configureEmbeddings();
+        $this->fakeEmbeddings([[[0.2, 0.8]]]);
+        Http::fake(function (Request $request) {
+            if (isset($request['aggregate_by'])) {
+                return Http::response(['aggregations' => ['count' => 2]]);
+            }
+
+            return Http::response(['rows' => [
+                ['id' => 1],
+                ['id' => 2],
+            ]]);
+        });
+
+        $results = $this->engine()->paginate(
+            (new Builder(new SearchableModel, 'semantic query'))->semantic(),
+            1,
+            2
+        );
+
+        $this->assertSame([2], array_column($results['rows'], 'id'));
+        $this->assertSame(2, $results['total']);
+        $this->assertCount(1, FakeEmbeddings::$requests);
     }
 
     public function test_pagination_rejects_windows_above_turbopuffer_limit()
@@ -243,5 +393,30 @@ class TurbopufferEngineTest extends TestCase
     protected function engine(): TurbopufferEngine
     {
         return $this->app->make(EngineManager::class)->engine('turbopuffer');
+    }
+
+    protected function configureEmbeddings(array $overrides = []): void
+    {
+        $config = $this->app['config']->get('scout.turbopuffer');
+        $settings = $config['model-settings'][SearchableModel::class];
+
+        $settings['embedding'] = array_merge([
+            'attribute' => 'embedding',
+            'dimensions' => 2,
+        ], $overrides);
+        $settings['schema']['embedding'] = ['type' => '[2]f32', 'ann' => true];
+
+        $config['model-settings'][SearchableModel::class] = $settings;
+
+        $this->app['config']->set('scout.turbopuffer', $config);
+    }
+
+    protected function fakeEmbeddings(array $responses): void
+    {
+        if (! class_exists('Laravel\\Ai\\Embeddings')) {
+            class_alias(FakeEmbeddings::class, 'Laravel\\Ai\\Embeddings');
+        }
+
+        FakeEmbeddings::fake($responses);
     }
 }

--- a/tests/Feature/Engines/TurbopufferEngineTest.php
+++ b/tests/Feature/Engines/TurbopufferEngineTest.php
@@ -147,8 +147,7 @@ class TurbopufferEngineTest extends TestCase
 
         $this->engine()->search($builder);
 
-        Http::assertSent(fn (Request $request) =>
-            $request['rank_by'] === ['embedding', 'ANN', [0.1, 0.2]] &&
+        Http::assertSent(fn (Request $request) => $request['rank_by'] === ['embedding', 'ANN', [0.1, 0.2]] &&
             $request['include_attributes'] === ['name', 'id'] &&
             $request['consistency'] === ['level' => 'eventual']
         );
@@ -186,8 +185,7 @@ class TurbopufferEngineTest extends TestCase
         $this->assertSame([3, 4], array_column($results['rows'], 'id'));
         $this->assertSame(10000, $results['total']);
 
-        Http::assertSent(fn (Request $request) =>
-            isset($request['aggregate_by']) &&
+        Http::assertSent(fn (Request $request) => isset($request['aggregate_by']) &&
             $request['filters'] === ['status', 'Eq', 'published']
         );
     }
@@ -208,8 +206,7 @@ class TurbopufferEngineTest extends TestCase
 
         $this->engine()->flush(new SearchableModel);
 
-        Http::assertSent(fn (Request $request) =>
-            $request->method() === 'DELETE' &&
+        Http::assertSent(fn (Request $request) => $request->method() === 'DELETE' &&
             $request->url() === 'https://turbopuffer.test/v2/namespaces/table'
         );
     }

--- a/tests/Feature/Engines/TurbopufferEngineTest.php
+++ b/tests/Feature/Engines/TurbopufferEngineTest.php
@@ -63,6 +63,7 @@ class TurbopufferEngineTest extends TestCase
             return $request->method() === 'POST' &&
                 $request->url() === 'https://turbopuffer.test/v2/namespaces/table' &&
                 $request->hasHeader('Authorization', 'Bearer tpuf-test-key') &&
+                $request->hasHeader('X-Laravel-Scout', '11.5.0') &&
                 $request['upsert_rows'] === [['id' => 10, 'name' => 'Taylor']] &&
                 $request['schema'] === [
                     'name' => ['type' => 'string', 'full_text_search' => true],

--- a/tests/Fixtures/FakeEmbeddings.php
+++ b/tests/Fixtures/FakeEmbeddings.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Laravel\Scout\Tests\Fixtures;
+
+class FakeEmbeddings
+{
+    public static $requests = [];
+
+    public static $responses = [];
+
+    public static function fake(array $responses)
+    {
+        static::$requests = [];
+        static::$responses = $responses;
+    }
+
+    public static function for(array $inputs)
+    {
+        return new FakePendingEmbeddings($inputs);
+    }
+}
+
+class FakePendingEmbeddings
+{
+    protected $dimensions;
+
+    public function __construct(protected array $inputs)
+    {
+        //
+    }
+
+    public function dimensions($dimensions)
+    {
+        $this->dimensions = $dimensions;
+
+        return $this;
+    }
+
+    public function generate($provider = null, $model = null)
+    {
+        FakeEmbeddings::$requests[] = [
+            'inputs' => $this->inputs,
+            'dimensions' => $this->dimensions,
+            'provider' => $provider,
+            'model' => $model,
+        ];
+
+        return (object) [
+            'embeddings' => array_shift(FakeEmbeddings::$responses),
+        ];
+    }
+}

--- a/tests/Fixtures/FakeEmbeddings.php
+++ b/tests/Fixtures/FakeEmbeddings.php
@@ -22,6 +22,8 @@ class FakeEmbeddings
 
 class FakePendingEmbeddings
 {
+    protected $cacheSeconds = false;
+
     protected $dimensions;
 
     public function __construct(protected array $inputs)
@@ -36,10 +38,18 @@ class FakePendingEmbeddings
         return $this;
     }
 
+    public function cache($seconds = null)
+    {
+        $this->cacheSeconds = $seconds;
+
+        return $this;
+    }
+
     public function generate($provider = null, $model = null)
     {
         FakeEmbeddings::$requests[] = [
             'inputs' => $this->inputs,
+            'cache' => $this->cacheSeconds,
             'dimensions' => $this->dimensions,
             'provider' => $provider,
             'model' => $model,

--- a/tests/Fixtures/SearchableModel.php
+++ b/tests/Fixtures/SearchableModel.php
@@ -25,4 +25,9 @@ class SearchableModel extends Model
     {
         return 'table';
     }
+
+    public function toSearchableEmbedding()
+    {
+        return $this->name;
+    }
 }

--- a/tests/Fixtures/SearchableModelWithNativeEmbedding.php
+++ b/tests/Fixtures/SearchableModelWithNativeEmbedding.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Laravel\Scout\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Scout\Searchable;
+
+class SearchableModelWithNativeEmbedding extends Model
+{
+    use Searchable;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = ['id', 'name', 'embedding'];
+
+    public function searchableAs()
+    {
+        return 'table';
+    }
+
+    public function indexableAs()
+    {
+        return 'table';
+    }
+}

--- a/tests/Fixtures/SearchableModelWithPrecomputedEmbedding.php
+++ b/tests/Fixtures/SearchableModelWithPrecomputedEmbedding.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Laravel\Scout\Tests\Fixtures;
+
+class SearchableModelWithPrecomputedEmbedding extends SearchableModel
+{
+    public function toSearchableEmbedding()
+    {
+        return $this->embedding ?? parent::toSearchableEmbedding();
+    }
+}

--- a/tests/Unit/BuilderTest.php
+++ b/tests/Unit/BuilderTest.php
@@ -5,6 +5,8 @@ namespace Laravel\Scout\Tests\Unit;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Pagination\Paginator;
 use Laravel\Scout\Builder;
+use Laravel\Scout\Exceptions\NotSupportedException;
+use Laravel\Scout\Exceptions\ScoutException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -145,5 +147,56 @@ class BuilderTest extends TestCase
         $builder = new Builder($model = m::mock(), 'zonda', null, true);
 
         $this->assertSame([['field' => '__soft_deleted', 'operator' => '=', 'value' => 0]], $builder->wheres);
+    }
+
+    public function test_semantic_search_can_be_enabled()
+    {
+        $builder = (new Builder(m::mock(), 'conceptual query'))->semantic();
+
+        $this->assertTrue($builder->semanticSearch);
+        $this->assertNull($builder->hybridSearch);
+    }
+
+    public function test_hybrid_search_can_be_enabled_with_weights()
+    {
+        $builder = (new Builder(m::mock(), 'combined query'))->hybrid(2, 3);
+
+        $this->assertFalse($builder->semanticSearch);
+        $this->assertSame([
+            'text_weight' => 2,
+            'semantic_weight' => 3,
+        ], $builder->hybridSearch);
+    }
+
+    public function test_semantic_and_hybrid_search_require_a_query()
+    {
+        foreach (['semantic', 'hybrid'] as $method) {
+            try {
+                (new Builder(m::mock(), ''))->{$method}();
+
+                $this->fail("Expected [{$method}] to reject an empty query.");
+            } catch (ScoutException $e) {
+                $this->assertStringContainsString('non-empty query', $e->getMessage());
+            }
+        }
+    }
+
+    public function test_hybrid_search_requires_positive_weights()
+    {
+        $this->expectException(ScoutException::class);
+        $this->expectExceptionMessage('positive numbers');
+
+        (new Builder(m::mock(), 'query'))->hybrid(1, 0);
+    }
+
+    public function test_unsupported_engines_reject_semantic_search()
+    {
+        $model = m::mock();
+        $model->shouldReceive('searchableUsing')->andReturn(m::mock());
+
+        $this->expectException(NotSupportedException::class);
+        $this->expectExceptionMessage('does not support semantic search');
+
+        (new Builder($model, 'query'))->semantic()->raw();
     }
 }

--- a/tests/Unit/BuilderTest.php
+++ b/tests/Unit/BuilderTest.php
@@ -151,21 +151,23 @@ class BuilderTest extends TestCase
 
     public function test_semantic_search_can_be_enabled()
     {
-        $builder = (new Builder(m::mock(), 'conceptual query'))->semantic();
+        $builder = (new Builder(m::mock(), 'conceptual query'))->semantic(minSimilarity: 0.7);
 
         $this->assertTrue($builder->semanticSearch);
         $this->assertNull($builder->hybridSearch);
+        $this->assertSame(0.7, $builder->minimumSimilarity);
     }
 
     public function test_hybrid_search_can_be_enabled_with_weights()
     {
-        $builder = (new Builder(m::mock(), 'combined query'))->hybrid(2, 3);
+        $builder = (new Builder(m::mock(), 'combined query'))->hybrid(2, 3, minSimilarity: 0.8);
 
         $this->assertFalse($builder->semanticSearch);
         $this->assertSame([
             'text_weight' => 2,
             'semantic_weight' => 3,
         ], $builder->hybridSearch);
+        $this->assertSame(0.8, $builder->minimumSimilarity);
     }
 
     public function test_semantic_and_hybrid_search_require_a_query()

--- a/tests/Unit/BuilderTest.php
+++ b/tests/Unit/BuilderTest.php
@@ -199,4 +199,16 @@ class BuilderTest extends TestCase
 
         (new Builder($model, 'query'))->semantic()->raw();
     }
+
+    public function test_unsupported_engines_treat_hybrid_search_as_normal_text_search()
+    {
+        $model = m::mock();
+        $engine = m::mock();
+        $model->shouldReceive('searchableUsing')->andReturn($engine);
+        $engine->shouldReceive('search')->once()->andReturn(['results']);
+
+        $results = (new Builder($model, 'query'))->hybrid()->raw();
+
+        $this->assertSame(['results'], $results);
+    }
 }

--- a/tests/Unit/DatabaseEngineHybridTest.php
+++ b/tests/Unit/DatabaseEngineHybridTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Laravel\Scout\Tests\Unit;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Pagination\Paginator;
+use Laravel\Scout\Builder;
+use Laravel\Scout\Engines\DatabaseEngine;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEngineHybridTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Paginator::currentPageResolver(fn () => 1);
+        Paginator::currentPathResolver(fn () => '/');
+    }
+
+    public function test_it_fuses_text_and_semantic_results_using_weighted_rrf()
+    {
+        $model = new DatabaseHybridModel;
+        $textModels = $model->newCollection([
+            new DatabaseHybridModel(['id' => 1, 'name' => 'Text first']),
+            new DatabaseHybridModel(['id' => 2, 'name' => 'Both']),
+        ]);
+        $semanticModels = $model->newCollection([
+            new DatabaseHybridModel(['id' => 2, 'name' => 'Both']),
+            new DatabaseHybridModel(['id' => 3, 'name' => 'Semantic only']),
+        ]);
+
+        $results = $this->fuse(
+            (new Builder($model, 'query'))->hybrid(),
+            $textModels,
+            $semanticModels
+        );
+
+        $this->assertSame([2, 1, 3], $results->modelKeys());
+    }
+
+    public function test_hybrid_weights_affect_rrf_ordering()
+    {
+        $model = new DatabaseHybridModel;
+        $textModels = $model->newCollection([
+            new DatabaseHybridModel(['id' => 1, 'name' => 'Text first']),
+            new DatabaseHybridModel(['id' => 2, 'name' => 'Text second']),
+        ]);
+        $semanticModels = $model->newCollection([
+            new DatabaseHybridModel(['id' => 3, 'name' => 'Semantic first']),
+        ]);
+
+        $results = $this->fuse(
+            (new Builder($model, 'query'))->hybrid(textWeight: 1, semanticWeight: 10),
+            $textModels,
+            $semanticModels
+        );
+
+        $this->assertSame([3, 1, 2], $results->modelKeys());
+    }
+
+    public function test_hybrid_pagination_fetches_and_slices_the_ranked_window()
+    {
+        $model = new DatabaseHybridModel;
+        $engine = new class extends DatabaseEngine
+        {
+            public $requestedWindow;
+
+            protected function shouldPerformHybridSearch(Builder $builder): bool
+            {
+                return true;
+            }
+
+            protected function hybridSearchModels(Builder $builder, int $limit)
+            {
+                $this->requestedWindow = $limit;
+
+                return $builder->model->newCollection(array_map(
+                    fn ($id) => new DatabaseHybridModel(['id' => $id]),
+                    range(1, 10)
+                ));
+            }
+        };
+
+        $results = $engine->paginateUsingDatabase(
+            (new Builder($model, 'query'))->hybrid(),
+            2,
+            'page',
+            2
+        );
+
+        $this->assertSame(1000, $engine->requestedWindow);
+        $this->assertSame([3, 4], $results->getCollection()->modelKeys());
+        $this->assertSame(10, $results->total());
+    }
+
+    public function test_hybrid_pagination_resolves_default_page_and_per_page_values()
+    {
+        Paginator::currentPageResolver(fn ($pageName) => $pageName === 'documents' ? 2 : 1);
+
+        $model = new DatabaseHybridModel;
+        $model->setPerPage(2);
+        $engine = new class extends DatabaseEngine
+        {
+            protected function shouldPerformHybridSearch(Builder $builder): bool
+            {
+                return true;
+            }
+
+            protected function hybridSearchModels(Builder $builder, int $limit)
+            {
+                return $builder->model->newCollection(array_map(
+                    fn ($id) => new DatabaseHybridModel(['id' => $id]),
+                    range(1, 5)
+                ));
+            }
+        };
+
+        $results = $engine->paginateUsingDatabase(
+            (new Builder($model, 'query'))->hybrid(),
+            null,
+            'documents',
+            null
+        );
+
+        $this->assertSame(2, $results->currentPage());
+        $this->assertSame(2, $results->perPage());
+        $this->assertSame([3, 4], $results->getCollection()->modelKeys());
+    }
+
+    protected function fuse(Builder $builder, $textModels, $semanticModels)
+    {
+        $engine = new class extends DatabaseEngine
+        {
+            public function fuse(Builder $builder, $textModels, $semanticModels)
+            {
+                return $this->fuseSearchResults($builder, $textModels, $semanticModels);
+            }
+        };
+
+        return $engine->fuse($builder, $textModels, $semanticModels);
+    }
+}
+
+class DatabaseHybridModel extends Model
+{
+    protected $guarded = [];
+
+    public function getScoutKey()
+    {
+        return $this->getKey();
+    }
+}

--- a/tests/Unit/DatabaseEngineSemanticTest.php
+++ b/tests/Unit/DatabaseEngineSemanticTest.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace Laravel\Scout\Tests\Unit;
+
+use Illuminate\Database\ConnectionResolver;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\PostgresConnection;
+use Illuminate\Pagination\Paginator;
+use Laravel\Scout\Builder;
+use Laravel\Scout\Engines\DatabaseEngine;
+use Laravel\Scout\Tests\Fixtures\FakeEmbeddings;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEngineSemanticTest extends TestCase
+{
+    protected $connectionResolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connectionResolver = Model::getConnectionResolver();
+        Paginator::currentPageResolver(fn () => 1);
+        Paginator::currentPathResolver(fn () => '/');
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_null($this->connectionResolver)) {
+            Model::unsetConnectionResolver();
+        } else {
+            Model::setConnectionResolver($this->connectionResolver);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_it_builds_a_filtered_postgres_vector_similarity_query()
+    {
+        $model = $this->model();
+
+        if (! method_exists($model->newQuery()->getQuery(), 'whereVectorSimilarTo')) {
+            $this->markTestSkipped('Vector similarity queries require Laravel 13.');
+        }
+
+        $this->fakeEmbeddings([[[0.1, 0.2]]]);
+
+        $query = $this->engine()->semanticQuery(
+            (new Builder($model, 'semantic query'))
+                ->semantic(minSimilarity: 0.4)
+                ->where('user_id', 1)
+        );
+
+        $this->assertSame(
+            'select * from "documents" where ("documents"."embedding" <=> ?) <= ? and "user_id" = ? order by ("documents"."embedding" <=> ?) asc, "documents"."id" asc',
+            $query->toSql()
+        );
+        $this->assertSame(['[0.1,0.2]', 0.6, 1, '[0.1,0.2]'], $query->getBindings());
+        $this->assertSame(['semantic query'], FakeEmbeddings::$requests[0]['inputs']);
+        $this->assertNull(FakeEmbeddings::$requests[0]['cache']);
+    }
+
+    public function test_semantic_search_callbacks_are_applied_after_the_vector_constraint()
+    {
+        $model = $this->model();
+
+        if (! method_exists($model->newQuery()->getQuery(), 'whereVectorSimilarTo')) {
+            $this->markTestSkipped('Vector similarity queries require Laravel 13.');
+        }
+
+        $this->fakeEmbeddings([[[0.1, 0.2]]]);
+        $query = $this->engine()->semanticQuery(
+            (new Builder($model, 'semantic query', function ($query) {
+                $query->orWhere('name', 'Fallback');
+            }))->semantic()
+        );
+
+        $this->assertSame(
+            'select * from "documents" where ("documents"."embedding" <=> ?) <= ? or "name" = ? order by ("documents"."embedding" <=> ?) asc, "documents"."id" asc',
+            $query->toSql()
+        );
+        $this->assertSame(['[0.1,0.2]', 0.4, 'Fallback', '[0.1,0.2]'], $query->getBindings());
+    }
+
+    public function test_semantic_search_callbacks_can_override_the_scout_result_limit()
+    {
+        $model = $this->model();
+
+        if (! method_exists($model->newQuery()->getQuery(), 'whereVectorSimilarTo')) {
+            $this->markTestSkipped('Vector similarity queries require Laravel 13.');
+        }
+
+        $this->fakeEmbeddings([[[0.1, 0.2]]]);
+        $query = $this->engine()->semanticQuery(
+            (new Builder($model, 'semantic query', function ($query) {
+                $query->take(1);
+            }))->semantic()->take(10)
+        );
+
+        $this->assertSame(1, $query->getQuery()->limit);
+    }
+
+    public function test_semantic_pagination_respects_the_scout_result_limit()
+    {
+        $model = $this->model();
+        $model->getConnection()->statement('create table documents (id integer primary key, name varchar(255))');
+        $model->getConnection()->table('documents')->insert([
+            ['id' => 1, 'name' => 'One'],
+            ['id' => 2, 'name' => 'Two'],
+            ['id' => 3, 'name' => 'Three'],
+            ['id' => 4, 'name' => 'Four'],
+        ]);
+        $engine = new class extends DatabaseEngine
+        {
+            protected function buildSemanticSearchQuery(Builder $builder)
+            {
+                return $builder->model->newQuery()->orderBy('id');
+            }
+        };
+
+        $results = $engine->paginateUsingDatabase(
+            (new Builder($model, 'query'))->semantic()->take(3),
+            2,
+            'page',
+            2
+        );
+
+        $this->assertSame(3, $results->total());
+        $this->assertSame([3], $results->getCollection()->modelKeys());
+    }
+
+    public function test_it_persists_a_precomputed_embedding_without_model_events()
+    {
+        $model = $this->model();
+
+        if (! method_exists($model->newQuery()->getQuery(), 'whereVectorSimilarTo')) {
+            $this->markTestSkipped('Vector similarity queries require Laravel 13.');
+        }
+
+        $model->getConnection()->statement('create table documents (id integer primary key, name varchar(255), embedding text)');
+        $model->getConnection()->table('documents')->insert(['id' => 1, 'name' => 'Document']);
+
+        $model->forceFill(['id' => 1, 'name' => 'Document', 'embedding' => [0.3, 0.7]]);
+        $model->exists = true;
+
+        (new DatabaseEngine)->update($model->newCollection([$model]));
+
+        $this->assertSame(
+            '[0.3,0.7]',
+            $model->getConnection()->table('documents')->where('id', 1)->value('embedding')
+        );
+    }
+
+    public function test_it_generates_and_persists_a_database_embedding()
+    {
+        $model = $this->model();
+
+        if (! method_exists($model->newQuery()->getQuery(), 'whereVectorSimilarTo')) {
+            $this->markTestSkipped('Vector similarity queries require Laravel 13.');
+        }
+
+        $model->getConnection()->statement('create table documents (id integer primary key, name varchar(255), embedding text)');
+        $model->getConnection()->table('documents')->insert(['id' => 1, 'name' => 'Generate this']);
+        $this->fakeEmbeddings([[[0.2, 0.8]]]);
+
+        $model->forceFill(['id' => 1, 'name' => 'Generate this']);
+        $model->exists = true;
+
+        (new DatabaseEngine)->update($model->newCollection([$model]));
+
+        $this->assertSame(['Generate this'], FakeEmbeddings::$requests[0]['inputs']);
+        $this->assertSame(
+            '[0.2,0.8]',
+            $model->getConnection()->table('documents')->where('id', 1)->value('embedding')
+        );
+    }
+
+    protected function model(): DatabaseSemanticModel
+    {
+        $connection = new PostgresConnection(new PDO('sqlite::memory:'), '', '', ['driver' => 'pgsql']);
+        $resolver = new ConnectionResolver(['pgsql' => $connection]);
+        $resolver->setDefaultConnection('pgsql');
+        Model::setConnectionResolver($resolver);
+
+        return new DatabaseSemanticModel;
+    }
+
+    protected function fakeEmbeddings(array $responses): void
+    {
+        if (! class_exists('Laravel\\Ai\\Embeddings')) {
+            class_alias(FakeEmbeddings::class, 'Laravel\\Ai\\Embeddings');
+        }
+
+        FakeEmbeddings::fake($responses);
+    }
+
+    protected function engine(): DatabaseEngine
+    {
+        return new class extends DatabaseEngine
+        {
+            public function semanticQuery(Builder $builder)
+            {
+                return $this->buildSemanticSearchQuery($builder);
+            }
+        };
+    }
+}
+
+class DatabaseSemanticModel extends Model
+{
+    protected $table = 'documents';
+
+    protected $guarded = [];
+
+    public function toSearchableArray()
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+        ];
+    }
+
+    public function toSearchableEmbedding()
+    {
+        return $this->embedding ?? $this->name;
+    }
+
+    public function getScoutKey()
+    {
+        return $this->getKey();
+    }
+}


### PR DESCRIPTION
This PR adds an initial Turbopuffer engine to Laravel Scout.

The engine supports synchronizing Eloquent models to Turbopuffer namespaces and searching them through Scout’s existing builder API. It uses Laravel’s HTTP client directly, so no additional PHP SDK dependency is required.

**Features**

- Batched model upserts and deletes
- Automatic namespace creation on first write
- Namespace deletion through scout:flush and scout:delete-index
- Weighted BM25 search across one or more attributes
- Turbopuffer distance metadata exposed as _turbopuffer_dist
- Bounded pagination with filtered candidate counts

**Configuration**

Set the Scout driver and Turbopuffer credentials:

```ini
SCOUT_DRIVER=turbopuffer
TURBOPUFFER_API_KEY=tpuf_...
TURBOPUFFER_REGION=gcp-us-central1
```

Configure each searchable model in `config/scout.php`:

```php
use App\Models\Document;

'turbopuffer' => [
    // ...

    'model-settings' => [
        Document::class => [
            'searchable-attributes' => [
                'title' => 3,
                'content' => 1,
            ],
            'schema' => [
                'user_id' => [
                    'type' => 'uint',
                ],
                'title' => [
                    'type' => 'string',
                    'full_text_search' => true,
                ],
                'content' => [
                    'type' => 'string',
                    'full_text_search' => true,
                ],
            ],
        ],
    ],
],
```

The numeric searchable attribute values are relative BM25 weights. In this example, title matches contribute three times their normal BM25 score.

**Searching**

Basic weighted full-text search:

```php
$documents = Document::search('ocean climate')->get();
```

Search with a Turbopuffer filter:

```php
$documents = Document::search('ocean climate')
    ->where('user_id', 1)
    ->take(20)
    ->get();
```

Multiple filters are combined using Turbopuffer’s And expression:

```php
$documents = Document::search('database migration')
    ->where('user_id', 1)
    ->where('published_at', '>=', '2026-01-01')
    ->whereIn('status', ['published', 'featured'])
    ->get();
```

**Pagination**

Turbopuffer does not provide offset pagination for ranked searches. To support Scout pagination, the engine requests the first page * perPage results and slices the requested page locally.

A separate filtered count aggregation supplies Scout’s required total. For BM25 and vector searches, this represents the filtered candidate corpus rather than an exact count of semantically relevant matches.

Result windows beyond Turbopuffer’s 10,000-record limit are rejected.