### PR TITLE
feat(typesense): add semantic and hybrid search

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -216,6 +216,10 @@ return [
             //     'search-parameters' => [
             //         'query_by' => 'name'
             //     ],
+            //     'embedding' => [
+            //         'attribute' => 'embedding',
+            //         'dimensions' => 1536,
+            //     ],
             // ],
         ],
         'import_action' => env('TYPESENSE_IMPORT_ACTION', 'upsert'),

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -168,7 +168,8 @@ class EngineManager extends Manager
 
         return new TypesenseEngine(
             new Typesense($config['client-settings']),
-            $config['max_total_results'] ?? 1000
+            $config['max_total_results'] ?? 1000,
+            $config
         );
     }
 

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;
+use Laravel\Scout\Contracts\SupportsSemanticSearch;
 use Laravel\Scout\Exceptions\NotSupportedException;
 use Laravel\Scout\Exceptions\ScoutException;
 use stdClass;
@@ -18,7 +19,7 @@ use Typesense\Exceptions\ObjectAlreadyExists;
 use Typesense\Exceptions\ObjectNotFound;
 use Typesense\Exceptions\TypesenseClientError;
 
-class TypesenseEngine extends Engine
+class TypesenseEngine extends Engine implements SupportsSemanticSearch
 {
     /**
      * The Typesense client instance.
@@ -445,7 +446,170 @@ class TypesenseEngine extends Engine
             $parameters['sort_by'] .= $this->parseOrderBy($builder->orders);
         }
 
+        return $this->applySemanticSearchParameters($builder, $parameters);
+    }
+
+    /**
+     * Apply semantic and hybrid search parameters to the search parameters.
+     */
+    protected function applySemanticSearchParameters(Builder $builder, array $parameters): array
+    {
+        if (! $builder->semanticSearch && is_null($builder->hybridSearch)) {
+            return $parameters;
+        }
+
+        if (array_key_exists('vector_query', $builder->options)) {
+            throw new ScoutException('Typesense semantic and hybrid searches cannot be combined with a custom [vector_query] option.');
+        }
+
+        $settings = $this->embeddingSettings($builder->model);
+
+        unset($parameters['vector']);
+
+        if ($builder->semanticSearch) {
+            $parameters = $this->usesNativeEmbeddings($settings)
+                ? $this->applyNativeSemanticQueryBy($parameters, $settings['attribute'])
+                : array_merge($parameters, ['q' => '*']);
+        } else {
+            $parameters = $this->applyHybridQueryBy($parameters, $settings);
+        }
+
+        if (! is_null($vectorQuery = $this->vectorQuery($builder, $settings))) {
+            $parameters['vector_query'] = $vectorQuery;
+        }
+
+        $parameters['exclude_fields'] = $this->appendField($parameters['exclude_fields'] ?? '', $settings['attribute']);
+
         return $parameters;
+    }
+
+    /**
+     * Target the embedding field for a semantic search using native embeddings.
+     */
+    protected function applyNativeSemanticQueryBy(array $parameters, string $attribute): array
+    {
+        $parameters['query_by'] = $attribute;
+
+        // Remote embedders reject prefix searches on embedding fields...
+        $parameters['prefix'] = false;
+
+        unset($parameters['query_by_weights']);
+
+        foreach (['num_typos', 'infix'] as $parameter) {
+            if (isset($parameters[$parameter]) && str_contains((string) $parameters[$parameter], ',')) {
+                unset($parameters[$parameter]);
+            }
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * Prepare the "query_by" fields and their per-field parameters for a hybrid search.
+     */
+    protected function applyHybridQueryBy(array $parameters, array $settings): array
+    {
+        $fields = array_filter(array_map('trim', explode(',', (string) ($parameters['query_by'] ?? ''))));
+
+        if (empty(array_diff($fields, [$settings['attribute']]))) {
+            throw new ScoutException('Typesense hybrid searches require at least one keyword field in the [query_by] search parameter.');
+        }
+
+        if (! $this->usesNativeEmbeddings($settings) || in_array($settings['attribute'], $fields, true)) {
+            return $parameters;
+        }
+
+        $parameters['query_by'] = implode(',', [...$fields, $settings['attribute']]);
+
+        if (isset($parameters['query_by_weights']) && $parameters['query_by_weights'] !== '') {
+            $parameters['query_by_weights'] .= ',0';
+        }
+
+        foreach (['num_typos' => '0', 'prefix' => 'false', 'infix' => 'off'] as $parameter => $placeholder) {
+            if (isset($parameters[$parameter]) && str_contains((string) $parameters[$parameter], ',')) {
+                $parameters[$parameter] .= ','.$placeholder;
+            }
+        }
+
+        // Remote embedders reject prefix searches on embedding fields, so a
+        // global prefix must become a per-field list that excludes them...
+        if (($parameters['prefix'] ?? null) === true || ($parameters['prefix'] ?? null) === 'true') {
+            $parameters['prefix'] = implode(',', [...array_fill(0, count($fields), 'true'), 'false']);
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * Build the "vector_query" parameter for the search.
+     */
+    protected function vectorQuery(Builder $builder, array $settings): ?string
+    {
+        if ($this->usesNativeEmbeddings($settings)) {
+            $vector = [];
+        } else {
+            $vector = $builder->options['vector'] ??
+                $this->generateEmbeddings([$builder->query], $settings)[0];
+
+            if (! is_array($vector) || empty($vector)) {
+                throw new ScoutException('The Typesense query [vector] must be a non-empty embedding array.');
+            }
+        }
+
+        $options = [];
+
+        if (! is_null($builder->hybridSearch)) {
+            $options[] = 'alpha: '.($builder->hybridSearch['semantic_weight'] / array_sum($builder->hybridSearch));
+        }
+
+        if (! is_null($builder->minimumSimilarity)) {
+            $options[] = 'distance_threshold: '.$this->distanceThreshold($builder);
+        }
+
+        // Typesense rejects an empty vector query without parameters; native
+        // semantic searches are expressed via "query_by" alone in that case...
+        if (empty($vector) && empty($options)) {
+            return null;
+        }
+
+        return sprintf(
+            '%s:([%s]%s)',
+            $settings['attribute'],
+            implode(', ', $vector),
+            empty($options) ? '' : ', '.implode(', ', $options)
+        );
+    }
+
+    /**
+     * Get the maximum vector distance for the search's minimum similarity.
+     *
+     * This assumes the collection uses the default cosine distance metric. On
+     * hybrid searches, Typesense only applies the threshold to vector search
+     * candidates; keyword matches are returned regardless of their distance.
+     */
+    protected function distanceThreshold(Builder $builder): float
+    {
+        $similarity = $builder->minimumSimilarity;
+
+        if (! is_numeric($similarity) || $similarity < 0 || $similarity > 1) {
+            throw new ScoutException('The minimum similarity must be between 0 and 1.');
+        }
+
+        return 1 - $similarity;
+    }
+
+    /**
+     * Append a field to a comma-separated field list if not already present.
+     */
+    protected function appendField(string $fields, string $field): string
+    {
+        $fields = array_filter(array_map('trim', explode(',', $fields)));
+
+        if (! in_array($field, $fields, true)) {
+            $fields[] = $field;
+        }
+
+        return implode(',', $fields);
     }
 
     /**

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -15,8 +15,13 @@ use Laravel\Scout\Exceptions\ScoutException;
 use stdClass;
 use Typesense\Client as Typesense;
 use Typesense\Collection as TypesenseCollection;
+use Typesense\Documents;
 use Typesense\Exceptions\ObjectAlreadyExists;
 use Typesense\Exceptions\ObjectNotFound;
+use Typesense\Exceptions\ObjectUnprocessable;
+use Typesense\Exceptions\RequestMalformed;
+use Typesense\Exceptions\RequestUnauthorized;
+use Typesense\Exceptions\ServiceUnavailable;
 use Typesense\Exceptions\TypesenseClientError;
 
 class TypesenseEngine extends Engine implements SupportsSemanticSearch
@@ -346,12 +351,70 @@ class TypesenseEngine extends Engine implements SupportsSemanticSearch
         }
 
         try {
-            return $documents->search($options);
+            return $this->executeSearch($builder, $documents, $options);
         } catch (ObjectNotFound) {
             $this->getOrCreateCollectionFromModel($builder->model, $builder->index, true);
 
+            return $this->executeSearch($builder, $documents, $options);
+        }
+    }
+
+    /**
+     * Execute the given search using the appropriate Typesense endpoint.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  \Typesense\Documents  $documents
+     * @param  array  $options
+     * @return mixed
+     *
+     * @throws \Http\Client\Exception
+     * @throws \Typesense\Exceptions\TypesenseClientError
+     */
+    protected function executeSearch(Builder $builder, Documents $documents, array $options): mixed
+    {
+        if (! isset($options['vector_query'])) {
             return $documents->search($options);
         }
+
+        // Serialized embeddings may exceed Typesense's query string length
+        // limit, so vector queries are sent through the multi-search
+        // endpoint, which accepts the parameters in the request body...
+        $results = $this->typesense->getMultiSearch()->perform([
+            'searches' => [
+                array_merge($options, [
+                    'collection' => $builder->index ?? $builder->model->searchableAs(),
+                ]),
+            ],
+        ]);
+
+        $result = $results['results'][0] ?? [];
+
+        if (isset($result['error'])) {
+            throw $this->multiSearchException($result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Convert a multi-search error result into a Typesense exception.
+     *
+     * @param  array  $result
+     * @return \Typesense\Exceptions\TypesenseClientError
+     */
+    protected function multiSearchException(array $result): TypesenseClientError
+    {
+        $exception = match ((int) ($result['code'] ?? 500)) {
+            400 => new RequestMalformed,
+            401 => new RequestUnauthorized,
+            404 => new ObjectNotFound,
+            409 => new ObjectAlreadyExists,
+            422 => new ObjectUnprocessable,
+            503 => new ServiceUnavailable,
+            default => new TypesenseClientError,
+        };
+
+        return $exception->setMessage($result['error']);
     }
 
     /**

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Exceptions\NotSupportedException;
+use Laravel\Scout\Exceptions\ScoutException;
 use stdClass;
 use Typesense\Client as Typesense;
 use Typesense\Collection as TypesenseCollection;
@@ -48,14 +49,22 @@ class TypesenseEngine extends Engine
     protected int $maxTotalResults;
 
     /**
+     * The Typesense configuration.
+     *
+     * @var array
+     */
+    protected array $config;
+
+    /**
      * Create new Typesense engine instance.
      *
      * @param  Typesense  $typesense
      */
-    public function __construct(Typesense $typesense, int $maxTotalResults)
+    public function __construct(Typesense $typesense, int $maxTotalResults, array $config = [])
     {
         $this->typesense = $typesense;
         $this->maxTotalResults = $maxTotalResults;
+        $this->config = $config;
     }
 
     /**
@@ -81,26 +90,90 @@ class TypesenseEngine extends Engine
             $models->each->pushSoftDeleteMetadata();
         }
 
-        $objects = $models->map(function ($model) {
+        $records = $models->map(function ($model) {
             if (empty($searchableData = $model->toSearchableArray())) {
                 return null;
             }
 
-            return array_merge(
-                $searchableData,
-                $model->scoutMetadata(),
-            );
+            return [
+                'model' => $model,
+                'object' => array_merge(
+                    $searchableData,
+                    $model->scoutMetadata(),
+                ),
+            ];
         })
             ->filter()
             ->values()
             ->all();
 
-        if (! empty($objects)) {
+        if (! empty($records)) {
+            $settings = $this->modelSettings($models->first());
+
+            $embeddingSettings = isset($settings['embedding'])
+                ? $this->embeddingSettings($models->first())
+                : null;
+
+            $objects = $embeddingSettings && ! $this->usesNativeEmbeddings($embeddingSettings)
+                ? $this->addEmbeddingsToRecords($records, $embeddingSettings)
+                : array_column($records, 'object');
+
             $this->importDocuments(
                 $collection,
                 $objects
             );
         }
+    }
+
+    /**
+     * Add generated embeddings to searchable records.
+     */
+    protected function addEmbeddingsToRecords(array $records, array $settings): array
+    {
+        $objects = [];
+
+        foreach (array_chunk($records, 100) as $batch) {
+            $inputs = [];
+            $vectors = [];
+
+            foreach ($batch as $index => $record) {
+                if (! method_exists($record['model'], 'toSearchableEmbedding')) {
+                    throw new ScoutException('Searchable models using generated embeddings must define a [toSearchableEmbedding] method.');
+                }
+
+                $input = $record['model']->toSearchableEmbedding();
+
+                if (is_array($input)) {
+                    $vectors[$index] = $input;
+
+                    continue;
+                }
+
+                if (! is_string($input) || trim($input) === '') {
+                    throw new ScoutException('The [toSearchableEmbedding] method must return a non-empty string or an embedding array.');
+                }
+
+                $inputs[$index] = $input;
+            }
+
+            if (! empty($inputs)) {
+                $generatedVectors = $this->generateEmbeddings(array_values($inputs), $settings);
+
+                foreach (array_keys($inputs) as $position => $index) {
+                    $vectors[$index] = $generatedVectors[$position];
+                }
+            }
+
+            foreach ($batch as $index => $record) {
+                $object = $record['object'];
+
+                $object[$settings['attribute']] = $vectors[$index];
+
+                $objects[] = $object;
+            }
+        }
+
+        return $objects;
     }
 
     /**
@@ -676,6 +749,85 @@ class TypesenseEngine extends Engine
         $collection->setExists(true);
 
         return $collection;
+    }
+
+    /**
+     * Get the configured settings for a model.
+     */
+    protected function modelSettings($model): array
+    {
+        return $this->config['model-settings'][get_class($model)] ?? [];
+    }
+
+    /**
+     * Get the validated embedding settings for a model.
+     */
+    protected function embeddingSettings($model): array
+    {
+        $settings = $this->modelSettings($model)['embedding'] ?? null;
+
+        if (! is_array($settings)) {
+            throw new ScoutException('No Typesense embedding settings have been configured for ['.get_class($model).'].');
+        }
+
+        if (! isset($settings['attribute']) || ! is_string($settings['attribute']) || trim($settings['attribute']) === '') {
+            throw new ScoutException('Typesense embedding settings must contain an [attribute].');
+        }
+
+        $driver = $settings['driver'] ?? 'laravel-ai';
+
+        if (! in_array($driver, ['laravel-ai', 'typesense'], true)) {
+            throw new ScoutException("The [{$driver}] Typesense embedding driver is not supported.");
+        }
+
+        $settings['driver'] = $driver;
+
+        if ($this->usesNativeEmbeddings($settings)) {
+            return $settings;
+        }
+
+        if (! isset($settings['dimensions']) ||
+            filter_var($settings['dimensions'], FILTER_VALIDATE_INT) === false ||
+            $settings['dimensions'] < 1) {
+            throw new ScoutException('Typesense embedding settings must contain positive [dimensions].');
+        }
+
+        $settings['dimensions'] = (int) $settings['dimensions'];
+
+        return $settings;
+    }
+
+    /**
+     * Determine if Typesense should generate embeddings natively.
+     */
+    protected function usesNativeEmbeddings(array $settings): bool
+    {
+        return ($settings['driver'] ?? null) === 'typesense';
+    }
+
+    /**
+     * Generate and validate embeddings using the optional Laravel AI SDK.
+     */
+    protected function generateEmbeddings(array $inputs, array $settings): array
+    {
+        $embeddingsClass = 'Laravel\\Ai\\Embeddings';
+
+        if (! class_exists($embeddingsClass)) {
+            throw new ScoutException('Semantic search requires the Laravel AI SDK. Please install the [laravel/ai] package.');
+        }
+
+        $response = $embeddingsClass::for(array_values($inputs))
+            ->dimensions($settings['dimensions'])
+            ->cache()
+            ->generate($settings['provider'] ?? null, $settings['model'] ?? null);
+
+        $embeddings = $response->embeddings;
+
+        if (! is_array($embeddings) || count($embeddings) !== count($inputs)) {
+            throw new ScoutException('Laravel AI returned an unexpected number of embeddings.');
+        }
+
+        return $embeddings;
     }
 
     /**

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -376,9 +376,7 @@ class TypesenseEngine extends Engine implements SupportsSemanticSearch
             return $documents->search($options);
         }
 
-        // Serialized embeddings may exceed Typesense's query string length
-        // limit, so vector queries are sent through the multi-search
-        // endpoint, which accepts the parameters in the request body...
+        // Serialized embeddings may exceed Typesense's query string length, so send through multi-search...
         $results = $this->typesense->getMultiSearch()->perform([
             'searches' => [
                 array_merge($options, [
@@ -390,7 +388,7 @@ class TypesenseEngine extends Engine implements SupportsSemanticSearch
         $result = $results['results'][0] ?? [];
 
         if (isset($result['error'])) {
-            throw $this->multiSearchException($result);
+            throw $this->marshalMultiSearchException($result);
         }
 
         return $result;
@@ -402,7 +400,7 @@ class TypesenseEngine extends Engine implements SupportsSemanticSearch
      * @param  array  $result
      * @return \Typesense\Exceptions\TypesenseClientError
      */
-    protected function multiSearchException(array $result): TypesenseClientError
+    protected function marshalMultiSearchException(array $result): TypesenseClientError
     {
         $exception = match ((int) ($result['code'] ?? 500)) {
             400 => new RequestMalformed,
@@ -537,7 +535,7 @@ class TypesenseEngine extends Engine implements SupportsSemanticSearch
             $parameters = $this->applyHybridQueryBy($parameters, $settings);
         }
 
-        if (! is_null($vectorQuery = $this->vectorQuery($builder, $settings))) {
+        if (! is_null($vectorQuery = $this->buildVectorQueryParameter($builder, $settings))) {
             $parameters['vector_query'] = $vectorQuery;
         }
 
@@ -594,8 +592,7 @@ class TypesenseEngine extends Engine implements SupportsSemanticSearch
             }
         }
 
-        // Remote embedders reject prefix searches on embedding fields, so a
-        // global prefix must become a per-field list that excludes them...
+        // Remote embedders reject prefix searches on embedding fields, so global prefix must become per-field...
         if (($parameters['prefix'] ?? null) === true || ($parameters['prefix'] ?? null) === 'true') {
             $parameters['prefix'] = implode(',', [...array_fill(0, count($fields), 'true'), 'false']);
         }
@@ -606,7 +603,7 @@ class TypesenseEngine extends Engine implements SupportsSemanticSearch
     /**
      * Build the "vector_query" parameter for the search.
      */
-    protected function vectorQuery(Builder $builder, array $settings): ?string
+    protected function buildVectorQueryParameter(Builder $builder, array $settings): ?string
     {
         if ($this->usesNativeEmbeddings($settings)) {
             $vector = [];
@@ -629,8 +626,6 @@ class TypesenseEngine extends Engine implements SupportsSemanticSearch
             $options[] = 'distance_threshold: '.$this->distanceThreshold($builder);
         }
 
-        // Typesense rejects an empty vector query without parameters; native
-        // semantic searches are expressed via "query_by" alone in that case...
         if (empty($vector) && empty($options)) {
             return null;
         }
@@ -645,10 +640,6 @@ class TypesenseEngine extends Engine implements SupportsSemanticSearch
 
     /**
      * Get the maximum vector distance for the search's minimum similarity.
-     *
-     * This assumes the collection uses the default cosine distance metric. On
-     * hybrid searches, Typesense only applies the threshold to vector search
-     * candidates; keyword matches are returned regardless of their distance.
      */
     protected function distanceThreshold(Builder $builder): float
     {

--- a/tests/Integration/TypesenseSearchableTest.php
+++ b/tests/Integration/TypesenseSearchableTest.php
@@ -2,8 +2,12 @@
 
 namespace Laravel\Scout\Tests\Integration;
 
+use Laravel\Scout\Builder;
+use Laravel\Scout\Engines\TypesenseEngine;
+use Laravel\Scout\Tests\Fixtures\SearchableModel;
 use Orchestra\Testbench\Attributes\RequiresEnv;
 use PHPUnit\Framework\Attributes\Group;
+use Typesense\Client;
 use Workbench\App\Models\SearchableUser;
 
 /**
@@ -272,6 +276,88 @@ class TypesenseSearchableTest extends TestCase
     public function test_it_can_filter_with_where_comparisons()
     {
         $this->itCanMakeWhereComparisons();
+    }
+
+    public function test_it_can_use_user_provided_embeddings_for_semantic_search()
+    {
+        $model = new class extends SearchableModel
+        {
+            public static $index;
+
+            public function searchableAs()
+            {
+                return static::$index;
+            }
+
+            public function indexableAs()
+            {
+                return static::$index;
+            }
+
+            public function toSearchableArray()
+            {
+                return [
+                    'id' => (string) $this->id,
+                    'name' => $this->name,
+                ];
+            }
+
+            public function toSearchableEmbedding()
+            {
+                return $this->embedding;
+            }
+        };
+
+        $modelClass = get_class($model);
+        $modelClass::$index = config('scout.prefix').'semantic_'.str()->random(12);
+
+        config()->set('scout.typesense.model-settings.'.$modelClass, [
+            'collection-schema' => [
+                'fields' => [
+                    ['name' => 'id', 'type' => 'string'],
+                    ['name' => 'name', 'type' => 'string'],
+                    ['name' => 'embedding', 'type' => 'float[]', 'num_dim' => 2],
+                ],
+            ],
+            'search-parameters' => [
+                'query_by' => 'name',
+            ],
+        ]);
+
+        $engine = new TypesenseEngine(
+            new Client(config('scout.typesense.client-settings')),
+            1000,
+            [
+                'model-settings' => [
+                    $modelClass => [
+                        'embedding' => [
+                            'attribute' => 'embedding',
+                            'dimensions' => 2,
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        try {
+            $cat = new $modelClass(['id' => 1, 'name' => 'A sleeping cat']);
+            $cat->setAttribute('embedding', [1, 0]);
+
+            $rocket = new $modelClass(['id' => 2, 'name' => 'A rocket launch']);
+            $rocket->setAttribute('embedding', [0, 1]);
+
+            $engine->update($model->newCollection([$cat, $rocket]));
+
+            $results = $engine->search(
+                (new Builder($model, 'a relaxed pet'))
+                    ->options(['vector' => [1, 0]])
+                    ->semantic()
+            );
+
+            $this->assertSame('1', $results['hits'][0]['document']['id']);
+        } finally {
+            $engine->deleteIndex($modelClass::$index);
+        }
     }
 
     protected static function scoutDriver(): string

--- a/tests/Integration/TypesenseSearchableTest.php
+++ b/tests/Integration/TypesenseSearchableTest.php
@@ -311,12 +311,14 @@ class TypesenseSearchableTest extends TestCase
         $modelClass = get_class($model);
         $modelClass::$index = config('scout.prefix').'semantic_'.str()->random(12);
 
+        $dimensions = 384;
+
         config()->set('scout.typesense.model-settings.'.$modelClass, [
             'collection-schema' => [
                 'fields' => [
                     ['name' => 'id', 'type' => 'string'],
                     ['name' => 'name', 'type' => 'string'],
-                    ['name' => 'embedding', 'type' => 'float[]', 'num_dim' => 2],
+                    ['name' => 'embedding', 'type' => 'float[]', 'num_dim' => $dimensions],
                 ],
             ],
             'search-parameters' => [
@@ -332,7 +334,7 @@ class TypesenseSearchableTest extends TestCase
                     $modelClass => [
                         'embedding' => [
                             'attribute' => 'embedding',
-                            'dimensions' => 2,
+                            'dimensions' => $dimensions,
                         ],
                     ],
                 ],
@@ -340,21 +342,39 @@ class TypesenseSearchableTest extends TestCase
         );
 
         try {
+            $catVector = array_fill(0, $dimensions, 0.001953125);
+            $catVector[0] = 1.0;
+
+            $rocketVector = array_fill(0, $dimensions, 0.001953125);
+            $rocketVector[$dimensions - 1] = 1.0;
+
             $cat = new $modelClass(['id' => 1, 'name' => 'A sleeping cat']);
-            $cat->setAttribute('embedding', [1, 0]);
+            $cat->setAttribute('embedding', $catVector);
 
             $rocket = new $modelClass(['id' => 2, 'name' => 'A rocket launch']);
-            $rocket->setAttribute('embedding', [0, 1]);
+            $rocket->setAttribute('embedding', $rocketVector);
 
             $engine->update($model->newCollection([$cat, $rocket]));
 
+            // The serialized query vector exceeds Typesense's 4,000 character
+            // query string limit, requiring the multi-search endpoint...
+            $this->assertGreaterThan(4000, strlen(implode(', ', $catVector)));
+
             $results = $engine->search(
                 (new Builder($model, 'a relaxed pet'))
-                    ->options(['vector' => [1, 0]])
+                    ->options(['vector' => $catVector])
                     ->semantic()
             );
 
             $this->assertSame('1', $results['hits'][0]['document']['id']);
+
+            $results = $engine->search(
+                (new Builder($model, 'rocket'))
+                    ->options(['vector' => $rocketVector])
+                    ->hybrid()
+            );
+
+            $this->assertSame('2', $results['hits'][0]['document']['id']);
         } finally {
             $engine->deleteIndex($modelClass::$index);
         }

--- a/tests/Unit/TypesenseEngineTest.php
+++ b/tests/Unit/TypesenseEngineTest.php
@@ -21,7 +21,9 @@ use PHPUnit\Framework\TestCase;
 use Typesense\Client as TypesenseClient;
 use Typesense\Collection as TypesenseCollection;
 use Typesense\Documents;
+use Typesense\Exceptions\RequestMalformed;
 use Typesense\Exceptions\TypesenseClientError;
+use Typesense\MultiSearch;
 
 class TypesenseEngineTest extends TestCase
 {
@@ -496,6 +498,83 @@ class TypesenseEngineTest extends TestCase
         $engine->buildSearchParameters($builder, 1, 10);
     }
 
+    public function test_searches_with_vector_queries_use_the_multi_search_endpoint(): void
+    {
+        $multiSearch = $this->createMock(MultiSearch::class);
+        $engine = $this->multiSearchEngine($multiSearch);
+
+        $engine->expects($this->once())
+            ->method('buildSearchParameters')
+            ->willReturn([
+                'q' => '*',
+                'query_by' => 'name',
+                'vector_query' => 'embedding:([0.1, 0.2])',
+            ]);
+
+        $multiSearch->expects($this->once())
+            ->method('perform')
+            ->with([
+                'searches' => [
+                    [
+                        'q' => '*',
+                        'query_by' => 'name',
+                        'vector_query' => 'embedding:([0.1, 0.2])',
+                        'collection' => 'table',
+                    ],
+                ],
+            ])
+            ->willReturn(['results' => [['found' => 1, 'hits' => [['document' => ['id' => '1']]]]]]);
+
+        $results = $engine->search(new Builder(new SearchableModel, 'conceptual query'));
+
+        $this->assertSame(1, $results['found']);
+        $this->assertSame('1', $results['hits'][0]['document']['id']);
+    }
+
+    public function test_multi_search_errors_are_converted_to_typesense_exceptions(): void
+    {
+        $multiSearch = $this->createMock(MultiSearch::class);
+        $engine = $this->multiSearchEngine($multiSearch);
+
+        $engine->method('buildSearchParameters')->willReturn([
+            'q' => '*',
+            'query_by' => 'name',
+            'vector_query' => 'embedding:([0.1, 0.2])',
+        ]);
+
+        $multiSearch->method('perform')->willReturn([
+            'results' => [['code' => 400, 'error' => 'Query string exceeds max allowed length.']],
+        ]);
+
+        $this->expectException(RequestMalformed::class);
+        $this->expectExceptionMessage('Query string exceeds max allowed length.');
+
+        $engine->search(new Builder(new SearchableModel, 'conceptual query'));
+    }
+
+    public function test_multi_search_creates_missing_collections_and_retries(): void
+    {
+        $multiSearch = $this->createMock(MultiSearch::class);
+        $engine = $this->multiSearchEngine($multiSearch);
+
+        $engine->method('buildSearchParameters')->willReturn([
+            'q' => '*',
+            'query_by' => 'name',
+            'vector_query' => 'embedding:([0.1, 0.2])',
+        ]);
+
+        $multiSearch->expects($this->exactly(2))
+            ->method('perform')
+            ->willReturnOnConsecutiveCalls(
+                ['results' => [['code' => 404, 'error' => 'Not found.']]],
+                ['results' => [['found' => 0, 'hits' => []]]],
+            );
+
+        $results = $engine->search(new Builder(new SearchableModel, 'conceptual query'));
+
+        $this->assertSame(0, $results['found']);
+    }
+
     public function test_delete_method(): void
     {
         // Mock models and their methods
@@ -730,6 +809,29 @@ class TypesenseEngineTest extends TestCase
         // Assert that the soft deleted object is returned
         $this->assertCount(1, $results);
         $this->assertEquals(1, $results->first()->id);
+    }
+
+    /**
+     * Create a partially mocked engine whose client performs multi-searches.
+     */
+    protected function multiSearchEngine(MultiSearch $multiSearch): TypesenseEngine
+    {
+        $client = $this->createMock(TypesenseClient::class);
+        $client->method('getMultiSearch')->willReturn($multiSearch);
+
+        $engine = $this->getMockBuilder(TypesenseEngine::class)
+            ->setConstructorArgs([$client, 1000])
+            ->onlyMethods(['getOrCreateCollectionFromModel', 'buildSearchParameters'])
+            ->getMock();
+
+        $collection = $this->createMock(TypesenseCollection::class);
+        $documents = $this->createMock(Documents::class);
+        $collection->method('getDocuments')->willReturn($documents);
+        $documents->expects($this->never())->method('search');
+
+        $engine->method('getOrCreateCollectionFromModel')->willReturn($collection);
+
+        return $engine;
     }
 
     /**

--- a/tests/Unit/TypesenseEngineTest.php
+++ b/tests/Unit/TypesenseEngineTest.php
@@ -10,7 +10,9 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Facade;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\TypesenseEngine;
+use Laravel\Scout\Tests\Fixtures\FakeEmbeddings;
 use Laravel\Scout\Tests\Fixtures\SearchableModel;
+use Laravel\Scout\Tests\Fixtures\SearchableModelWithPrecomputedEmbedding;
 use Mockery as m;
 use Orchestra\Testbench\Concerns\InteractsWithMockery;
 use PHPUnit\Framework\TestCase;
@@ -198,6 +200,113 @@ class TypesenseEngineTest extends TestCase
 
         // Call the update method
         $this->engine->update(collect($models));
+    }
+
+    public function test_update_adds_precomputed_and_generated_embeddings_to_documents(): void
+    {
+        Config::shouldReceive('get')->with('scout.typesense.import_action', m::any())->andReturn('upsert');
+
+        $this->fakeEmbeddings([[[0.3, 0.4]]]);
+
+        $engine = $this->getMockBuilder(TypesenseEngine::class)
+            ->setConstructorArgs([$this->createMock(TypesenseClient::class), 1000, [
+                'model-settings' => [
+                    SearchableModelWithPrecomputedEmbedding::class => [
+                        'embedding' => [
+                            'attribute' => 'embedding',
+                            'dimensions' => 2,
+                            'provider' => 'openai',
+                            'model' => 'text-embedding-test',
+                        ],
+                    ],
+                ],
+            ]])
+            ->onlyMethods(['getOrCreateCollectionFromModel'])
+            ->getMock();
+
+        $precomputed = new SearchableModelWithPrecomputedEmbedding(['id' => 10, 'name' => 'Precomputed']);
+        $precomputed->setAttribute('embedding', [0.1, 0.2]);
+
+        $generated = new SearchableModelWithPrecomputedEmbedding(['id' => 20, 'name' => 'Generate this']);
+
+        $collection = $this->createMock(TypesenseCollection::class);
+        $documents = $this->createMock(Documents::class);
+        $collection->expects($this->once())
+            ->method('getDocuments')
+            ->willReturn($documents);
+        $documents->expects($this->once())
+            ->method('import')
+            ->with(
+                [
+                    ['id' => 10, 'name' => 'Precomputed', 'embedding' => [0.1, 0.2]],
+                    ['id' => 20, 'name' => 'Generate this', 'embedding' => [0.3, 0.4]],
+                ],
+                ['action' => 'upsert'],
+            )
+            ->willReturn([
+                ['success' => true],
+                ['success' => true],
+            ]);
+
+        $engine->expects($this->once())
+            ->method('getOrCreateCollectionFromModel')
+            ->willReturn($collection);
+
+        $engine->update($precomputed->newCollection([$precomputed, $generated]));
+
+        $this->assertSame([[
+            'inputs' => ['Generate this'],
+            'cache' => null,
+            'dimensions' => 2,
+            'provider' => 'openai',
+            'model' => 'text-embedding-test',
+        ]], FakeEmbeddings::$requests);
+    }
+
+    public function test_update_does_not_generate_embeddings_when_using_native_embeddings(): void
+    {
+        Config::shouldReceive('get')->with('scout.typesense.import_action', m::any())->andReturn('upsert');
+
+        $this->fakeEmbeddings([]);
+
+        $engine = $this->getMockBuilder(TypesenseEngine::class)
+            ->setConstructorArgs([$this->createMock(TypesenseClient::class), 1000, [
+                'model-settings' => [
+                    SearchableModel::class => [
+                        'embedding' => [
+                            'attribute' => 'embedding',
+                            'driver' => 'typesense',
+                        ],
+                    ],
+                ],
+            ]])
+            ->onlyMethods(['getOrCreateCollectionFromModel'])
+            ->getMock();
+
+        $model = new SearchableModel(['id' => 1, 'name' => 'Model 1']);
+
+        $collection = $this->createMock(TypesenseCollection::class);
+        $documents = $this->createMock(Documents::class);
+        $collection->expects($this->once())
+            ->method('getDocuments')
+            ->willReturn($documents);
+        $documents->expects($this->once())
+            ->method('import')
+            ->with(
+                [['id' => 1, 'name' => 'Model 1']],
+                ['action' => 'upsert'],
+            )
+            ->willReturn([[
+                'success' => true,
+            ]]);
+
+        $engine->expects($this->once())
+            ->method('getOrCreateCollectionFromModel')
+            ->willReturn($collection);
+
+        $engine->update($model->newCollection([$model]));
+
+        $this->assertSame([], FakeEmbeddings::$requests);
     }
 
     public function test_delete_method(): void
@@ -434,5 +543,17 @@ class TypesenseEngineTest extends TestCase
         // Assert that the soft deleted object is returned
         $this->assertCount(1, $results);
         $this->assertEquals(1, $results->first()->id);
+    }
+
+    /**
+     * Register fake Laravel AI embedding responses.
+     */
+    protected function fakeEmbeddings(array $responses): void
+    {
+        if (! class_exists('Laravel\\Ai\\Embeddings')) {
+            class_alias(FakeEmbeddings::class, 'Laravel\\Ai\\Embeddings');
+        }
+
+        FakeEmbeddings::fake($responses);
     }
 }

--- a/tests/Unit/TypesenseEngineTest.php
+++ b/tests/Unit/TypesenseEngineTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Scout\Tests\Unit;
 
 use Http\Client\Exception;
+use Illuminate\Config\Repository;
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
@@ -10,6 +11,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Facade;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\TypesenseEngine;
+use Laravel\Scout\Exceptions\ScoutException;
 use Laravel\Scout\Tests\Fixtures\FakeEmbeddings;
 use Laravel\Scout\Tests\Fixtures\SearchableModel;
 use Laravel\Scout\Tests\Fixtures\SearchableModelWithPrecomputedEmbedding;
@@ -309,6 +311,191 @@ class TypesenseEngineTest extends TestCase
         $this->assertSame([], FakeEmbeddings::$requests);
     }
 
+    public function test_semantic_search_generates_a_query_vector(): void
+    {
+        $engine = $this->semanticEngine([
+            'attribute' => 'embedding',
+            'dimensions' => 2,
+        ]);
+
+        $this->fakeEmbeddings([[[0.25, 0.75]]]);
+
+        $builder = (new Builder(new SearchableModel, 'conceptual query'))
+            ->semantic(minSimilarity: 0.7);
+
+        $parameters = $engine->buildSearchParameters($builder, 1, 10);
+
+        $this->assertSame('*', $parameters['q']);
+        $this->assertSame('name', $parameters['query_by']);
+        $this->assertSame('embedding:([0.25, 0.75], distance_threshold: 0.3)', $parameters['vector_query']);
+        $this->assertSame('embedding', $parameters['exclude_fields']);
+        $this->assertArrayNotHasKey('vector', $parameters);
+        $this->assertSame(['conceptual query'], FakeEmbeddings::$requests[0]['inputs']);
+    }
+
+    public function test_hybrid_search_accepts_a_precomputed_query_vector_and_normalizes_weights(): void
+    {
+        $engine = $this->semanticEngine([
+            'attribute' => 'embedding',
+            'dimensions' => 2,
+        ]);
+
+        $this->fakeEmbeddings([]);
+
+        $builder = (new Builder(new SearchableModel, 'combined query'))
+            ->options(['vector' => [0.4, 0.6]])
+            ->hybrid(textWeight: 1, semanticWeight: 2);
+
+        $parameters = $engine->buildSearchParameters($builder, 2, 5);
+
+        $this->assertSame('combined query', $parameters['q']);
+        $this->assertSame('name', $parameters['query_by']);
+        $this->assertSame('embedding:([0.4, 0.6], alpha: '.(2 / 3).')', $parameters['vector_query']);
+        $this->assertSame('embedding', $parameters['exclude_fields']);
+        $this->assertArrayNotHasKey('vector', $parameters);
+        $this->assertSame([], FakeEmbeddings::$requests);
+    }
+
+    public function test_semantic_search_with_native_embeddings_queries_the_embedding_field(): void
+    {
+        $engine = $this->semanticEngine([
+            'attribute' => 'embedding',
+            'driver' => 'typesense',
+        ]);
+
+        $this->fakeEmbeddings([]);
+
+        $builder = (new Builder(new SearchableModel, 'conceptual query'))->semantic();
+
+        $parameters = $engine->buildSearchParameters($builder, 1, 10);
+
+        $this->assertSame('conceptual query', $parameters['q']);
+        $this->assertSame('embedding', $parameters['query_by']);
+        $this->assertFalse($parameters['prefix']);
+        $this->assertArrayNotHasKey('vector_query', $parameters);
+        $this->assertSame('embedding', $parameters['exclude_fields']);
+        $this->assertSame([], FakeEmbeddings::$requests);
+    }
+
+    public function test_semantic_search_with_native_embeddings_applies_a_distance_threshold(): void
+    {
+        $engine = $this->semanticEngine([
+            'attribute' => 'embedding',
+            'driver' => 'typesense',
+        ]);
+
+        $builder = (new Builder(new SearchableModel, 'conceptual query'))->semantic(minSimilarity: 0.5);
+
+        $parameters = $engine->buildSearchParameters($builder, 1, 10);
+
+        $this->assertSame('embedding', $parameters['query_by']);
+        $this->assertSame('embedding:([], distance_threshold: 0.5)', $parameters['vector_query']);
+    }
+
+    public function test_semantic_search_with_native_embeddings_drops_per_field_parameters(): void
+    {
+        $engine = $this->semanticEngine([
+            'attribute' => 'embedding',
+            'driver' => 'typesense',
+        ], 'name,description');
+
+        $builder = (new Builder(new SearchableModel, 'conceptual query'))
+            ->options(['query_by_weights' => '2,1', 'num_typos' => '2,1', 'infix' => 'off'])
+            ->semantic();
+
+        $parameters = $engine->buildSearchParameters($builder, 1, 10);
+
+        $this->assertSame('embedding', $parameters['query_by']);
+        $this->assertFalse($parameters['prefix']);
+        $this->assertArrayNotHasKey('query_by_weights', $parameters);
+        $this->assertArrayNotHasKey('num_typos', $parameters);
+        $this->assertSame('off', $parameters['infix']);
+    }
+
+    public function test_hybrid_search_with_native_embeddings_appends_the_embedding_field_to_query_by(): void
+    {
+        $engine = $this->semanticEngine([
+            'attribute' => 'embedding',
+            'driver' => 'typesense',
+        ]);
+
+        $builder = (new Builder(new SearchableModel, 'combined query'))->hybrid();
+
+        $parameters = $engine->buildSearchParameters($builder, 1, 10);
+
+        $this->assertSame('combined query', $parameters['q']);
+        $this->assertSame('name,embedding', $parameters['query_by']);
+        $this->assertSame('true,false', $parameters['prefix']);
+        $this->assertSame('embedding:([], alpha: 0.5)', $parameters['vector_query']);
+        $this->assertSame('embedding', $parameters['exclude_fields']);
+    }
+
+    public function test_hybrid_search_with_native_embeddings_extends_per_field_parameters(): void
+    {
+        $engine = $this->semanticEngine([
+            'attribute' => 'embedding',
+            'driver' => 'typesense',
+        ], 'name,description');
+
+        $builder = (new Builder(new SearchableModel, 'combined query'))
+            ->options(['query_by_weights' => '2,1', 'num_typos' => '2,1', 'prefix' => 'true,false', 'infix' => 'off'])
+            ->hybrid();
+
+        $parameters = $engine->buildSearchParameters($builder, 1, 10);
+
+        $this->assertSame('name,description,embedding', $parameters['query_by']);
+        $this->assertSame('2,1,0', $parameters['query_by_weights']);
+        $this->assertSame('2,1,0', $parameters['num_typos']);
+        $this->assertSame('true,false,false', $parameters['prefix']);
+        $this->assertSame('off', $parameters['infix']);
+    }
+
+    public function test_hybrid_search_requires_a_keyword_field_in_query_by(): void
+    {
+        $engine = $this->semanticEngine([
+            'attribute' => 'embedding',
+            'driver' => 'typesense',
+        ], '');
+
+        $builder = (new Builder(new SearchableModel, 'combined query'))->hybrid();
+
+        $this->expectException(ScoutException::class);
+        $this->expectExceptionMessage('Typesense hybrid searches require at least one keyword field in the [query_by] search parameter.');
+
+        $engine->buildSearchParameters($builder, 1, 10);
+    }
+
+    public function test_semantic_search_cannot_be_combined_with_a_custom_vector_query_option(): void
+    {
+        $engine = $this->semanticEngine([
+            'attribute' => 'embedding',
+            'dimensions' => 2,
+        ]);
+
+        $builder = (new Builder(new SearchableModel, 'conceptual query'))
+            ->options(['vector_query' => 'embedding:([], k: 10)'])
+            ->semantic();
+
+        $this->expectException(ScoutException::class);
+        $this->expectExceptionMessage('Typesense semantic and hybrid searches cannot be combined with a custom [vector_query] option.');
+
+        $engine->buildSearchParameters($builder, 1, 10);
+    }
+
+    public function test_semantic_search_requires_embedding_settings(): void
+    {
+        Container::getInstance()->instance('config', new Repository(['scout' => []]));
+
+        $engine = new TypesenseEngine($this->createMock(TypesenseClient::class), 1000);
+
+        $builder = (new Builder(new SearchableModel, 'conceptual query'))->semantic();
+
+        $this->expectException(ScoutException::class);
+        $this->expectExceptionMessage('No Typesense embedding settings have been configured for ['.SearchableModel::class.'].');
+
+        $engine->buildSearchParameters($builder, 1, 10);
+    }
+
     public function test_delete_method(): void
     {
         // Mock models and their methods
@@ -543,6 +730,34 @@ class TypesenseEngineTest extends TestCase
         // Assert that the soft deleted object is returned
         $this->assertCount(1, $results);
         $this->assertEquals(1, $results->first()->id);
+    }
+
+    /**
+     * Create an engine with embedding settings for the searchable model fixture.
+     */
+    protected function semanticEngine(array $embedding, string $queryBy = 'name'): TypesenseEngine
+    {
+        Container::getInstance()->instance('config', new Repository([
+            'scout' => [
+                'typesense' => [
+                    'model-settings' => [
+                        SearchableModel::class => [
+                            'search-parameters' => [
+                                'query_by' => $queryBy,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]));
+
+        return new TypesenseEngine($this->createMock(TypesenseClient::class), 1000, [
+            'model-settings' => [
+                SearchableModel::class => [
+                    'embedding' => $embedding,
+                ],
+            ],
+        ]);
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Brings the Typesense engine up to parity with the Meilisearch and Turbopuffer engines for `Builder::semantic()` and `Builder::hybrid()`. Embeddings come from one of two drivers configured per model: `laravel-ai` (the default), where Scout generates vectors through the Laravel AI SDK from `toSearchableEmbedding()` or accepts precomputed ones, embedding the query at search time, or `typesense`, where the collection's native auto-embedding field does everything server-side and Scout only targets it in `query_by`.

**Laravel AI driver (default)**

```php
// config/scout.php
'model-settings' => [
    Product::class => [
        'collection-schema' => [
            'fields' => [
                ['name' => 'name', 'type' => 'string'],
                ['name' => 'embedding', 'type' => 'float[]', 'num_dim' => 1536],
            ],
        ],
        'search-parameters' => ['query_by' => 'name'],
        'embedding' => ['attribute' => 'embedding', 'dimensions' => 1536],
    ],
],

// Scout embeds this at index time, or return an array to supply your own vector...
public function toSearchableEmbedding(): string
{
    return $this->name.' '.$this->description;
}

Product::search('device to type things on')->semantic()->get();
Product::search('a relaxed pet')->options(['vector' => $vector])->semantic(minSimilarity: 0.7)->get();
```

**Native Typesense driver**

```php
// config/scout.php
'model-settings' => [
    Product::class => [
        'collection-schema' => [
            'fields' => [
                ['name' => 'name', 'type' => 'string'],
                [
                    'name' => 'embedding',
                    'type' => 'float[]',
                    'embed' => [
                        'from' => ['name'],
                        'model_config' => ['model_name' => 'ts/all-MiniLM-L12-v2'],
                    ],
                ],
            ],
        ],
        'search-parameters' => ['query_by' => 'name'],
        'embedding' => ['attribute' => 'embedding', 'driver' => 'typesense'],
    ],
],

Product::search('device to type things on')->semantic()->get();
Product::search('desktop copier')->hybrid(textWeight: 1, semanticWeight: 2)->get();
```

- implement `SupportsSemanticSearch` on `TypesenseEngine`, configured via `scout.typesense.model-settings.<model>.embedding`
- generate or accept precomputed document embeddings during indexing, batched through the Laravel AI SDK
- translate `semantic()`/`hybrid()` into `vector_query`: hybrid weights normalize into `alpha`, `minSimilarity` maps to `distance_threshold` (1 - similarity), and `options(['vector' => ...])` supplies a precomputed query vector
- keep `query_by_weights`, `num_typos`, `prefix`, and `infix` count-aligned when the embedding field replaces or extends `query_by`, and disable prefix search on it since remote embedders reject that
- append the embedding attribute to `exclude_fields` so raw vectors never come back in responses
- add unit coverage for every driver and search-mode combination plus a live integration test using user-provided embeddings

