### PR TITLE
Add Elasticsearch engine

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,6 +113,56 @@ jobs:
           MEILISEARCH_KEY: 'masterKey'
           DB_CONNECTION: 'testing'
 
+  tests-using-elasticsearch:
+    runs-on: ubuntu-22.04
+
+    services:
+      elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.0
+        ports:
+          - 9200:9200
+        env:
+          discovery.type: single-node
+          xpack.security.enabled: false
+          ES_JAVA_OPTS: -Xms512m -Xmx512m
+          cluster.routing.allocation.disk.threshold_enabled: false
+
+    strategy:
+      fail-fast: true
+      matrix:
+          php: ['8.0', 8.1, 8.2, 8.3, 8.4]
+
+    name: PHP ${{ matrix.php }} using Elasticsearch
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Wait for Elasticsearch
+        run: |
+          timeout 120 bash -c 'until curl -s -o /dev/null http://localhost:9200; do sleep 2; done'
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip
+          ini-values: error_reporting=E_ALL
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+           composer update --prefer-dist --no-interaction --no-progress
+
+      - name: Execute tests
+        run: vendor/bin/phpunit --no-configuration --no-coverage --color --bootstrap vendor/autoload.php --group elasticsearch tests/Integration
+        env:
+          ELASTICSEARCH_HOST: 'http://localhost:9200'
+          DB_CONNECTION: 'testing'
+
   tests-using-typesense:
     runs-on: ubuntu-22.04
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Laravel Scout provides a simple, driver-based solution for adding full-text sear
 - [Algolia](https://www.algolia.com/)
 - [Meilisearch](https://github.com/meilisearch/meilisearch)
 - [Typesense](https://github.com/typesense/typesense)
+- [Elasticsearch](https://www.elastic.co/elasticsearch)
 
 ## Official Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "algolia/algoliasearch-client-php": "^3.2|^4.0",
         "typesense/typesense-php": "^4.9.3",
         "meilisearch/meilisearch-php": "^1.0",
+        "elasticsearch/elasticsearch": "^8.0",
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^7.31|^8.36|^9.15|^10.8|^11.0",
         "php-http/guzzle7-adapter": "^1.0",
@@ -60,6 +61,7 @@
     },
     "suggest": {
         "algolia/algoliasearch-client-php": "Required to use the Algolia engine (^3.2).",
+        "elasticsearch/elasticsearch": "Required to use the Elasticsearch engine (^8.0).",
         "laravel/ai": "Required to generate embeddings for semantic and hybrid search.",
         "meilisearch/meilisearch-php": "Required to use the Meilisearch engine (^1.0).",
         "typesense/typesense-php": "Required to use the Typesense engine (^4.9)."

--- a/config/scout.php
+++ b/config/scout.php
@@ -12,7 +12,7 @@ return [
     | to the search service. You should adjust this based on your needs.
     |
     | Supported: "algolia", "meilisearch", "typesense", "turbopuffer",
-    |            "database", "collection", "null"
+    |            "elasticsearch", "database", "collection", "null"
     |
     */
 
@@ -257,6 +257,41 @@ return [
             //         'name' => ['type' => 'string', 'full_text_search' => true],
             //         'email' => ['type' => 'string', 'full_text_search' => true],
             //         'embedding' => ['type' => '[1536]f32', 'ann' => true],
+            //     ],
+            // ],
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Elasticsearch Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your Elasticsearch connection. Elasticsearch is
+    | a distributed, RESTful search and analytics engine. Below, you can
+    | state the host(s) and credentials for your Elasticsearch cluster.
+    |
+    | See: https://www.elastic.co/guide/en/elasticsearch/client/php-api/current
+    |
+    */
+
+    'elasticsearch' => [
+        'hosts' => [
+            env('ELASTICSEARCH_HOST', 'http://localhost:9200'),
+        ],
+        'user' => env('ELASTICSEARCH_USER'),
+        'password' => env('ELASTICSEARCH_PASSWORD'),
+        'index-settings' => [
+            // 'users' => [
+            //     'settings' => [
+            //         'number_of_shards' => 1,
+            //         'number_of_replicas' => 0,
+            //     ],
+            //     'mappings' => [
+            //         'properties' => [
+            //             'id' => ['type' => 'keyword'],
+            //             'name' => ['type' => 'text'],
+            //         ],
             //     ],
             // ],
         ],

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -5,12 +5,14 @@ namespace Laravel\Scout;
 use Algolia\AlgoliaSearch\Algolia;
 use Algolia\AlgoliaSearch\Support\AlgoliaAgent as Algolia4UserAgent;
 use Algolia\AlgoliaSearch\Support\UserAgent as Algolia3UserAgent;
+use Elastic\Elasticsearch\Client as ElasticsearchClient;
 use Exception;
 use Illuminate\Support\Manager;
 use Laravel\Scout\Engines\Algolia3Engine;
 use Laravel\Scout\Engines\Algolia4Engine;
 use Laravel\Scout\Engines\CollectionEngine;
 use Laravel\Scout\Engines\DatabaseEngine;
+use Laravel\Scout\Engines\ElasticsearchEngine;
 use Laravel\Scout\Engines\MeilisearchEngine;
 use Laravel\Scout\Engines\NullEngine;
 use Laravel\Scout\Engines\TurbopufferEngine;
@@ -119,6 +121,37 @@ class EngineManager extends Manager
         }
 
         return $headers;
+    }
+
+    /**
+     * Create an Elasticsearch engine instance.
+     *
+     * @return \Laravel\Scout\Engines\ElasticsearchEngine
+     */
+    public function createElasticsearchDriver()
+    {
+        $this->ensureElasticsearchClientIsInstalled();
+
+        return new ElasticsearchEngine(
+            $this->container->make(ElasticsearchClient::class),
+            config('scout.soft_delete', false)
+        );
+    }
+
+    /**
+     * Ensure the Elasticsearch client is installed.
+     *
+     * @return void
+     *
+     * @throws \Exception
+     */
+    protected function ensureElasticsearchClientIsInstalled()
+    {
+        if (class_exists(ElasticsearchClient::class)) {
+            return;
+        }
+
+        throw new Exception('Please install the suggested Elasticsearch client: elasticsearch/elasticsearch.');
     }
 
     /**

--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -1,0 +1,510 @@
+<?php
+
+namespace Laravel\Scout\Engines;
+
+use Elastic\Elasticsearch\Client as ElasticsearchClient;
+use Elastic\Elasticsearch\Exception\ClientResponseException;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\LazyCollection;
+use Laravel\Scout\Builder;
+use Laravel\Scout\Contracts\UpdatesIndexSettings;
+use stdClass;
+
+class ElasticsearchEngine extends Engine implements UpdatesIndexSettings
+{
+    /**
+     * The Elasticsearch client.
+     *
+     * @var \Elastic\Elasticsearch\Client
+     */
+    protected $elasticsearch;
+
+    /**
+     * Determines if soft deletes for Scout are enabled or not.
+     *
+     * @var bool
+     */
+    protected $softDelete;
+
+    /**
+     * Create a new Elasticsearch engine instance.
+     *
+     * @param  \Elastic\Elasticsearch\Client  $elasticsearch
+     * @param  bool  $softDelete
+     * @return void
+     */
+    public function __construct(ElasticsearchClient $elasticsearch, $softDelete = false)
+    {
+        $this->elasticsearch = $elasticsearch;
+        $this->softDelete = $softDelete;
+    }
+
+    /**
+     * Update the given model in the index.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @return void
+     */
+    public function update($models)
+    {
+        if ($models->isEmpty()) {
+            return;
+        }
+
+        if ($this->usesSoftDelete($models->first()) && $this->softDelete) {
+            $models->each->pushSoftDeleteMetadata();
+        }
+
+        $params = ['body' => []];
+
+        $models->each(function ($model) use (&$params) {
+            if (empty($searchableData = $model->toSearchableArray())) {
+                return;
+            }
+
+            $params['body'][] = [
+                'index' => [
+                    '_index' => $model->indexableAs(),
+                    '_id' => $model->getScoutKey(),
+                ],
+            ];
+
+            $params['body'][] = array_merge(
+                $searchableData,
+                $model->scoutMetadata(),
+                [$model->getScoutKeyName() => $model->getScoutKey()],
+            );
+        });
+
+        if (! empty($params['body'])) {
+            $this->elasticsearch->bulk($params);
+        }
+    }
+
+    /**
+     * Remove the given model from the index.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @return void
+     */
+    public function delete($models)
+    {
+        if ($models->isEmpty()) {
+            return;
+        }
+
+        $params = ['body' => []];
+
+        $models->each(function ($model) use (&$params) {
+            $params['body'][] = [
+                'delete' => [
+                    '_index' => $model->indexableAs(),
+                    '_id' => $model->getScoutKey(),
+                ],
+            ];
+        });
+
+        $this->elasticsearch->bulk($params);
+    }
+
+    /**
+     * Perform the given search on the engine.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return mixed
+     */
+    public function search(Builder $builder)
+    {
+        return $this->performSearch($builder, array_filter([
+            'size' => $builder->limit,
+            'body' => $this->buildSearchBody($builder),
+        ]));
+    }
+
+    /**
+     * Perform the given search on the engine.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  int  $perPage
+     * @param  int  $page
+     * @return mixed
+     */
+    public function paginate(Builder $builder, $perPage, $page)
+    {
+        return $this->performSearch($builder, [
+            'from' => ($page - 1) * $perPage,
+            'size' => (int) $perPage,
+            'body' => $this->buildSearchBody($builder),
+        ]);
+    }
+
+    /**
+     * Perform the given search on the engine.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  array  $searchParams
+     * @return mixed
+     */
+    protected function performSearch(Builder $builder, array $searchParams = [])
+    {
+        $searchParams = array_merge($builder->options, $searchParams);
+
+        $searchParams['index'] = $builder->index ?: $builder->model->searchableAs();
+
+        if ($builder->callback) {
+            return call_user_func(
+                $builder->callback,
+                $this->elasticsearch,
+                $builder->query,
+                $searchParams
+            );
+        }
+
+        return $this->elasticsearch->search($searchParams);
+    }
+
+    /**
+     * Build the search body for the given query.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return array
+     */
+    protected function buildSearchBody(Builder $builder)
+    {
+        $body = ['query' => $this->buildQuery($builder)];
+
+        if (! empty($builder->orders)) {
+            $body['sort'] = $this->buildSort($builder);
+        }
+
+        return $body;
+    }
+
+    /**
+     * Build the Elasticsearch query for the given search.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return array
+     */
+    protected function buildQuery(Builder $builder)
+    {
+        $bool = [];
+
+        if ($builder->query !== '' && $builder->query !== '*') {
+            $bool['must'][] = [
+                'multi_match' => [
+                    'query' => $builder->query,
+                    'type' => 'bool_prefix',
+                    'fields' => ['*'],
+                ],
+            ];
+        }
+
+        $filters = collect($builder->wheres)->map(function ($where) {
+            return $this->buildFilter($where['field'], $where['operator'], $where['value']);
+        });
+
+        foreach ($builder->whereIns as $field => $values) {
+            $filters->push(['terms' => [$field => array_values($values)]]);
+        }
+
+        foreach ($builder->whereNotIns as $field => $values) {
+            $filters->push(['bool' => ['must_not' => ['terms' => [$field => array_values($values)]]]]);
+        }
+
+        if ($filters->isNotEmpty()) {
+            $bool['filter'] = $filters->values()->all();
+        }
+
+        return empty($bool) ? ['match_all' => new stdClass] : ['bool' => $bool];
+    }
+
+    /**
+     * Build an Elasticsearch filter clause for the given field, operator, and value.
+     *
+     * @param  string  $field
+     * @param  string  $operator
+     * @param  mixed  $value
+     * @return array
+     */
+    protected function buildFilter($field, $operator, $value)
+    {
+        if (is_null($value)) {
+            return $operator === '!='
+                ? ['exists' => ['field' => $field]]
+                : ['bool' => ['must_not' => ['exists' => ['field' => $field]]]];
+        }
+
+        return match ($operator) {
+            '!=' => ['bool' => ['must_not' => ['term' => [$field => $value]]]],
+            '>' => ['range' => [$field => ['gt' => $value]]],
+            '>=' => ['range' => [$field => ['gte' => $value]]],
+            '<' => ['range' => [$field => ['lt' => $value]]],
+            '<=' => ['range' => [$field => ['lte' => $value]]],
+            default => ['term' => [$field => $value]],
+        };
+    }
+
+    /**
+     * Build the sort clauses for the given search.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return array
+     */
+    protected function buildSort(Builder $builder)
+    {
+        return collect($builder->orders)
+            ->map(fn (array $order) => [$order['column'] => $order['direction']])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Pluck and return the primary keys of the given results.
+     *
+     * @param  mixed  $results
+     * @return \Illuminate\Support\Collection
+     */
+    public function mapIds($results)
+    {
+        return collect($results['hits']['hits'])->pluck('_id')->values();
+    }
+
+    /**
+     * Pluck the given results with the given primary key name.
+     *
+     * @param  mixed  $results
+     * @param  string  $key
+     * @return \Illuminate\Support\Collection
+     */
+    public function mapIdsFrom($results, $key)
+    {
+        return collect($results['hits']['hits'])->pluck('_source.'.$key)->values();
+    }
+
+    /**
+     * Get the results of the query as a Collection of primary keys.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @return \Illuminate\Support\Collection
+     */
+    public function keys(Builder $builder)
+    {
+        $scoutKey = $builder->model->getScoutKeyName();
+
+        return $this->mapIdsFrom($this->search($builder), $scoutKey);
+    }
+
+    /**
+     * Map the given results to instances of the given model.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  mixed  $results
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function map(Builder $builder, $results, $model)
+    {
+        if (count($results['hits']['hits']) === 0) {
+            return $model->newCollection();
+        }
+
+        $objectIds = collect($results['hits']['hits'])
+            ->pluck('_id')
+            ->values()
+            ->all();
+
+        $objectIdPositions = array_flip($objectIds);
+
+        return $model->getScoutModelsByIds($builder, $objectIds)
+            ->filter(fn ($model) => in_array($model->getScoutKey(), $objectIds))
+            ->map(function ($model) use ($results, $objectIdPositions) {
+                $result = $results['hits']['hits'][$objectIdPositions[$model->getScoutKey()]] ?? [];
+
+                foreach ($result['_source'] ?? [] as $key => $value) {
+                    if (str_starts_with($key, '_')) {
+                        $model->withScoutMetadata($key, $value);
+                    }
+                }
+
+                return $model;
+            })
+            ->sortBy(fn ($model) => $objectIdPositions[$model->getScoutKey()])
+            ->values();
+    }
+
+    /**
+     * Map the given results to instances of the given model via a lazy collection.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  mixed  $results
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Support\LazyCollection
+     */
+    public function lazyMap(Builder $builder, $results, $model)
+    {
+        if (count($results['hits']['hits']) === 0) {
+            return LazyCollection::make($model->newCollection());
+        }
+
+        $objectIds = collect($results['hits']['hits'])
+            ->pluck('_id')
+            ->values()
+            ->all();
+
+        $objectIdPositions = array_flip($objectIds);
+
+        return $model->queryScoutModelsByIds($builder, $objectIds)
+            ->cursor()
+            ->filter(fn ($model) => in_array($model->getScoutKey(), $objectIds))
+            ->map(function ($model) use ($results, $objectIdPositions) {
+                $result = $results['hits']['hits'][$objectIdPositions[$model->getScoutKey()]] ?? [];
+
+                foreach ($result['_source'] ?? [] as $key => $value) {
+                    if (str_starts_with($key, '_')) {
+                        $model->withScoutMetadata($key, $value);
+                    }
+                }
+
+                return $model;
+            })
+            ->sortBy(fn ($model) => $objectIdPositions[$model->getScoutKey()])
+            ->values();
+    }
+
+    /**
+     * Get the total count from a raw result returned by the engine.
+     *
+     * @param  mixed  $results
+     * @return int
+     */
+    public function getTotalCount($results)
+    {
+        return $results['hits']['total']['value'];
+    }
+
+    /**
+     * Flush all of the model's records from the engine.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    public function flush($model)
+    {
+        $this->elasticsearch->deleteByQuery([
+            'index' => $model->indexableAs(),
+            'body' => [
+                'query' => ['match_all' => new stdClass],
+            ],
+        ]);
+    }
+
+    /**
+     * Create a search index.
+     *
+     * @param  string  $name
+     * @param  array  $options
+     * @return void
+     */
+    public function createIndex($name, array $options = [])
+    {
+        $this->elasticsearch->indices()->create(array_merge([
+            'index' => $name,
+        ], $options));
+    }
+
+    /**
+     * Update the index settings for the given index.
+     *
+     * @param  string  $name
+     * @param  array  $settings
+     * @return void
+     */
+    public function updateIndexSettings($name, array $settings = [])
+    {
+        if (! empty($settings['settings'])) {
+            $this->elasticsearch->indices()->putSettings([
+                'index' => $name,
+                'body' => $settings['settings'],
+            ]);
+        }
+
+        if (! empty($settings['mappings'])) {
+            $this->elasticsearch->indices()->putMapping([
+                'index' => $name,
+                'body' => $settings['mappings'],
+            ]);
+        }
+    }
+
+    /**
+     * Configure the soft delete filter within the given settings.
+     *
+     * @param  array  $settings
+     * @return array
+     */
+    public function configureSoftDeleteFilter(array $settings = [])
+    {
+        $settings['mappings']['properties']['__soft_deleted'] = [
+            'type' => 'integer',
+        ];
+
+        return $settings;
+    }
+
+    /**
+     * Delete a search index.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public function deleteIndex($name)
+    {
+        $this->elasticsearch->indices()->delete(['index' => $name]);
+    }
+
+    /**
+     * Delete all search indexes.
+     *
+     * @return void
+     */
+    public function deleteAllIndexes()
+    {
+        $prefix = Config::get('scout.prefix');
+
+        try {
+            $indexes = collect($this->elasticsearch->indices()->get(['index' => '*'])->asArray());
+        } catch (ClientResponseException) {
+            return;
+        }
+
+        $indexes->keys()
+            ->filter(fn ($name) => str_starts_with($name, $prefix))
+            ->reject(fn ($name) => str_starts_with($name, '.'))
+            ->each(fn ($name) => $this->elasticsearch->indices()->delete(['index' => $name]));
+    }
+
+    /**
+     * Determine if the given model uses soft deletes.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return bool
+     */
+    protected function usesSoftDelete($model)
+    {
+        return in_array(SoftDeletes::class, class_uses_recursive($model));
+    }
+
+    /**
+     * Dynamically call the Elasticsearch client instance.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->elasticsearch->$method(...$parameters);
+    }
+}

--- a/src/ScoutServiceProvider.php
+++ b/src/ScoutServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Scout;
 
+use Elastic\Elasticsearch\Client as ElasticsearchClient;
+use Elastic\Elasticsearch\ClientBuilder;
 use Illuminate\Http\Client\Factory as HttpFactory;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Scout\Console\DeleteAllIndexesCommand;
@@ -34,6 +36,20 @@ class ScoutServiceProvider extends ServiceProvider
                     $config['key'],
                     clientAgents: [sprintf('Meilisearch Laravel Scout (v%s)', Scout::VERSION)],
                 );
+            });
+        }
+
+        if (class_exists(ElasticsearchClient::class)) {
+            $this->app->singleton(ElasticsearchClient::class, function ($app) {
+                $config = $app['config']->get('scout.elasticsearch');
+
+                $builder = ClientBuilder::create()->setHosts($config['hosts']);
+
+                if (! empty($config['user'])) {
+                    $builder->setBasicAuthentication($config['user'], $config['password']);
+                }
+
+                return $builder->build();
             });
         }
 

--- a/tests/Feature/Engines/ElasticsearchEngineTest.php
+++ b/tests/Feature/Engines/ElasticsearchEngineTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Laravel\Scout\Tests\Feature\Engines;
+
+use Elastic\Elasticsearch\Client;
+use Laravel\Scout\EngineManager;
+use Laravel\Scout\Engines\ElasticsearchEngine;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+
+class ElasticsearchEngineTest extends TestCase
+{
+    use WithWorkbench;
+
+    protected function defineEnvironment($app)
+    {
+        $app['config']->set('scout.driver', 'elasticsearch');
+        $app['config']->set('scout.elasticsearch.hosts', ['http://localhost:9200']);
+    }
+
+    public function test_the_elasticsearch_client_can_be_initialized()
+    {
+        $this->assertInstanceOf(Client::class, app(Client::class));
+    }
+
+    public function test_driver_is_registered()
+    {
+        $this->assertInstanceOf(
+            ElasticsearchEngine::class,
+            $this->app->make(EngineManager::class)->engine()
+        );
+    }
+}

--- a/tests/Integration/ElasticsearchSearchableTest.php
+++ b/tests/Integration/ElasticsearchSearchableTest.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace Laravel\Scout\Tests\Integration;
+
+use Elastic\Elasticsearch\Client;
+use Orchestra\Testbench\Attributes\RequiresEnv;
+use PHPUnit\Framework\Attributes\Group;
+use Workbench\App\Models\SearchableUser;
+
+/**
+ * @group elasticsearch
+ * @group external-network
+ */
+#[Group('elasticsearch')]
+#[Group('external-network')]
+#[RequiresEnv('ELASTICSEARCH_HOST')]
+class ElasticsearchSearchableTest extends TestCase
+{
+    use SearchableTests {
+        defineScoutDatabaseMigrations as baseDefineScoutDatabaseMigrations;
+    }
+
+    /**
+     * Define environment setup.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return void
+     */
+    protected function defineEnvironment($app)
+    {
+        $this->defineScoutEnvironment($app);
+
+        $app['config']->set('scout.elasticsearch.hosts', [env('ELASTICSEARCH_HOST', 'http://localhost:9200')]);
+    }
+
+    /**
+     * Define database migrations.
+     */
+    protected function defineDatabaseMigrations()
+    {
+        $this->defineScoutDatabaseMigrations();
+    }
+
+    protected function defineScoutDatabaseMigrations()
+    {
+        $this->baseDefineScoutDatabaseMigrations();
+
+        $this->importScoutIndexFrom(SearchableUser::class);
+    }
+
+    public function test_it_can_use_basic_search()
+    {
+        $results = $this->itCanUseBasicSearch();
+
+        $this->assertSame([
+            1 => 'Laravel Framework',
+            11 => 'Larry Casper',
+            12 => 'Reta Larkin',
+            20 => 'Prof. Larry Prosacco DVM',
+            39 => 'Linkwood Larkin',
+            40 => 'Otis Larson MD',
+            41 => 'Gudrun Larkin',
+            42 => 'Dax Larkin',
+            43 => 'Dana Larson Sr.',
+            44 => 'Amos Larson Sr.',
+        ], $results->pluck('name', 'id')->all());
+    }
+
+    public function test_it_can_use_basic_search_with_query_callback()
+    {
+        $results = $this->itCanUseBasicSearchWithQueryCallback();
+
+        $this->assertEqualsCanonicalizing([
+            1 => 'Laravel Framework',
+            12 => 'Reta Larkin',
+            40 => 'Otis Larson MD',
+            41 => 'Gudrun Larkin',
+            42 => 'Dax Larkin',
+            43 => 'Dana Larson Sr.',
+            44 => 'Amos Larson Sr.',
+        ], $results->pluck('name', 'id')->all());
+    }
+
+    public function test_it_can_use_basic_search_to_fetch_keys()
+    {
+        $results = $this->itCanUseBasicSearchToFetchKeys();
+
+        $this->assertEqualsCanonicalizing([
+            1,
+            11,
+            12,
+            39,
+            40,
+            41,
+            42,
+            43,
+            44,
+            20,
+        ], $results->all());
+    }
+
+    public function test_it_can_use_basic_search_with_query_callback_to_fetch_keys()
+    {
+        $results = $this->itCanUseBasicSearchWithQueryCallbackToFetchKeys();
+
+        $this->assertEqualsCanonicalizing([
+            1,
+            11,
+            12,
+            20,
+            39,
+            40,
+            41,
+            42,
+            43,
+            44,
+        ], $results->all());
+    }
+
+    public function test_it_return_same_keys_with_query_callback()
+    {
+        $this->assertEqualsCanonicalizing(
+            $this->itCanUseBasicSearchToFetchKeys()->all(),
+            $this->itCanUseBasicSearchWithQueryCallbackToFetchKeys()->all()
+        );
+    }
+
+    public function test_it_can_use_paginated_search()
+    {
+        [$page1, $page2] = $this->itCanUsePaginatedSearch();
+
+        $this->assertSame(10, $page1->total());
+        $this->assertCount(5, $page1);
+        $this->assertCount(5, $page2);
+
+        $this->assertEqualsCanonicalizing([
+            'Laravel Framework',
+            'Larry Casper',
+            'Reta Larkin',
+            'Prof. Larry Prosacco DVM',
+            'Linkwood Larkin',
+        ], $page1->pluck('name')->all());
+
+        $this->assertEqualsCanonicalizing([
+            'Otis Larson MD',
+            'Gudrun Larkin',
+            'Dax Larkin',
+            'Dana Larson Sr.',
+            'Amos Larson Sr.',
+        ], $page2->pluck('name')->all());
+    }
+
+    public function test_it_can_use_paginated_search_with_query_callback()
+    {
+        [$page1, $page2] = $this->itCanUsePaginatedSearchWithQueryCallback();
+
+        $this->assertSame(7, $page1->total());
+
+        $this->assertEqualsCanonicalizing([
+            'Laravel Framework',
+            'Reta Larkin',
+        ], $page1->pluck('name')->all());
+
+        $this->assertEqualsCanonicalizing([
+            'Otis Larson MD',
+            'Gudrun Larkin',
+            'Dax Larkin',
+            'Dana Larson Sr.',
+            'Amos Larson Sr.',
+        ], $page2->pluck('name')->all());
+    }
+
+    public function test_it_can_use_paginated_search_with_empty_query_callback()
+    {
+        $results = $this->itCanUsePaginatedSearchWithEmptyQueryCallback();
+
+        $this->assertSame(44, $results->total());
+    }
+
+    public function test_it_can_use_raw_paginated_search_with_after_raw_search_callback()
+    {
+        $rawResults = $this->itCanAccessRawSearchResultsOfPaginateUsingAfterRawSearchCallback();
+
+        $this->assertInstanceOf(\Elastic\Elasticsearch\Response\Elasticsearch::class, $rawResults);
+        $this->assertSame(44, $rawResults['hits']['total']['value']);
+    }
+
+    public function test_it_can_access_raw_search_results_of_paginate_raw()
+    {
+        $rawResults = $this->itCanAccessRawSearchResultsOfPaginateRawUsingAfterRawSearchCallback();
+
+        $this->assertSame(44, $rawResults['hits']['total']['value']);
+    }
+
+    public function test_it_can_access_raw_search_results_of_simple_paginate()
+    {
+        $rawResults = $this->itCanAccessRawSearchResultsOfSimplePaginateUsingAfterRawSearchCallback();
+
+        $this->assertSame(44, $rawResults['hits']['total']['value']);
+    }
+
+    public function test_it_can_access_raw_search_results_of_get()
+    {
+        $rawResults = $this->itCanAccessRawSearchResultsOfGetUsingAfterRawSearchCallback();
+
+        $this->assertSame(44, $rawResults['hits']['total']['value']);
+    }
+
+    public function test_it_can_access_raw_search_results_of_cursor()
+    {
+        $rawResults = $this->itCanAccessRawSearchResultsOfCursorUsingAfterRawSearchCallback();
+
+        $this->assertSame(44, $rawResults['hits']['total']['value']);
+    }
+
+    public function test_it_can_filter_with_where_comparisons()
+    {
+        $this->itCanMakeWhereComparisons();
+    }
+
+    protected function importScoutIndexFrom($model = null)
+    {
+        parent::importScoutIndexFrom($model);
+
+        $this->app->make(Client::class)->indices()->refresh(['index' => '*']);
+    }
+
+    protected static function scoutDriver(): string
+    {
+        return 'elasticsearch';
+    }
+}

--- a/tests/Unit/ElasticsearchEngineTest.php
+++ b/tests/Unit/ElasticsearchEngineTest.php
@@ -1,0 +1,566 @@
+<?php
+
+namespace Laravel\Scout\Tests\Unit;
+
+use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\ClientBuilder;
+use Elastic\Elasticsearch\Endpoints\Indices;
+use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\LazyCollection;
+use Laravel\Scout\Builder;
+use Laravel\Scout\Engines\ElasticsearchEngine;
+use Laravel\Scout\Tests\Fixtures\SearchableModel;
+use Mockery as m;
+use Nyholm\Psr7\Response;
+use Orchestra\Testbench\Concerns\InteractsWithMockery;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface as Psr18Client;
+use Psr\Http\Message\RequestInterface;
+use stdClass;
+
+class ElasticsearchEngineTest extends TestCase
+{
+    use InteractsWithMockery;
+
+    /**
+     * The HTTP requests captured from the Elasticsearch client.
+     *
+     * @var array
+     */
+    protected $requests = [];
+
+    protected function setUp(): void
+    {
+        Config::shouldReceive('get')->with('scout.after_commit', m::any())->andReturn(false);
+        Config::shouldReceive('get')->with('scout.soft_delete', m::any())->andReturn(false);
+    }
+
+    protected function tearDown(): void
+    {
+        Container::getInstance()->flush();
+
+        $this->tearDownTheTestEnvironmentUsingMockery();
+    }
+
+    public function test_update_sends_bulk_index_operations()
+    {
+        $engine = $this->engine();
+
+        $engine->update(new Collection([
+            new SearchableModel(['id' => 1, 'name' => 'Taylor']),
+            new SearchableModel(['id' => 2, 'name' => 'Abigail']),
+        ]));
+
+        $this->assertCount(1, $this->requests);
+
+        $this->assertSame('POST', $this->request()->getMethod());
+        $this->assertSame('/_bulk', $this->request()->getUri()->getPath());
+        $this->assertEquals([
+            [
+                'index' => ['_index' => 'table', '_id' => 1],
+            ],
+            [
+                'id' => 1,
+                'name' => 'Taylor',
+            ],
+            [
+                'index' => ['_index' => 'table', '_id' => 2],
+            ],
+            [
+                'id' => 2,
+                'name' => 'Abigail',
+            ],
+        ], $this->ndjsonBody());
+    }
+
+    public function test_update_includes_soft_delete_metadata_when_enabled()
+    {
+        $engine = $this->engine([], true);
+
+        $engine->update(new Collection([
+            (new ElasticsearchSoftDeleteSearchableModel)->forceFill(['id' => 1, 'name' => 'Taylor']),
+        ]));
+
+        $this->assertEquals([
+            [
+                'index' => ['_index' => 'table', '_id' => 1],
+            ],
+            [
+                'id' => 1,
+                'name' => 'Taylor',
+                '__soft_deleted' => 0,
+            ],
+        ], $this->ndjsonBody());
+    }
+
+    public function test_updating_empty_eloquent_collection_does_nothing()
+    {
+        $this->engine()->update(new Collection);
+
+        $this->assertCount(0, $this->requests);
+    }
+
+    public function test_delete_sends_bulk_delete_operations()
+    {
+        $this->engine()->delete(new Collection([
+            new SearchableModel(['id' => 1]),
+        ]));
+
+        $this->assertCount(1, $this->requests);
+
+        $this->assertSame('POST', $this->request()->getMethod());
+        $this->assertSame('/_bulk', $this->request()->getUri()->getPath());
+        $this->assertEquals([
+            [
+                'delete' => ['_index' => 'table', '_id' => 1],
+            ],
+        ], $this->ndjsonBody());
+    }
+
+    public function test_search_sends_multi_match_query()
+    {
+        $this->engine()->search($this->builder('hello'));
+
+        $this->assertSame('POST', $this->request()->getMethod());
+        $this->assertSame('/table/_search', $this->request()->getUri()->getPath());
+        $this->assertEquals([
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        ['multi_match' => ['query' => 'hello', 'type' => 'bool_prefix', 'fields' => ['*']]],
+                    ],
+                ],
+            ],
+        ], $this->jsonBody());
+    }
+
+    public function test_search_without_query_matches_all_documents()
+    {
+        $this->engine()->search($this->builder());
+
+        $this->assertEquals([
+            'query' => ['match_all' => []],
+        ], $this->jsonBody());
+    }
+
+    public function test_search_with_wildcard_query_matches_all_documents()
+    {
+        $this->engine()->search($this->builder('*'));
+
+        $this->assertEquals([
+            'query' => ['match_all' => []],
+        ], $this->jsonBody());
+    }
+
+    public function test_search_translates_wheres_into_filters()
+    {
+        $builder = $this->builder()
+            ->where('name', 'Taylor')
+            ->where('price', '>', 100)
+            ->where('price', '<=', 500)
+            ->where('foo', null)
+            ->where('bar', '!=', null)
+            ->whereIn('id', [1, 2])
+            ->whereNotIn('color', ['red']);
+
+        $this->engine()->search($builder);
+
+        $this->assertEquals([
+            'query' => [
+                'bool' => [
+                    'filter' => [
+                        ['term' => ['name' => 'Taylor']],
+                        ['range' => ['price' => ['gt' => 100]]],
+                        ['range' => ['price' => ['lte' => 500]]],
+                        ['bool' => ['must_not' => ['exists' => ['field' => 'foo']]]],
+                        ['exists' => ['field' => 'bar']],
+                        ['terms' => ['id' => [1, 2]]],
+                        ['bool' => ['must_not' => ['terms' => ['color' => ['red']]]]],
+                    ],
+                ],
+            ],
+        ], $this->jsonBody());
+    }
+
+    public function test_search_applies_soft_delete_filter()
+    {
+        $this->engine()->search(new Builder(new SearchableModel, 'hello', null, true));
+
+        $this->assertEquals([
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        ['multi_match' => ['query' => 'hello', 'type' => 'bool_prefix', 'fields' => ['*']]],
+                    ],
+                    'filter' => [
+                        ['term' => ['__soft_deleted' => 0]],
+                    ],
+                ],
+            ],
+        ], $this->jsonBody());
+    }
+
+    public function test_search_with_limit_and_orders()
+    {
+        $builder = $this->builder('hello')->take(5)->orderBy('name', 'desc');
+
+        $this->engine()->search($builder);
+
+        $this->assertSame('size=5', $this->request()->getUri()->getQuery());
+        $this->assertEquals([
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        ['multi_match' => ['query' => 'hello', 'type' => 'bool_prefix', 'fields' => ['*']]],
+                    ],
+                ],
+            ],
+            'sort' => [
+                ['name' => 'desc'],
+            ],
+        ], $this->jsonBody());
+    }
+
+    public function test_paginate_sends_from_and_size()
+    {
+        $this->engine()->paginate($this->builder('hello'), 15, 2);
+
+        $this->assertSame('/table/_search', $this->request()->getUri()->getPath());
+        $this->assertSame('from=15&size=15', $this->request()->getUri()->getQuery());
+    }
+
+    public function test_search_with_callback()
+    {
+        $client = $this->client();
+
+        $engine = new ElasticsearchEngine($client);
+
+        $builder = $this->builder('hello', function ($elasticsearch, $query, $searchParams) use ($client) {
+            $this->assertSame($client, $elasticsearch);
+            $this->assertSame('hello', $query);
+            $this->assertSame('table', $searchParams['index']);
+
+            return 'result';
+        });
+
+        $this->assertSame('result', $engine->search($builder));
+        $this->assertCount(0, $this->requests);
+    }
+
+    public function test_map_ids_returns_correct_values_of_primary_key()
+    {
+        $engine = $this->engine();
+
+        $results = [
+            'hits' => [
+                'hits' => [
+                    ['_id' => '1', '_source' => ['id' => 1]],
+                    ['_id' => '2', '_source' => ['id' => 2]],
+                    ['_id' => '3', '_source' => ['id' => 3]],
+                ],
+            ],
+        ];
+
+        $this->assertEquals([1, 2, 3], $engine->mapIdsFrom($results, 'id')->all());
+        $this->assertEquals(['1', '2', '3'], $engine->mapIds($results)->all());
+    }
+
+    public function test_map_ids_returns_empty_collection_if_no_hits()
+    {
+        $results = ['hits' => ['hits' => []]];
+
+        $this->assertCount(0, $this->engine()->mapIdsFrom($results, 'id'));
+    }
+
+    public function test_map_correctly_maps_results_to_models()
+    {
+        $engine = $this->engine();
+
+        $model = m::mock(stdClass::class);
+        $model->shouldReceive(['getScoutKeyName' => 'id']);
+        $model->shouldReceive('getScoutModelsByIds')->andReturn($models = Collection::make([
+            new SearchableModel(['id' => 1, 'name' => 'test']),
+        ]));
+
+        $builder = m::mock(Builder::class);
+
+        $results = $engine->map($builder, [
+            'hits' => [
+                'total' => ['value' => 1],
+                'hits' => [
+                    ['_id' => '1', '_source' => ['id' => 1, 'name' => 'test', '__soft_deleted' => 0]],
+                ],
+            ],
+        ], $model);
+
+        $this->assertCount(1, $results);
+        $this->assertEquals(['id' => 1, 'name' => 'test'], $results->first()->toArray());
+        $this->assertEquals(['__soft_deleted' => 0], $results->first()->scoutMetadata());
+    }
+
+    public function test_map_method_respects_order()
+    {
+        $engine = $this->engine();
+
+        $model = m::mock(stdClass::class);
+        $model->shouldReceive(['getScoutKeyName' => 'id']);
+        $model->shouldReceive('getScoutModelsByIds')->andReturn($models = Collection::make([
+            new SearchableModel(['id' => 1]),
+            new SearchableModel(['id' => 2]),
+            new SearchableModel(['id' => 3]),
+            new SearchableModel(['id' => 4]),
+        ]));
+
+        $builder = m::mock(Builder::class);
+
+        $results = $engine->map($builder, [
+            'hits' => [
+                'total' => ['value' => 4],
+                'hits' => [
+                    ['_id' => '1', '_source' => ['id' => 1]],
+                    ['_id' => '2', '_source' => ['id' => 2]],
+                    ['_id' => '4', '_source' => ['id' => 4]],
+                    ['_id' => '3', '_source' => ['id' => 3]],
+                ],
+            ],
+        ], $model);
+
+        $this->assertCount(4, $results);
+        $this->assertEquals([1, 2, 4, 3], $results->pluck('id')->all());
+    }
+
+    public function test_lazy_map_correctly_maps_results_to_models()
+    {
+        $engine = $this->engine();
+
+        $model = m::mock(stdClass::class);
+        $model->shouldReceive(['getScoutKeyName' => 'id']);
+        $model->shouldReceive('queryScoutModelsByIds->cursor')->andReturn($models = LazyCollection::make([
+            new SearchableModel(['id' => 1, 'name' => 'test']),
+        ]));
+
+        $builder = m::mock(Builder::class);
+
+        $results = $engine->lazyMap($builder, [
+            'hits' => [
+                'total' => ['value' => 1],
+                'hits' => [
+                    ['_id' => '1', '_source' => ['id' => 1, 'name' => 'test', '__soft_deleted' => 0]],
+                ],
+            ],
+        ], $model);
+
+        $this->assertCount(1, $results);
+        $this->assertEquals(['id' => 1, 'name' => 'test'], $results->first()->toArray());
+        $this->assertEquals(['__soft_deleted' => 0], $results->first()->scoutMetadata());
+    }
+
+    public function test_lazy_map_method_respects_order()
+    {
+        $engine = $this->engine();
+
+        $model = m::mock(stdClass::class);
+        $model->shouldReceive(['getScoutKeyName' => 'id']);
+        $model->shouldReceive('queryScoutModelsByIds->cursor')->andReturn($models = LazyCollection::make([
+            new SearchableModel(['id' => 1]),
+            new SearchableModel(['id' => 2]),
+            new SearchableModel(['id' => 3]),
+            new SearchableModel(['id' => 4]),
+        ]));
+
+        $builder = m::mock(Builder::class);
+
+        $results = $engine->lazyMap($builder, [
+            'hits' => [
+                'total' => ['value' => 4],
+                'hits' => [
+                    ['_id' => '1', '_source' => ['id' => 1]],
+                    ['_id' => '2', '_source' => ['id' => 2]],
+                    ['_id' => '4', '_source' => ['id' => 4]],
+                    ['_id' => '3', '_source' => ['id' => 3]],
+                ],
+            ],
+        ], $model);
+
+        $this->assertCount(4, $results);
+        $this->assertEquals([1, 2, 4, 3], $results->pluck('id')->all());
+    }
+
+    public function test_engine_returns_total_count_from_search_response()
+    {
+        $this->assertTrue(
+            $this->engine()->getTotalCount(['hits' => ['total' => ['value' => 3]]]) === 3
+        );
+    }
+
+    public function test_flush_deletes_all_documents_from_the_index()
+    {
+        $this->engine()->flush(new SearchableModel);
+
+        $this->assertSame('POST', $this->request()->getMethod());
+        $this->assertSame('/table/_delete_by_query', $this->request()->getUri()->getPath());
+        $this->assertEquals([
+            'query' => ['match_all' => []],
+        ], $this->jsonBody());
+    }
+
+    public function test_create_index()
+    {
+        $this->engine()->createIndex('table', ['body' => ['settings' => ['number_of_shards' => 1]]]);
+
+        $this->assertSame('PUT', $this->request()->getMethod());
+        $this->assertSame('/table', $this->request()->getUri()->getPath());
+        $this->assertEquals([
+            'settings' => ['number_of_shards' => 1],
+        ], $this->jsonBody());
+    }
+
+    public function test_update_index_settings_updates_settings_and_mappings()
+    {
+        $this->engine()->updateIndexSettings('table', [
+            'settings' => ['number_of_replicas' => 2],
+            'mappings' => ['properties' => ['name' => ['type' => 'text']]],
+        ]);
+
+        $this->assertCount(2, $this->requests);
+
+        $this->assertSame('/table/_settings', $this->request(0)->getUri()->getPath());
+        $this->assertEquals(['number_of_replicas' => 2], $this->jsonBody(0));
+
+        $this->assertSame('/table/_mapping', $this->request(1)->getUri()->getPath());
+        $this->assertEquals(['properties' => ['name' => ['type' => 'text']]], $this->jsonBody(1));
+    }
+
+    public function test_configure_soft_delete_filter_adds_mapping()
+    {
+        $settings = $this->engine()->configureSoftDeleteFilter(['settings' => ['number_of_shards' => 1]]);
+
+        $this->assertEquals([
+            'settings' => ['number_of_shards' => 1],
+            'mappings' => ['properties' => ['__soft_deleted' => ['type' => 'integer']]],
+        ], $settings);
+    }
+
+    public function test_delete_index()
+    {
+        $this->engine()->deleteIndex('table');
+
+        $this->assertSame('DELETE', $this->request()->getMethod());
+        $this->assertSame('/table', $this->request()->getUri()->getPath());
+    }
+
+    public function test_delete_all_indexes_only_deletes_indexes_with_scout_prefix()
+    {
+        Config::shouldReceive('get')->with('scout.prefix')->andReturn('app_');
+
+        $engine = $this->engine([
+            '{"users": {}, "app_users": {}}',
+            '{}',
+        ]);
+
+        $engine->deleteAllIndexes();
+
+        $this->assertCount(2, $this->requests);
+
+        $this->assertSame('GET', $this->request(0)->getMethod());
+
+        $this->assertSame('DELETE', $this->request(1)->getMethod());
+        $this->assertSame('/app_users', $this->request(1)->getUri()->getPath());
+    }
+
+    public function test_engine_forwards_calls_to_elasticsearch_client()
+    {
+        $this->assertInstanceOf(Indices::class, $this->engine()->indices());
+    }
+
+    /**
+     * Create a new Elasticsearch engine instance.
+     *
+     * @param  bool  $softDelete
+     * @return ElasticsearchEngine
+     */
+    protected function engine(array $responses = [], $softDelete = false)
+    {
+        return new ElasticsearchEngine($this->client($responses), $softDelete);
+    }
+
+    /**
+     * Create an Elasticsearch client with a mocked HTTP handler.
+     *
+     * @return Client
+     */
+    protected function client(array $responses = [])
+    {
+        $http = m::mock(Psr18Client::class);
+
+        $http->shouldReceive('sendRequest')->andReturnUsing(function (RequestInterface $request) use (&$responses) {
+            $this->requests[] = $request;
+
+            $body = array_shift($responses) ?? '{}';
+
+            return new Response(200, [
+                'Content-Type' => 'application/json',
+                'X-elastic-product' => 'Elasticsearch',
+            ], $body);
+        });
+
+        return ClientBuilder::create()
+            ->setHosts(['http://localhost:9200'])
+            ->setHttpClient($http)
+            ->build();
+    }
+
+    /**
+     * Create a new search builder instance.
+     *
+     * @param  string  $query
+     * @param  \Closure|null  $callback
+     * @return Builder
+     */
+    protected function builder($query = '', $callback = null)
+    {
+        return new Builder(new SearchableModel, $query, $callback);
+    }
+
+    /**
+     * Get the captured request at the given position.
+     *
+     * @param  int  $position
+     * @return RequestInterface
+     */
+    protected function request($position = 0)
+    {
+        return $this->requests[$position];
+    }
+
+    /**
+     * Get the decoded JSON body of the captured request.
+     *
+     * @param  int  $position
+     * @return array
+     */
+    protected function jsonBody($position = 0)
+    {
+        return json_decode((string) $this->request($position)->getBody(), true);
+    }
+
+    /**
+     * Get the decoded new-line delimited JSON body of the captured request.
+     *
+     * @return array
+     */
+    protected function ndjsonBody()
+    {
+        $lines = explode("\n", trim((string) $this->request()->getBody()));
+
+        return array_map(fn ($line) => json_decode($line, true), $lines);
+    }
+}
+
+class ElasticsearchSoftDeleteSearchableModel extends SearchableModel
+{
+    use SoftDeletes;
+}


