### PR TITLE
[11.x] Fix collection searches for zero

### DIFF
--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -125,7 +125,7 @@ class CollectionEngine extends Engine
                 return false;
             }
 
-            if (! $builder->query) {
+            if (is_null($builder->query) || $builder->query === '') {
                 return true;
             }
 

--- a/tests/Feature/CollectionEngineTest.php
+++ b/tests/Feature/CollectionEngineTest.php
@@ -41,6 +41,45 @@ class CollectionEngineTest extends TestCase
         $this->assertCount(2, $models);
     }
 
+    public function test_it_can_retrieve_results_with_null_search()
+    {
+        $this->assertCount(2, SearchableUser::search(null)->get());
+    }
+
+    public function test_it_searches_for_whitespace_literally()
+    {
+        $this->assertCount(0, SearchableUser::search('  ')->get());
+    }
+
+    public function test_it_can_retrieve_results_for_zero()
+    {
+        $user = UserFactory::new()->create([
+            'name' => 'Agent 0',
+            'email' => 'agent@example.com',
+        ]);
+
+        $models = SearchableUser::search('0')->get();
+
+        $this->assertSame([$user->id], $models->modelKeys());
+    }
+
+    public function test_it_can_paginate_results_for_zero()
+    {
+        UserFactory::new()->create([
+            'name' => 'Agent 0',
+            'email' => 'first@example.com',
+        ]);
+        $second = UserFactory::new()->create([
+            'name' => 'Agent 00',
+            'email' => 'second@example.com',
+        ]);
+
+        $page = SearchableUser::search('0')->orderBy('id')->paginate(1, 'page', 2);
+
+        $this->assertSame(2, $page->total());
+        $this->assertSame([$second->id], $page->getCollection()->modelKeys());
+    }
+
     public function test_it_can_retrieve_results()
     {
         $models = SearchableUser::search('Taylor')->where('email', 'taylor@laravel.com')->get();


### PR DESCRIPTION
Searching for the string `'0'` with the collection engine currently skips text filtering because PHP evaluates that string as false. Non-matching models are returned, and pagination totals include those models.

For example, with searchable names `Taylor Otwell`, `Abigail Otwell`, and `Agent 0`, `User::search('0')->get()` currently returns all three users instead of only `Agent 0`.

This change limits the empty-query guard to `null` and `''`. It preserves searches without an argument, null queries, and literal whitespace matching. The latter would change if the guard used `blank()`.

Four regression tests cover retrieval and pagination for `'0'`, null queries, and whitespace-only queries. The two zero-query tests fail on the unmodified `11.x` implementation and pass with the fix.

Validation on PHP 8.5.10, Laravel 13.31.0, Orchestra Testbench 11.2.0, and PHPUnit 13.3.3:

- `vendor/bin/phpunit --filter '(CollectionEngineTest|DatabaseEngineTest|CollectionSearchableTest|DatabaseSearchableTest)'`: 50 tests, 153 assertions passed.
- `git diff --check`: passed.
- The broader Unit/Feature run during investigation had one unrelated failure in `TurbopufferEngineTest::test_update_upserts_models_with_schema_and_scout_ids`. That failure also reproduces with the unmodified collection engine. The run also reported one deprecation, 32 PHPUnit notices, and one skipped test.

AI assistance: the implementation, tests, and this description were prepared with Codex.