### PR DESCRIPTION
## Description

This PR adds a first-party Elasticsearch engine, following the same structure and conventions as the existing Meilisearch and Typesense engines.

**Engine (`Laravel\Scout\Engines\ElasticsearchEngine`)**

- Uses the `elasticsearch/elasticsearch` v8 client (required via `suggest`, guarded at runtime like the other optional clients).
- `update()` / `delete()` use the bulk API, indexing documents under the Scout key (`_id`) and merging the Scout key name into the document body, mirroring the Meilisearch engine.
- Searches use a `multi_match` query with `type: bool_prefix` so partial queries (e.g. `lar`) behave like the Meilisearch/Typesense engines; empty and `*` queries use `match_all`.
- `where` constraints are translated into `bool.filter` clauses (`term` / `range` / `exists`, including `whereNull` semantics), `whereIn` / `whereNotIn` into `terms` / `must_not` clauses, and `orderBy` into `sort`.
- Soft deletes rely on the `__soft_deleted` where clause injected by the Scout builder; the engine maps it to an `integer` field to match the `0` / `1` values written by `pushSoftDeleteMetadata()`.
- Pagination uses `from` / `size`, and the custom search callback receives `(, , )` with the resolved index included.
- Implements `UpdatesIndexSettings`: index settings are synced via `putSettings` / `putMapping` depending on the configured `settings` / `mappings` keys.
- `deleteAllIndexes()` deletes only indexes carrying the Scout prefix and skips dot-prefixed system indexes.

**Configuration**

`config/scout.php` gains an `elasticsearch` block (hosts + HTTP basic credentials + index settings), and the container binding builds the client via `ClientBuilder` when the package is installed.

## Tests

- **Unit** (`tests/Unit/ElasticsearchEngineTest.php`): since the ES `Client` is final, the tests drive a real client through a mocked PSR-18 handler and assert on the resulting wire-level requests (bulk NDJSON payloads, search bodies, sort, pagination, filters, soft-delete metadata, index lifecycle).
- **Feature** (`tests/Feature/Engines/ElasticsearchEngineTest.php`): container wiring and driver registration.
- **Integration** (`tests/Integration/ElasticsearchSearchableTest.php`): runs the shared `SearchableTests` suite against a live Elasticsearch service, with a new CI job mirroring the existing Meilisearch/Typesense service jobs.

The integration suite was verified locally against Elasticsearch 8.19.

Note: `TurbopufferEngineTest::test_update_upserts_models_with_schema_and_scout_ids` currently fails on pristine `11.x` as well; it is unrelated to this change.